### PR TITLE
fix: rename geographic to geography

### DIFF
--- a/catalog/ge00_ballots.json
+++ b/catalog/ge00_ballots.json
@@ -1,142 +1,133 @@
 {
-    "file": {
-        "manual_trigger": 0,
-        "bucket": "elections_federal",
-        "file_name": "ge00_ballots",
-        "category": "ELECTIONS",
-        "category_en": "Elections",
-        "category_bm": "Pilihanraya",
-        "subcategory": "FEDERAL",
-        "subcategory_en": "Federal",
-        "subcategory_bm": "Persekutuan",
-        "description": {
-            "en": "Ballots for every seat contested at the pre-Independence general election held on 27 July 1955.",
-            "bm": "Perincian undi bagi setiap kerusi yang dipertandingkan di pilihanraya umum pramerdeka yang diadakan pada 27 Julai 1955."
-        },
-        "link_parquet": "https://storage.data.gov.my/elections/federal/ge00_ballots.parquet",
-        "link_csv": "https://storage.data.gov.my/elections/federal/ge00_ballots.csv",
-        "link_preview": "https://storage.data.gov.my/elections/federal/ge00_ballots.parquet",
-        "variables": [
-            {
-                "id": 0,
-                "name": "ge00_ballots",
-                "title_en": "GE-00: Ballots",
-                "title_bm": "PRU-00: Kertas Undi",
-                "desc_en": "Ballots for every seat contested at the pre-Independence general election held on 27 July 1955.",
-                "desc_bm": "Perincian undi bagi setiap kerusi yang dipertandingkan di pilihanraya umum pramerdeka yang diadakan pada 27 Julai 1955.",
-                "catalog_data": {
-                    "catalog_filters": {
-                        "frequency": "INFREQUENT",
-                        "geographic": [
-                            "PARLIMEN",
-                            "STATE",
-                            "NATIONAL"
-                        ],
-                        "demographic": [],
-                        "start": "1955",
-                        "end": "1955",
-                        "data_source": [
-                            "SPR"
-                        ]
-                    },
-                    "metadata_neutral": {
-                        "data_as_of": "1955-08-31 23:59",
-                        "last_updated": "2023-07-18 23:59",
-                        "next_update": "-"
-                    },
-                    "metadata_lang": {
-                        "en": {
-                            "methodology": "This data is a digital representation of the physical election results tabulated and gazetted per the Electoral Regulations (Conduct of Elections). The digitalisation process was rigorously cross-checked against physical records to ensure consistency and accuracy of information.",
-                            "caveat": "As of now, this data has not been verified by SPR, and is shown here on the staging site to provide easy access for exploring and checking the data.",
-                            "publication": "-"
-                        },
-                        "bm": {
-                            "methodology": "Data ini merupakan rekod digital keputusan pilihanraya yang dikira dan diwartakan selaras dengan Peraturan-Peraturan Pilihan Raya (Penjalanan Pilihan Raya). Proses pendigitalan disemak silang dengan rekod fizikal untuk memastikan ketepatan maklumat.",
-                            "caveat": "Setakat sekarang, data ini belum disemak dan diabsahkan oleh SPR, maka hanya dipaparkan di portal UAT ini bagi tujuan memudahkan proses semakan.",
-                            "publication": "-"
-                        }
-                    },
-                    "chart": {
-                        "chart_type": "TABLE",
-                        "chart_filters": {
-                            "SLICE_BY": [],
-                            "precision": 0
-                        },
-                        "chart_variables": {
-                            "parents": [],
-                            "exclude": [],
-                            "freeze": [
-                                "state",
-                                "parlimen"
-                            ]
-                        }
-                    }
-                }
-            },
-            {
-                "id": -1,
-                "name": "state",
-                "title_en": "State",
-                "title_bm": "Negeri",
-                "desc_en": "[String] 1 of 16 states",
-                "desc_bm": "[Rentetan] 1 antara 16 negeri"
-            },
-            {
-                "id": -1,
-                "name": "parlimen",
-                "title_en": "Parliament",
-                "title_bm": "Parlimen",
-                "desc_en": "[String] Name of seat as it appeared on the ballot on voting day",
-                "desc_bm": "[Rentetan] Nama kerusi seperti mana yang tertera di kertas undi pada hari mengundi"
-            },
-            {
-                "id": -1,
-                "name": "area_name",
-                "title_en": "Area Name",
-                "title_bm": "Nama Kawasan",
-                "desc_en": "[String] Name of the area, with seat code (P.xxx) stripped out, and area name historically harmonised. For example, Kota Baharu, Kota Bahru and Kota Bharu are all harmonised to the modern Kota Bharu.",
-                "desc_bm": "[Rentetan] Nama kawasan, tanpa kod kerusi (P.xxx) dan namanya diselaraskan mengambil kira perubahan dari zaman ke zaman. Contohnya, nama Kota Baharu, Kota Bahru, dan Kota Bharu semuanya diharmonikan kepada penggunaan moden iaitu Kota Bharu."
-            },
-            {
-                "id": -1,
-                "name": "ballot_order",
-                "title_en": "Ballot Order",
-                "title_bm": "Urutan Nama",
-                "desc_en": "[Integer] Order in which the candidate appears on the ballot",
-                "desc_bm": "[Integer] Urutan nama-nama yang tertera pada kertas undi"
-            },
-            {
-                "id": -1,
-                "name": "name",
-                "title_en": "Name",
-                "title_bm": "Nama",
-                "desc_en": "[String] Name of candidate as it appeared on the ballot on voting day; this may not be the same as their real name as candidates are free to choose the name they use for campaigning and voting",
-                "desc_bm": "[Rentetan] Nama calon seperti mana yang tertera di kertas undi pada hari mengundi; ini tidak semestinya sama dengan nama sebenar mereka kerana calon adalah bebas untuk memilih nama yang digunakan bagi tujuan kempen dan undi"
-            },
-            {
-                "id": -1,
-                "name": "candidate_uid",
-                "title_en": "Unique Candidate ID",
-                "title_bm": "ID Unik Calon",
-                "desc_en": "[Integer] Unique integer identifier to track candidates across elections",
-                "desc_bm": "[Integer] Integer unik untuk menjejaki keputusan seseorang calon merentasi pilihan raya"
-            },
-            {
-                "id": -1,
-                "name": "party",
-                "title_en": "Party",
-                "title_bm": "Parti",
-                "desc_en": "[String] Party of the candidate as it appeared on the ballot on voting day; this record is not amended to reflect unofficial information on parties and coalitions. For example, if a candidate competed under the flag of Party X despite being a member of Party Y, their party is recorded as Party X.",
-                "desc_bm": "[String] Parti calon seperti yang tertera pada kertas undi pada hari mengundi; rekod ini tidak dipinda untuk menggambarkan maklumat tidak rasmi mengenai parti dan gabungan. Sebagai contoh, jika calon bertanding bawah bendera Parti X walaupun menjadi ahli Parti Y, parti mereka direkodkan sebagai Parti X."
-            },
-            {
-                "id": -1,
-                "name": "votes",
-                "title_en": "Votes",
-                "title_bm": "Undi",
-                "desc_en": "Integer] Number of votes won by the candidate",
-                "desc_bm": "[Integer] Jumlah undi yang diperolehi oleh calon"
-            }
-        ]
-    }
+	"file": {
+		"manual_trigger": 0,
+		"bucket": "elections_federal",
+		"file_name": "ge00_ballots",
+		"category": "ELECTIONS",
+		"category_en": "Elections",
+		"category_bm": "Pilihanraya",
+		"subcategory": "FEDERAL",
+		"subcategory_en": "Federal",
+		"subcategory_bm": "Persekutuan",
+		"description": {
+			"en": "Ballots for every seat contested at the pre-Independence general election held on 27 July 1955.",
+			"bm": "Perincian undi bagi setiap kerusi yang dipertandingkan di pilihanraya umum pramerdeka yang diadakan pada 27 Julai 1955."
+		},
+		"link_parquet": "https://storage.data.gov.my/elections/federal/ge00_ballots.parquet",
+		"link_csv": "https://storage.data.gov.my/elections/federal/ge00_ballots.csv",
+		"link_preview": "https://storage.data.gov.my/elections/federal/ge00_ballots.parquet",
+		"variables": [
+			{
+				"id": 0,
+				"name": "ge00_ballots",
+				"title_en": "GE-00: Ballots",
+				"title_bm": "PRU-00: Kertas Undi",
+				"desc_en": "Ballots for every seat contested at the pre-Independence general election held on 27 July 1955.",
+				"desc_bm": "Perincian undi bagi setiap kerusi yang dipertandingkan di pilihanraya umum pramerdeka yang diadakan pada 27 Julai 1955.",
+				"catalog_data": {
+					"catalog_filters": {
+						"frequency": "INFREQUENT",
+						"geography": ["PARLIMEN", "STATE", "NATIONAL"],
+						"demographic": [],
+						"start": "1955",
+						"end": "1955",
+						"data_source": ["SPR"]
+					},
+					"metadata_neutral": {
+						"data_as_of": "1955-08-31 23:59",
+						"last_updated": "2023-07-18 23:59",
+						"next_update": "-"
+					},
+					"metadata_lang": {
+						"en": {
+							"methodology": "This data is a digital representation of the physical election results tabulated and gazetted per the Electoral Regulations (Conduct of Elections). The digitalisation process was rigorously cross-checked against physical records to ensure consistency and accuracy of information.",
+							"caveat": "As of now, this data has not been verified by SPR, and is shown here on the staging site to provide easy access for exploring and checking the data.",
+							"publication": "-"
+						},
+						"bm": {
+							"methodology": "Data ini merupakan rekod digital keputusan pilihanraya yang dikira dan diwartakan selaras dengan Peraturan-Peraturan Pilihan Raya (Penjalanan Pilihan Raya). Proses pendigitalan disemak silang dengan rekod fizikal untuk memastikan ketepatan maklumat.",
+							"caveat": "Setakat sekarang, data ini belum disemak dan diabsahkan oleh SPR, maka hanya dipaparkan di portal UAT ini bagi tujuan memudahkan proses semakan.",
+							"publication": "-"
+						}
+					},
+					"chart": {
+						"chart_type": "TABLE",
+						"chart_filters": {
+							"SLICE_BY": [],
+							"precision": 0
+						},
+						"chart_variables": {
+							"parents": [],
+							"exclude": [],
+							"freeze": ["state", "parlimen"]
+						}
+					}
+				}
+			},
+			{
+				"id": -1,
+				"name": "state",
+				"title_en": "State",
+				"title_bm": "Negeri",
+				"desc_en": "[String] 1 of 16 states",
+				"desc_bm": "[Rentetan] 1 antara 16 negeri"
+			},
+			{
+				"id": -1,
+				"name": "parlimen",
+				"title_en": "Parliament",
+				"title_bm": "Parlimen",
+				"desc_en": "[String] Name of seat as it appeared on the ballot on voting day",
+				"desc_bm": "[Rentetan] Nama kerusi seperti mana yang tertera di kertas undi pada hari mengundi"
+			},
+			{
+				"id": -1,
+				"name": "area_name",
+				"title_en": "Area Name",
+				"title_bm": "Nama Kawasan",
+				"desc_en": "[String] Name of the area, with seat code (P.xxx) stripped out, and area name historically harmonised. For example, Kota Baharu, Kota Bahru and Kota Bharu are all harmonised to the modern Kota Bharu.",
+				"desc_bm": "[Rentetan] Nama kawasan, tanpa kod kerusi (P.xxx) dan namanya diselaraskan mengambil kira perubahan dari zaman ke zaman. Contohnya, nama Kota Baharu, Kota Bahru, dan Kota Bharu semuanya diharmonikan kepada penggunaan moden iaitu Kota Bharu."
+			},
+			{
+				"id": -1,
+				"name": "ballot_order",
+				"title_en": "Ballot Order",
+				"title_bm": "Urutan Nama",
+				"desc_en": "[Integer] Order in which the candidate appears on the ballot",
+				"desc_bm": "[Integer] Urutan nama-nama yang tertera pada kertas undi"
+			},
+			{
+				"id": -1,
+				"name": "name",
+				"title_en": "Name",
+				"title_bm": "Nama",
+				"desc_en": "[String] Name of candidate as it appeared on the ballot on voting day; this may not be the same as their real name as candidates are free to choose the name they use for campaigning and voting",
+				"desc_bm": "[Rentetan] Nama calon seperti mana yang tertera di kertas undi pada hari mengundi; ini tidak semestinya sama dengan nama sebenar mereka kerana calon adalah bebas untuk memilih nama yang digunakan bagi tujuan kempen dan undi"
+			},
+			{
+				"id": -1,
+				"name": "candidate_uid",
+				"title_en": "Unique Candidate ID",
+				"title_bm": "ID Unik Calon",
+				"desc_en": "[Integer] Unique integer identifier to track candidates across elections",
+				"desc_bm": "[Integer] Integer unik untuk menjejaki keputusan seseorang calon merentasi pilihan raya"
+			},
+			{
+				"id": -1,
+				"name": "party",
+				"title_en": "Party",
+				"title_bm": "Parti",
+				"desc_en": "[String] Party of the candidate as it appeared on the ballot on voting day; this record is not amended to reflect unofficial information on parties and coalitions. For example, if a candidate competed under the flag of Party X despite being a member of Party Y, their party is recorded as Party X.",
+				"desc_bm": "[String] Parti calon seperti yang tertera pada kertas undi pada hari mengundi; rekod ini tidak dipinda untuk menggambarkan maklumat tidak rasmi mengenai parti dan gabungan. Sebagai contoh, jika calon bertanding bawah bendera Parti X walaupun menjadi ahli Parti Y, parti mereka direkodkan sebagai Parti X."
+			},
+			{
+				"id": -1,
+				"name": "votes",
+				"title_en": "Votes",
+				"title_bm": "Undi",
+				"desc_en": "Integer] Number of votes won by the candidate",
+				"desc_bm": "[Integer] Jumlah undi yang diperolehi oleh calon"
+			}
+		]
+	}
 }

--- a/catalog/ge00_ballots.json
+++ b/catalog/ge00_ballots.json
@@ -28,7 +28,7 @@
 					"catalog_filters": {
 						"frequency": "INFREQUENT",
 						"geography": ["PARLIMEN", "STATE", "NATIONAL"],
-						"demographic": [],
+						"demography": [],
 						"start": "1955",
 						"end": "1955",
 						"data_source": ["SPR"]

--- a/catalog/ge00_summary.json
+++ b/catalog/ge00_summary.json
@@ -1,150 +1,141 @@
 {
-    "file": {
-        "manual_trigger": 0,
-        "bucket": "elections_federal",
-        "file_name": "ge00_summary",
-        "category": "ELECTIONS",
-        "category_en": "Elections",
-        "category_bm": "Pilihanraya",
-        "subcategory": "FEDERAL",
-        "subcategory_en": "Federal",
-        "subcategory_bm": "Persekutuan",
-        "description": {
-            "en": "Analytical summary of the pre-Independence general election held on 27 July 1955.",
-            "bm": "Ringkasan analitik bagi pilihanraya umum pramerdeka yang diadakan pada 27 Julai 1955."
-        },
-        "link_parquet": "https://storage.data.gov.my/elections/federal/ge00_summary.parquet",
-        "link_csv": "https://storage.data.gov.my/elections/federal/ge00_summary.csv",
-        "link_preview": "https://storage.data.gov.my/elections/federal/ge00_summary.parquet",
-        "variables": [
-            {
-                "id": 0,
-                "name": "ge00_summary",
-                "title_en": "GE-00: Summary",
-                "title_bm": "PRU-00: Rumusan",
-                "desc_en": "Analytical summary of the pre-Independence general election held on 27 July 1955.",
-                "desc_bm": "Ringkasan analitik bagi pilihanraya umum pramerdeka yang diadakan pada 27 Julai 1955.",
-                "catalog_data": {
-                    "catalog_filters": {
-                        "frequency": "INFREQUENT",
-                        "geographic": [
-                            "PARLIMEN",
-                            "STATE",
-                            "NATIONAL"
-                        ],
-                        "demographic": [],
-                        "start": "1955",
-                        "end": "1955",
-                        "data_source": [
-                            "SPR"
-                        ]
-                    },
-                    "metadata_neutral": {
-                        "data_as_of": "1955-08-31 23:59",
-                        "last_updated": "2023-07-18 23:59",
-                        "next_update": "-"
-                    },
-                    "metadata_lang": {
-                        "en": {
-                            "methodology": "This data is a digital representation of the physical election results tabulated and gazetted per the Electoral Regulations (Conduct of Elections). The digitalisation process was rigorously cross-checked against physical records to ensure consistency and accuracy of information.",
-                            "caveat": "As of now, this data has not been verified by SPR, and is shown here on the staging site to provide easy access for exploring and checking the data.",
-                            "publication": "-"
-                        },
-                        "bm": {
-                            "methodology": "Data ini merupakan rekod digital keputusan pilihanraya yang dikira dan diwartakan selaras dengan Peraturan-Peraturan Pilihan Raya (Penjalanan Pilihan Raya). Proses pendigitalan disemak silang dengan rekod fizikal untuk memastikan ketepatan maklumat.",
-                            "caveat": "Setakat sekarang, data ini belum disemak dan diabsahkan oleh SPR, maka hanya dipaparkan di portal UAT ini bagi tujuan memudahkan proses semakan.",
-                            "publication": "-"
-                        }
-                    },
-                    "chart": {
-                        "chart_type": "TABLE",
-                        "chart_filters": {
-                            "SLICE_BY": [],
-                            "precision": 0
-                        },
-                        "chart_variables": {
-                            "parents": [],
-                            "exclude": [],
-                            "freeze": [
-                                "state",
-                                "parlimen"
-                            ]
-                        }
-                    }
-                }
-            },
-            {
-                "id": -1,
-                "name": "state",
-                "title_en": "State",
-                "title_bm": "Negeri",
-                "desc_en": "[String] 1 of 16 states",
-                "desc_bm": "[Rentetan] 1 antara 16 negeri"
-            },
-            {
-                "id": -1,
-                "name": "parlimen",
-                "title_en": "Parliament",
-                "title_bm": "Parlimen",
-                "desc_en": "[String] Name of seat as it appeared on the ballot on voting day",
-                "desc_bm": "[Rentetan] Nama kerusi seperti mana yang tertera di kertas undi pada hari mengundi"
-            },
-            {
-                "id": -1,
-                "name": "area_name",
-                "title_en": "Area Name",
-                "title_bm": "Nama Kawasan",
-                "desc_en": "[String] Name of the area, with seat code (P.xxx) stripped out, and area name historically harmonised. For example, Kota Baharu, Kota Bahru and Kota Bharu are all harmonised to the modern Kota Bharu.",
-                "desc_bm": "[Rentetan] Nama kawasan, tanpa kod kerusi (P.xxx) dan namanya diselaraskan mengambil kira perubahan dari zaman ke zaman. Contohnya, nama Kota Baharu, Kota Bahru, dan Kota Bharu semuanya diharmonikan kepada penggunaan moden iaitu Kota Bharu."
-            },
-            {
-                "id": -1,
-                "name": "voters_total",
-                "title_en": "Total Voters",
-                "title_bm": "Jumlah Pengundi",
-                "desc_en": "[Integer] Number of voters registered to vote in that seat at that election",
-                "desc_bm": "[Integer] Jumlah pengundi yang didaftarkan untuk mengundi di kerusi tersebut semasa PRU-00"
-            },
-            {
-                "id": -1,
-                "name": "ballots_issued",
-                "title_en": "Ballots Issued",
-                "title_bm": "Undi Dikeluarkan",
-                "desc_en": "[Integer] Number of ballots issued, including postal ballots, but not inclduing ballots accidentally damaged and immediately replace during the voting procedure",
-                "desc_bm": "[Integer] Jumlah kertas undi yang dikeluarkan, termasuk kertas undi pos, tetapi tidak termasuk kertas undi yang rosak dan terus digantikan semasa urusan mengundi dijalankan"
-            },
-            {
-                "id": -1,
-                "name": "ballots_not_returned",
-                "title_en": "Ballots Not Returned",
-                "title_bm": "Undi Tidak Dikembalikan",
-                "desc_en": "[Integer] Number of ballots issued but not returned for counting, including postal ballots not returned to the counting centre in time, but excluding spoilt ballots (e.g. torn or stained) which were replaced and therefore not counted as ballots issued",
-                "desc_bm": "[Integer] Jumlah kertas undi yang dikeluarkan tetapi tidak dikembalikan untuk pengiraan undi, termasuk kertas undi pos yang tidak dikembalikan ke pusat kiraan undi, tetapi tidak termasuk kertas undi rosak (contohnya terkoyak atau ternoda) yang telah digantikan maka tidak dikira sebagai kertas undi yang dikeluarkan"
-            },
-            {
-                "id": -1,
-                "name": "votes_rejected",
-                "title_en": "Votes Rejected",
-                "title_bm": "Undi Ditolak",
-                "desc_en": "[Integer] Number of ballots returned but declared invalid during counting because the candidate could not be determined",
-                "desc_bm": "[Integer] Jumlah kertas undi yang telah dikembalikan tetapi ditolak semasa proses kiraan undi kerana calon yang diundi tidak dapat ditentukan"
-            },
-            {
-                "id": -1,
-                "name": "voter_turnout",
-                "title_en": "Voter Turnout",
-                "title_bm": "Peratus Keluar",
-                "desc_en": "[Float] Derived as: (ballots_issued / voters_total) * 100",
-                "desc_bm": " [Apung] Diperolehi dengan formula: (ballots_issued / voters_total) * 100"
-            },
-            {
-                "id": -1,
-                "name": "votes_rejected_perc",
-                "title_en": "Percentage Rejected",
-                "title_bm": "Peratus Ditolak",
-                "desc_en": "[Float] Derived as: (votes_rejected / (ballots_issued - ballots_not_returned)) * 100",
-                "desc_bm": " [Apung] Diperolehi dengan formula: (votes_rejected / (ballots_issued - ballots_not_returned)) * 100"
-            }
-        ]
-    }
+	"file": {
+		"manual_trigger": 0,
+		"bucket": "elections_federal",
+		"file_name": "ge00_summary",
+		"category": "ELECTIONS",
+		"category_en": "Elections",
+		"category_bm": "Pilihanraya",
+		"subcategory": "FEDERAL",
+		"subcategory_en": "Federal",
+		"subcategory_bm": "Persekutuan",
+		"description": {
+			"en": "Analytical summary of the pre-Independence general election held on 27 July 1955.",
+			"bm": "Ringkasan analitik bagi pilihanraya umum pramerdeka yang diadakan pada 27 Julai 1955."
+		},
+		"link_parquet": "https://storage.data.gov.my/elections/federal/ge00_summary.parquet",
+		"link_csv": "https://storage.data.gov.my/elections/federal/ge00_summary.csv",
+		"link_preview": "https://storage.data.gov.my/elections/federal/ge00_summary.parquet",
+		"variables": [
+			{
+				"id": 0,
+				"name": "ge00_summary",
+				"title_en": "GE-00: Summary",
+				"title_bm": "PRU-00: Rumusan",
+				"desc_en": "Analytical summary of the pre-Independence general election held on 27 July 1955.",
+				"desc_bm": "Ringkasan analitik bagi pilihanraya umum pramerdeka yang diadakan pada 27 Julai 1955.",
+				"catalog_data": {
+					"catalog_filters": {
+						"frequency": "INFREQUENT",
+						"geography": ["PARLIMEN", "STATE", "NATIONAL"],
+						"demographic": [],
+						"start": "1955",
+						"end": "1955",
+						"data_source": ["SPR"]
+					},
+					"metadata_neutral": {
+						"data_as_of": "1955-08-31 23:59",
+						"last_updated": "2023-07-18 23:59",
+						"next_update": "-"
+					},
+					"metadata_lang": {
+						"en": {
+							"methodology": "This data is a digital representation of the physical election results tabulated and gazetted per the Electoral Regulations (Conduct of Elections). The digitalisation process was rigorously cross-checked against physical records to ensure consistency and accuracy of information.",
+							"caveat": "As of now, this data has not been verified by SPR, and is shown here on the staging site to provide easy access for exploring and checking the data.",
+							"publication": "-"
+						},
+						"bm": {
+							"methodology": "Data ini merupakan rekod digital keputusan pilihanraya yang dikira dan diwartakan selaras dengan Peraturan-Peraturan Pilihan Raya (Penjalanan Pilihan Raya). Proses pendigitalan disemak silang dengan rekod fizikal untuk memastikan ketepatan maklumat.",
+							"caveat": "Setakat sekarang, data ini belum disemak dan diabsahkan oleh SPR, maka hanya dipaparkan di portal UAT ini bagi tujuan memudahkan proses semakan.",
+							"publication": "-"
+						}
+					},
+					"chart": {
+						"chart_type": "TABLE",
+						"chart_filters": {
+							"SLICE_BY": [],
+							"precision": 0
+						},
+						"chart_variables": {
+							"parents": [],
+							"exclude": [],
+							"freeze": ["state", "parlimen"]
+						}
+					}
+				}
+			},
+			{
+				"id": -1,
+				"name": "state",
+				"title_en": "State",
+				"title_bm": "Negeri",
+				"desc_en": "[String] 1 of 16 states",
+				"desc_bm": "[Rentetan] 1 antara 16 negeri"
+			},
+			{
+				"id": -1,
+				"name": "parlimen",
+				"title_en": "Parliament",
+				"title_bm": "Parlimen",
+				"desc_en": "[String] Name of seat as it appeared on the ballot on voting day",
+				"desc_bm": "[Rentetan] Nama kerusi seperti mana yang tertera di kertas undi pada hari mengundi"
+			},
+			{
+				"id": -1,
+				"name": "area_name",
+				"title_en": "Area Name",
+				"title_bm": "Nama Kawasan",
+				"desc_en": "[String] Name of the area, with seat code (P.xxx) stripped out, and area name historically harmonised. For example, Kota Baharu, Kota Bahru and Kota Bharu are all harmonised to the modern Kota Bharu.",
+				"desc_bm": "[Rentetan] Nama kawasan, tanpa kod kerusi (P.xxx) dan namanya diselaraskan mengambil kira perubahan dari zaman ke zaman. Contohnya, nama Kota Baharu, Kota Bahru, dan Kota Bharu semuanya diharmonikan kepada penggunaan moden iaitu Kota Bharu."
+			},
+			{
+				"id": -1,
+				"name": "voters_total",
+				"title_en": "Total Voters",
+				"title_bm": "Jumlah Pengundi",
+				"desc_en": "[Integer] Number of voters registered to vote in that seat at that election",
+				"desc_bm": "[Integer] Jumlah pengundi yang didaftarkan untuk mengundi di kerusi tersebut semasa PRU-00"
+			},
+			{
+				"id": -1,
+				"name": "ballots_issued",
+				"title_en": "Ballots Issued",
+				"title_bm": "Undi Dikeluarkan",
+				"desc_en": "[Integer] Number of ballots issued, including postal ballots, but not inclduing ballots accidentally damaged and immediately replace during the voting procedure",
+				"desc_bm": "[Integer] Jumlah kertas undi yang dikeluarkan, termasuk kertas undi pos, tetapi tidak termasuk kertas undi yang rosak dan terus digantikan semasa urusan mengundi dijalankan"
+			},
+			{
+				"id": -1,
+				"name": "ballots_not_returned",
+				"title_en": "Ballots Not Returned",
+				"title_bm": "Undi Tidak Dikembalikan",
+				"desc_en": "[Integer] Number of ballots issued but not returned for counting, including postal ballots not returned to the counting centre in time, but excluding spoilt ballots (e.g. torn or stained) which were replaced and therefore not counted as ballots issued",
+				"desc_bm": "[Integer] Jumlah kertas undi yang dikeluarkan tetapi tidak dikembalikan untuk pengiraan undi, termasuk kertas undi pos yang tidak dikembalikan ke pusat kiraan undi, tetapi tidak termasuk kertas undi rosak (contohnya terkoyak atau ternoda) yang telah digantikan maka tidak dikira sebagai kertas undi yang dikeluarkan"
+			},
+			{
+				"id": -1,
+				"name": "votes_rejected",
+				"title_en": "Votes Rejected",
+				"title_bm": "Undi Ditolak",
+				"desc_en": "[Integer] Number of ballots returned but declared invalid during counting because the candidate could not be determined",
+				"desc_bm": "[Integer] Jumlah kertas undi yang telah dikembalikan tetapi ditolak semasa proses kiraan undi kerana calon yang diundi tidak dapat ditentukan"
+			},
+			{
+				"id": -1,
+				"name": "voter_turnout",
+				"title_en": "Voter Turnout",
+				"title_bm": "Peratus Keluar",
+				"desc_en": "[Float] Derived as: (ballots_issued / voters_total) * 100",
+				"desc_bm": " [Apung] Diperolehi dengan formula: (ballots_issued / voters_total) * 100"
+			},
+			{
+				"id": -1,
+				"name": "votes_rejected_perc",
+				"title_en": "Percentage Rejected",
+				"title_bm": "Peratus Ditolak",
+				"desc_en": "[Float] Derived as: (votes_rejected / (ballots_issued - ballots_not_returned)) * 100",
+				"desc_bm": " [Apung] Diperolehi dengan formula: (votes_rejected / (ballots_issued - ballots_not_returned)) * 100"
+			}
+		]
+	}
 }

--- a/catalog/ge00_summary.json
+++ b/catalog/ge00_summary.json
@@ -28,7 +28,7 @@
 					"catalog_filters": {
 						"frequency": "INFREQUENT",
 						"geography": ["PARLIMEN", "STATE", "NATIONAL"],
-						"demographic": [],
+						"demography": [],
 						"start": "1955",
 						"end": "1955",
 						"data_source": ["SPR"]

--- a/catalog/ge01_ballots.json
+++ b/catalog/ge01_ballots.json
@@ -28,7 +28,7 @@
 					"catalog_filters": {
 						"frequency": "INFREQUENT",
 						"geography": ["PARLIMEN", "STATE", "NATIONAL"],
-						"demographic": [],
+						"demography": [],
 						"start": "1959",
 						"end": "1959",
 						"data_source": ["SPR"]

--- a/catalog/ge01_ballots.json
+++ b/catalog/ge01_ballots.json
@@ -1,142 +1,133 @@
 {
-    "file": {
-        "manual_trigger": 0,
-        "bucket": "elections_federal",
-        "file_name": "ge01_ballots",
-        "category": "ELECTIONS",
-        "category_en": "Elections",
-        "category_bm": "Pilihanraya",
-        "subcategory": "FEDERAL",
-        "subcategory_en": "Federal",
-        "subcategory_bm": "Persekutuan",
-        "description": {
-            "en": "Ballots for every seat contested at the pre-Independence general election held in 1955.",
-            "bm": "Perincian undi bagi setiap kerusi yang dipertandingkan di pilihanraya umum pramerdeka yang diadakan pada tahun 1955."
-        },
-        "link_parquet": "https://storage.data.gov.my/elections/federal/ge01_ballots.parquet",
-        "link_csv": "https://storage.data.gov.my/elections/federal/ge01_ballots.csv",
-        "link_preview": "https://storage.data.gov.my/elections/federal/ge01_ballots.parquet",
-        "variables": [
-            {
-                "id": 0,
-                "name": "ge01_ballots",
-                "title_en": "GE-01: Ballots",
-                "title_bm": "PRU-01: Kertas Undi",
-                "desc_en": "Ballots for every seat contested at the pre-Independence general election held on 27 July 1955.",
-                "desc_bm": "Perincian undi bagi setiap kerusi yang dipertandingkan di pilihanraya umum pramerdeka yang diadakan pada 27 Julai 1955.",
-                "catalog_data": {
-                    "catalog_filters": {
-                        "frequency": "INFREQUENT",
-                        "geographic": [
-                            "PARLIMEN",
-                            "STATE",
-                            "NATIONAL"
-                        ],
-                        "demographic": [],
-                        "start": "1959",
-                        "end": "1959",
-                        "data_source": [
-                            "SPR"
-                        ]
-                    },
-                    "metadata_neutral": {
-                        "data_as_of": "1955-08-31 23:59",
-                        "last_updated": "2023-07-18 23:59",
-                        "next_update": "-"
-                    },
-                    "metadata_lang": {
-                        "en": {
-                            "methodology": "This data is a digital representation of the physical election results tabulated and gazetted per the Electoral Regulations (Conduct of Elections). The digitalisation process was rigorously cross-checked against physical records to ensure consistency and accuracy of information.",
-                            "caveat": "As of now, this data has not been verified by SPR, and is shown here on the staging site to provide easy access for exploring and checking the data.",
-                            "publication": "-"
-                        },
-                        "bm": {
-                            "methodology": "Data ini merupakan rekod digital keputusan pilihanraya yang dikira dan diwartakan selaras dengan Peraturan-Peraturan Pilihan Raya (Penjalanan Pilihan Raya). Proses pendigitalan disemak silang dengan rekod fizikal untuk memastikan ketepatan maklumat.",
-                            "caveat": "Setakat sekarang, data ini belum disemak dan diabsahkan oleh SPR, maka hanya dipaparkan di portal UAT ini bagi tujuan memudahkan proses semakan.",
-                            "publication": "-"
-                        }
-                    },
-                    "chart": {
-                        "chart_type": "TABLE",
-                        "chart_filters": {
-                            "SLICE_BY": [],
-                            "precision": 0
-                        },
-                        "chart_variables": {
-                            "parents": [],
-                            "exclude": [],
-                            "freeze": [
-                                "state",
-                                "parlimen"
-                            ]
-                        }
-                    }
-                }
-            },
-            {
-                "id": -1,
-                "name": "state",
-                "title_en": "State",
-                "title_bm": "Negeri",
-                "desc_en": "[String] 1 of 16 states",
-                "desc_bm": "[Rentetan] 1 antara 16 negeri"
-            },
-            {
-                "id": -1,
-                "name": "parlimen",
-                "title_en": "Parliament",
-                "title_bm": "Parlimen",
-                "desc_en": "[String] Name of seat as it appeared on the ballot on voting day",
-                "desc_bm": "[Rentetan] Nama kerusi seperti mana yang tertera di kertas undi pada hari mengundi"
-            },
-            {
-                "id": -1,
-                "name": "area_name",
-                "title_en": "Area Name",
-                "title_bm": "Nama Kawasan",
-                "desc_en": "[String] Name of the area, with seat code (P.xxx) stripped out, and area name historically harmonised. For example, Kota Baharu, Kota Bahru and Kota Bharu are all harmonised to the modern Kota Bharu.",
-                "desc_bm": "[Rentetan] Nama kawasan, tanpa kod kerusi (P.xxx) dan namanya diselaraskan mengambil kira perubahan dari zaman ke zaman. Contohnya, nama Kota Baharu, Kota Bahru, dan Kota Bharu semuanya diharmonikan kepada penggunaan moden iaitu Kota Bharu."
-            },
-            {
-                "id": -1,
-                "name": "ballot_order",
-                "title_en": "Ballot Order",
-                "title_bm": "Urutan Nama",
-                "desc_en": "[Integer] Order in which the candidate appears on the ballot",
-                "desc_bm": "[Integer] Urutan nama-nama yang tertera pada kertas undi"
-            },
-            {
-                "id": -1,
-                "name": "name",
-                "title_en": "Name",
-                "title_bm": "Nama",
-                "desc_en": "[String] Name of candidate as it appeared on the ballot on voting day; this may not be the same as their real name as candidates are free to choose the name they use for campaigning and voting",
-                "desc_bm": "[Rentetan] Nama calon seperti mana yang tertera di kertas undi pada hari mengundi; ini tidak semestinya sama dengan nama sebenar mereka kerana calon adalah bebas untuk memilih nama yang digunakan bagi tujuan kempen dan undi"
-            },
-            {
-                "id": -1,
-                "name": "candidate_uid",
-                "title_en": "Unique Candidate ID",
-                "title_bm": "ID Unik Calon",
-                "desc_en": "[Integer] Unique integer identifier to track candidates across elections",
-                "desc_bm": "[Integer] Integer unik untuk menjejaki keputusan seseorang calon merentasi pilihan raya"
-            },
-            {
-                "id": -1,
-                "name": "party",
-                "title_en": "Party",
-                "title_bm": "Parti",
-                "desc_en": "[String] Party of the candidate as it appeared on the ballot on voting day; this record is not amended to reflect unofficial information on parties and coalitions. For example, if a candidate competed under the flag of Party X despite being a member of Party Y, their party is recorded as Party X.",
-                "desc_bm": "[String] Parti calon seperti yang tertera pada kertas undi pada hari mengundi; rekod ini tidak dipinda untuk menggambarkan maklumat tidak rasmi mengenai parti dan gabungan. Sebagai contoh, jika calon bertanding bawah bendera Parti X walaupun menjadi ahli Parti Y, parti mereka direkodkan sebagai Parti X."
-            },
-            {
-                "id": -1,
-                "name": "votes",
-                "title_en": "Votes",
-                "title_bm": "Undi",
-                "desc_en": "Integer] Number of votes won by the candidate",
-                "desc_bm": "[Integer] Jumlah undi yang diperolehi oleh calon"
-            }
-        ]
-    }
+	"file": {
+		"manual_trigger": 0,
+		"bucket": "elections_federal",
+		"file_name": "ge01_ballots",
+		"category": "ELECTIONS",
+		"category_en": "Elections",
+		"category_bm": "Pilihanraya",
+		"subcategory": "FEDERAL",
+		"subcategory_en": "Federal",
+		"subcategory_bm": "Persekutuan",
+		"description": {
+			"en": "Ballots for every seat contested at the pre-Independence general election held in 1955.",
+			"bm": "Perincian undi bagi setiap kerusi yang dipertandingkan di pilihanraya umum pramerdeka yang diadakan pada tahun 1955."
+		},
+		"link_parquet": "https://storage.data.gov.my/elections/federal/ge01_ballots.parquet",
+		"link_csv": "https://storage.data.gov.my/elections/federal/ge01_ballots.csv",
+		"link_preview": "https://storage.data.gov.my/elections/federal/ge01_ballots.parquet",
+		"variables": [
+			{
+				"id": 0,
+				"name": "ge01_ballots",
+				"title_en": "GE-01: Ballots",
+				"title_bm": "PRU-01: Kertas Undi",
+				"desc_en": "Ballots for every seat contested at the pre-Independence general election held on 27 July 1955.",
+				"desc_bm": "Perincian undi bagi setiap kerusi yang dipertandingkan di pilihanraya umum pramerdeka yang diadakan pada 27 Julai 1955.",
+				"catalog_data": {
+					"catalog_filters": {
+						"frequency": "INFREQUENT",
+						"geography": ["PARLIMEN", "STATE", "NATIONAL"],
+						"demographic": [],
+						"start": "1959",
+						"end": "1959",
+						"data_source": ["SPR"]
+					},
+					"metadata_neutral": {
+						"data_as_of": "1955-08-31 23:59",
+						"last_updated": "2023-07-18 23:59",
+						"next_update": "-"
+					},
+					"metadata_lang": {
+						"en": {
+							"methodology": "This data is a digital representation of the physical election results tabulated and gazetted per the Electoral Regulations (Conduct of Elections). The digitalisation process was rigorously cross-checked against physical records to ensure consistency and accuracy of information.",
+							"caveat": "As of now, this data has not been verified by SPR, and is shown here on the staging site to provide easy access for exploring and checking the data.",
+							"publication": "-"
+						},
+						"bm": {
+							"methodology": "Data ini merupakan rekod digital keputusan pilihanraya yang dikira dan diwartakan selaras dengan Peraturan-Peraturan Pilihan Raya (Penjalanan Pilihan Raya). Proses pendigitalan disemak silang dengan rekod fizikal untuk memastikan ketepatan maklumat.",
+							"caveat": "Setakat sekarang, data ini belum disemak dan diabsahkan oleh SPR, maka hanya dipaparkan di portal UAT ini bagi tujuan memudahkan proses semakan.",
+							"publication": "-"
+						}
+					},
+					"chart": {
+						"chart_type": "TABLE",
+						"chart_filters": {
+							"SLICE_BY": [],
+							"precision": 0
+						},
+						"chart_variables": {
+							"parents": [],
+							"exclude": [],
+							"freeze": ["state", "parlimen"]
+						}
+					}
+				}
+			},
+			{
+				"id": -1,
+				"name": "state",
+				"title_en": "State",
+				"title_bm": "Negeri",
+				"desc_en": "[String] 1 of 16 states",
+				"desc_bm": "[Rentetan] 1 antara 16 negeri"
+			},
+			{
+				"id": -1,
+				"name": "parlimen",
+				"title_en": "Parliament",
+				"title_bm": "Parlimen",
+				"desc_en": "[String] Name of seat as it appeared on the ballot on voting day",
+				"desc_bm": "[Rentetan] Nama kerusi seperti mana yang tertera di kertas undi pada hari mengundi"
+			},
+			{
+				"id": -1,
+				"name": "area_name",
+				"title_en": "Area Name",
+				"title_bm": "Nama Kawasan",
+				"desc_en": "[String] Name of the area, with seat code (P.xxx) stripped out, and area name historically harmonised. For example, Kota Baharu, Kota Bahru and Kota Bharu are all harmonised to the modern Kota Bharu.",
+				"desc_bm": "[Rentetan] Nama kawasan, tanpa kod kerusi (P.xxx) dan namanya diselaraskan mengambil kira perubahan dari zaman ke zaman. Contohnya, nama Kota Baharu, Kota Bahru, dan Kota Bharu semuanya diharmonikan kepada penggunaan moden iaitu Kota Bharu."
+			},
+			{
+				"id": -1,
+				"name": "ballot_order",
+				"title_en": "Ballot Order",
+				"title_bm": "Urutan Nama",
+				"desc_en": "[Integer] Order in which the candidate appears on the ballot",
+				"desc_bm": "[Integer] Urutan nama-nama yang tertera pada kertas undi"
+			},
+			{
+				"id": -1,
+				"name": "name",
+				"title_en": "Name",
+				"title_bm": "Nama",
+				"desc_en": "[String] Name of candidate as it appeared on the ballot on voting day; this may not be the same as their real name as candidates are free to choose the name they use for campaigning and voting",
+				"desc_bm": "[Rentetan] Nama calon seperti mana yang tertera di kertas undi pada hari mengundi; ini tidak semestinya sama dengan nama sebenar mereka kerana calon adalah bebas untuk memilih nama yang digunakan bagi tujuan kempen dan undi"
+			},
+			{
+				"id": -1,
+				"name": "candidate_uid",
+				"title_en": "Unique Candidate ID",
+				"title_bm": "ID Unik Calon",
+				"desc_en": "[Integer] Unique integer identifier to track candidates across elections",
+				"desc_bm": "[Integer] Integer unik untuk menjejaki keputusan seseorang calon merentasi pilihan raya"
+			},
+			{
+				"id": -1,
+				"name": "party",
+				"title_en": "Party",
+				"title_bm": "Parti",
+				"desc_en": "[String] Party of the candidate as it appeared on the ballot on voting day; this record is not amended to reflect unofficial information on parties and coalitions. For example, if a candidate competed under the flag of Party X despite being a member of Party Y, their party is recorded as Party X.",
+				"desc_bm": "[String] Parti calon seperti yang tertera pada kertas undi pada hari mengundi; rekod ini tidak dipinda untuk menggambarkan maklumat tidak rasmi mengenai parti dan gabungan. Sebagai contoh, jika calon bertanding bawah bendera Parti X walaupun menjadi ahli Parti Y, parti mereka direkodkan sebagai Parti X."
+			},
+			{
+				"id": -1,
+				"name": "votes",
+				"title_en": "Votes",
+				"title_bm": "Undi",
+				"desc_en": "Integer] Number of votes won by the candidate",
+				"desc_bm": "[Integer] Jumlah undi yang diperolehi oleh calon"
+			}
+		]
+	}
 }

--- a/catalog/ge01_summary.json
+++ b/catalog/ge01_summary.json
@@ -28,7 +28,7 @@
 					"catalog_filters": {
 						"frequency": "INFREQUENT",
 						"geography": ["PARLIMEN", "STATE", "NATIONAL"],
-						"demographic": [],
+						"demography": [],
 						"start": "1959",
 						"end": "1959",
 						"data_source": ["SPR"]

--- a/catalog/ge01_summary.json
+++ b/catalog/ge01_summary.json
@@ -1,150 +1,141 @@
 {
-    "file": {
-        "manual_trigger": 0,
-        "bucket": "elections_federal",
-        "file_name": "ge01_summary",
-        "category": "ELECTIONS",
-        "category_en": "Elections",
-        "category_bm": "Pilihanraya",
-        "subcategory": "FEDERAL",
-        "subcategory_en": "Federal",
-        "subcategory_bm": "Persekutuan",
-        "description": {
-            "en": "Analytical summary of the pre-Independence general election held in 1955.",
-            "bm": "Ringkasan analitik bagi pilihanraya umum pramerdeka yang diadakan pada tahun 1955."
-        },
-        "link_parquet": "https://storage.data.gov.my/elections/federal/ge01_summary.parquet",
-        "link_csv": "https://storage.data.gov.my/elections/federal/ge01_summary.csv",
-        "link_preview": "https://storage.data.gov.my/elections/federal/ge01_summary.parquet",
-        "variables": [
-            {
-                "id": 0,
-                "name": "ge01_summary",
-                "title_en": "GE-01: Summary",
-                "title_bm": "PRU-01: Rumusan",
-                "desc_en": "Analytical summary of the pre-Independence general election held on 27 July 1955.",
-                "desc_bm": "Ringkasan analitik bagi pilihanraya umum pramerdeka yang diadakan pada 27 Julai 1955.",
-                "catalog_data": {
-                    "catalog_filters": {
-                        "frequency": "INFREQUENT",
-                        "geographic": [
-                            "PARLIMEN",
-                            "STATE",
-                            "NATIONAL"
-                        ],
-                        "demographic": [],
-                        "start": "1959",
-                        "end": "1959",
-                        "data_source": [
-                            "SPR"
-                        ]
-                    },
-                    "metadata_neutral": {
-                        "data_as_of": "1955-08-31 23:59",
-                        "last_updated": "2023-07-18 23:59",
-                        "next_update": "-"
-                    },
-                    "metadata_lang": {
-                        "en": {
-                            "methodology": "This data is a digital representation of the physical election results tabulated and gazetted per the Electoral Regulations (Conduct of Elections). The digitalisation process was rigorously cross-checked against physical records to ensure consistency and accuracy of information.",
-                            "caveat": "As of now, this data has not been verified by SPR, and is shown here on the staging site to provide easy access for exploring and checking the data.",
-                            "publication": "-"
-                        },
-                        "bm": {
-                            "methodology": "Data ini merupakan rekod digital keputusan pilihanraya yang dikira dan diwartakan selaras dengan Peraturan-Peraturan Pilihan Raya (Penjalanan Pilihan Raya). Proses pendigitalan disemak silang dengan rekod fizikal untuk memastikan ketepatan maklumat.",
-                            "caveat": "Setakat sekarang, data ini belum disemak dan diabsahkan oleh SPR, maka hanya dipaparkan di portal UAT ini bagi tujuan memudahkan proses semakan.",
-                            "publication": "-"
-                        }
-                    },
-                    "chart": {
-                        "chart_type": "TABLE",
-                        "chart_filters": {
-                            "SLICE_BY": [],
-                            "precision": 0
-                        },
-                        "chart_variables": {
-                            "parents": [],
-                            "exclude": [],
-                            "freeze": [
-                                "state",
-                                "parlimen"
-                            ]
-                        }
-                    }
-                }
-            },
-            {
-                "id": -1,
-                "name": "state",
-                "title_en": "State",
-                "title_bm": "Negeri",
-                "desc_en": "[String] 1 of 16 states",
-                "desc_bm": "[Rentetan] 1 antara 16 negeri"
-            },
-            {
-                "id": -1,
-                "name": "parlimen",
-                "title_en": "Parliament",
-                "title_bm": "Parlimen",
-                "desc_en": "[String] Name of seat as it appeared on the ballot on voting day",
-                "desc_bm": "[Rentetan] Nama kerusi seperti mana yang tertera di kertas undi pada hari mengundi"
-            },
-            {
-                "id": -1,
-                "name": "area_name",
-                "title_en": "Area Name",
-                "title_bm": "Nama Kawasan",
-                "desc_en": "[String] Name of the area, with seat code (P.xxx) stripped out, and area name historically harmonised. For example, Kota Baharu, Kota Bahru and Kota Bharu are all harmonised to the modern Kota Bharu.",
-                "desc_bm": "[Rentetan] Nama kawasan, tanpa kod kerusi (P.xxx) dan namanya diselaraskan mengambil kira perubahan dari zaman ke zaman. Contohnya, nama Kota Baharu, Kota Bahru, dan Kota Bharu semuanya diharmonikan kepada penggunaan moden iaitu Kota Bharu."
-            },
-            {
-                "id": -1,
-                "name": "voters_total",
-                "title_en": "Total Voters",
-                "title_bm": "Jumlah Pengundi",
-                "desc_en": "[Integer] Number of voters registered to vote in that seat at that election",
-                "desc_bm": "[Integer] Jumlah pengundi yang didaftarkan untuk mengundi di kerusi tersebut semasa PRU-00"
-            },
-            {
-                "id": -1,
-                "name": "ballots_issued",
-                "title_en": "Ballots Issued",
-                "title_bm": "Undi Dikeluarkan",
-                "desc_en": "[Integer] Number of ballots issued, including postal ballots, but not inclduing ballots accidentally damaged and immediately replace during the voting procedure",
-                "desc_bm": "[Integer] Jumlah kertas undi yang dikeluarkan, termasuk kertas undi pos, tetapi tidak termasuk kertas undi yang rosak dan terus digantikan semasa urusan mengundi dijalankan"
-            },
-            {
-                "id": -1,
-                "name": "ballots_not_returned",
-                "title_en": "Ballots Not Returned",
-                "title_bm": "Undi Tidak Dikembalikan",
-                "desc_en": "[Integer] Number of ballots issued but not returned for counting, including postal ballots not returned to the counting centre in time, but excluding spoilt ballots (e.g. torn or stained) which were replaced and therefore not counted as ballots issued",
-                "desc_bm": "[Integer] Jumlah kertas undi yang dikeluarkan tetapi tidak dikembalikan untuk pengiraan undi, termasuk kertas undi pos yang tidak dikembalikan ke pusat kiraan undi, tetapi tidak termasuk kertas undi rosak (contohnya terkoyak atau ternoda) yang telah digantikan maka tidak dikira sebagai kertas undi yang dikeluarkan"
-            },
-            {
-                "id": -1,
-                "name": "votes_rejected",
-                "title_en": "Votes Rejected",
-                "title_bm": "Undi Ditolak",
-                "desc_en": "[Integer] Number of ballots returned but declared invalid during counting because the candidate could not be determined",
-                "desc_bm": "[Integer] Jumlah kertas undi yang telah dikembalikan tetapi ditolak semasa proses kiraan undi kerana calon yang diundi tidak dapat ditentukan"
-            },
-            {
-                "id": -1,
-                "name": "voter_turnout",
-                "title_en": "Voter Turnout",
-                "title_bm": "Peratus Keluar",
-                "desc_en": "[Float] Derived as: (ballots_issued / voters_total) * 100",
-                "desc_bm": " [Apung] Diperolehi dengan formula: (ballots_issued / voters_total) * 100"
-            },
-            {
-                "id": -1,
-                "name": "votes_rejected_perc",
-                "title_en": "Percentage Rejected",
-                "title_bm": "Peratus Ditolak",
-                "desc_en": "[Float] Derived as: (votes_rejected / (ballots_issued - ballots_not_returned)) * 100",
-                "desc_bm": " [Apung] Diperolehi dengan formula: (votes_rejected / (ballots_issued - ballots_not_returned)) * 100"
-            }
-        ]
-    }
+	"file": {
+		"manual_trigger": 0,
+		"bucket": "elections_federal",
+		"file_name": "ge01_summary",
+		"category": "ELECTIONS",
+		"category_en": "Elections",
+		"category_bm": "Pilihanraya",
+		"subcategory": "FEDERAL",
+		"subcategory_en": "Federal",
+		"subcategory_bm": "Persekutuan",
+		"description": {
+			"en": "Analytical summary of the pre-Independence general election held in 1955.",
+			"bm": "Ringkasan analitik bagi pilihanraya umum pramerdeka yang diadakan pada tahun 1955."
+		},
+		"link_parquet": "https://storage.data.gov.my/elections/federal/ge01_summary.parquet",
+		"link_csv": "https://storage.data.gov.my/elections/federal/ge01_summary.csv",
+		"link_preview": "https://storage.data.gov.my/elections/federal/ge01_summary.parquet",
+		"variables": [
+			{
+				"id": 0,
+				"name": "ge01_summary",
+				"title_en": "GE-01: Summary",
+				"title_bm": "PRU-01: Rumusan",
+				"desc_en": "Analytical summary of the pre-Independence general election held on 27 July 1955.",
+				"desc_bm": "Ringkasan analitik bagi pilihanraya umum pramerdeka yang diadakan pada 27 Julai 1955.",
+				"catalog_data": {
+					"catalog_filters": {
+						"frequency": "INFREQUENT",
+						"geography": ["PARLIMEN", "STATE", "NATIONAL"],
+						"demographic": [],
+						"start": "1959",
+						"end": "1959",
+						"data_source": ["SPR"]
+					},
+					"metadata_neutral": {
+						"data_as_of": "1955-08-31 23:59",
+						"last_updated": "2023-07-18 23:59",
+						"next_update": "-"
+					},
+					"metadata_lang": {
+						"en": {
+							"methodology": "This data is a digital representation of the physical election results tabulated and gazetted per the Electoral Regulations (Conduct of Elections). The digitalisation process was rigorously cross-checked against physical records to ensure consistency and accuracy of information.",
+							"caveat": "As of now, this data has not been verified by SPR, and is shown here on the staging site to provide easy access for exploring and checking the data.",
+							"publication": "-"
+						},
+						"bm": {
+							"methodology": "Data ini merupakan rekod digital keputusan pilihanraya yang dikira dan diwartakan selaras dengan Peraturan-Peraturan Pilihan Raya (Penjalanan Pilihan Raya). Proses pendigitalan disemak silang dengan rekod fizikal untuk memastikan ketepatan maklumat.",
+							"caveat": "Setakat sekarang, data ini belum disemak dan diabsahkan oleh SPR, maka hanya dipaparkan di portal UAT ini bagi tujuan memudahkan proses semakan.",
+							"publication": "-"
+						}
+					},
+					"chart": {
+						"chart_type": "TABLE",
+						"chart_filters": {
+							"SLICE_BY": [],
+							"precision": 0
+						},
+						"chart_variables": {
+							"parents": [],
+							"exclude": [],
+							"freeze": ["state", "parlimen"]
+						}
+					}
+				}
+			},
+			{
+				"id": -1,
+				"name": "state",
+				"title_en": "State",
+				"title_bm": "Negeri",
+				"desc_en": "[String] 1 of 16 states",
+				"desc_bm": "[Rentetan] 1 antara 16 negeri"
+			},
+			{
+				"id": -1,
+				"name": "parlimen",
+				"title_en": "Parliament",
+				"title_bm": "Parlimen",
+				"desc_en": "[String] Name of seat as it appeared on the ballot on voting day",
+				"desc_bm": "[Rentetan] Nama kerusi seperti mana yang tertera di kertas undi pada hari mengundi"
+			},
+			{
+				"id": -1,
+				"name": "area_name",
+				"title_en": "Area Name",
+				"title_bm": "Nama Kawasan",
+				"desc_en": "[String] Name of the area, with seat code (P.xxx) stripped out, and area name historically harmonised. For example, Kota Baharu, Kota Bahru and Kota Bharu are all harmonised to the modern Kota Bharu.",
+				"desc_bm": "[Rentetan] Nama kawasan, tanpa kod kerusi (P.xxx) dan namanya diselaraskan mengambil kira perubahan dari zaman ke zaman. Contohnya, nama Kota Baharu, Kota Bahru, dan Kota Bharu semuanya diharmonikan kepada penggunaan moden iaitu Kota Bharu."
+			},
+			{
+				"id": -1,
+				"name": "voters_total",
+				"title_en": "Total Voters",
+				"title_bm": "Jumlah Pengundi",
+				"desc_en": "[Integer] Number of voters registered to vote in that seat at that election",
+				"desc_bm": "[Integer] Jumlah pengundi yang didaftarkan untuk mengundi di kerusi tersebut semasa PRU-00"
+			},
+			{
+				"id": -1,
+				"name": "ballots_issued",
+				"title_en": "Ballots Issued",
+				"title_bm": "Undi Dikeluarkan",
+				"desc_en": "[Integer] Number of ballots issued, including postal ballots, but not inclduing ballots accidentally damaged and immediately replace during the voting procedure",
+				"desc_bm": "[Integer] Jumlah kertas undi yang dikeluarkan, termasuk kertas undi pos, tetapi tidak termasuk kertas undi yang rosak dan terus digantikan semasa urusan mengundi dijalankan"
+			},
+			{
+				"id": -1,
+				"name": "ballots_not_returned",
+				"title_en": "Ballots Not Returned",
+				"title_bm": "Undi Tidak Dikembalikan",
+				"desc_en": "[Integer] Number of ballots issued but not returned for counting, including postal ballots not returned to the counting centre in time, but excluding spoilt ballots (e.g. torn or stained) which were replaced and therefore not counted as ballots issued",
+				"desc_bm": "[Integer] Jumlah kertas undi yang dikeluarkan tetapi tidak dikembalikan untuk pengiraan undi, termasuk kertas undi pos yang tidak dikembalikan ke pusat kiraan undi, tetapi tidak termasuk kertas undi rosak (contohnya terkoyak atau ternoda) yang telah digantikan maka tidak dikira sebagai kertas undi yang dikeluarkan"
+			},
+			{
+				"id": -1,
+				"name": "votes_rejected",
+				"title_en": "Votes Rejected",
+				"title_bm": "Undi Ditolak",
+				"desc_en": "[Integer] Number of ballots returned but declared invalid during counting because the candidate could not be determined",
+				"desc_bm": "[Integer] Jumlah kertas undi yang telah dikembalikan tetapi ditolak semasa proses kiraan undi kerana calon yang diundi tidak dapat ditentukan"
+			},
+			{
+				"id": -1,
+				"name": "voter_turnout",
+				"title_en": "Voter Turnout",
+				"title_bm": "Peratus Keluar",
+				"desc_en": "[Float] Derived as: (ballots_issued / voters_total) * 100",
+				"desc_bm": " [Apung] Diperolehi dengan formula: (ballots_issued / voters_total) * 100"
+			},
+			{
+				"id": -1,
+				"name": "votes_rejected_perc",
+				"title_en": "Percentage Rejected",
+				"title_bm": "Peratus Ditolak",
+				"desc_en": "[Float] Derived as: (votes_rejected / (ballots_issued - ballots_not_returned)) * 100",
+				"desc_bm": " [Apung] Diperolehi dengan formula: (votes_rejected / (ballots_issued - ballots_not_returned)) * 100"
+			}
+		]
+	}
 }

--- a/catalog/ge02_ballots.json
+++ b/catalog/ge02_ballots.json
@@ -1,142 +1,133 @@
 {
-    "file": {
-        "manual_trigger": 0,
-        "bucket": "elections_federal",
-        "file_name": "ge02_ballots",
-        "category": "ELECTIONS",
-        "category_en": "Elections",
-        "category_bm": "Pilihanraya",
-        "subcategory": "FEDERAL",
-        "subcategory_en": "Federal",
-        "subcategory_bm": "Persekutuan",
-        "description": {
-            "en": "Ballots for every seat contested at the pre-Independence general election held in 1955.",
-            "bm": "Perincian undi bagi setiap kerusi yang dipertandingkan di pilihanraya umum pramerdeka yang diadakan pada tahun 1955."
-        },
-        "link_parquet": "https://storage.data.gov.my/elections/federal/ge02_ballots.parquet",
-        "link_csv": "https://storage.data.gov.my/elections/federal/ge02_ballots.csv",
-        "link_preview": "https://storage.data.gov.my/elections/federal/ge02_ballots.parquet",
-        "variables": [
-            {
-                "id": 0,
-                "name": "ge02_ballots",
-                "title_en": "GE-02: Ballots",
-                "title_bm": "PRU-02: Kertas Undi",
-                "desc_en": "Ballots for every seat contested at the pre-Independence general election held on 27 July 1955.",
-                "desc_bm": "Perincian undi bagi setiap kerusi yang dipertandingkan di pilihanraya umum pramerdeka yang diadakan pada 27 Julai 1955.",
-                "catalog_data": {
-                    "catalog_filters": {
-                        "frequency": "INFREQUENT",
-                        "geographic": [
-                            "PARLIMEN",
-                            "STATE",
-                            "NATIONAL"
-                        ],
-                        "demographic": [],
-                        "start": "1964",
-                        "end": "1964",
-                        "data_source": [
-                            "SPR"
-                        ]
-                    },
-                    "metadata_neutral": {
-                        "data_as_of": "1955-08-31 23:59",
-                        "last_updated": "2023-07-18 23:59",
-                        "next_update": "-"
-                    },
-                    "metadata_lang": {
-                        "en": {
-                            "methodology": "This data is a digital representation of the physical election results tabulated and gazetted per the Electoral Regulations (Conduct of Elections). The digitalisation process was rigorously cross-checked against physical records to ensure consistency and accuracy of information.",
-                            "caveat": "As of now, this data has not been verified by SPR, and is shown here on the staging site to provide easy access for exploring and checking the data.",
-                            "publication": "-"
-                        },
-                        "bm": {
-                            "methodology": "Data ini merupakan rekod digital keputusan pilihanraya yang dikira dan diwartakan selaras dengan Peraturan-Peraturan Pilihan Raya (Penjalanan Pilihan Raya). Proses pendigitalan disemak silang dengan rekod fizikal untuk memastikan ketepatan maklumat.",
-                            "caveat": "Setakat sekarang, data ini belum disemak dan diabsahkan oleh SPR, maka hanya dipaparkan di portal UAT ini bagi tujuan memudahkan proses semakan.",
-                            "publication": "-"
-                        }
-                    },
-                    "chart": {
-                        "chart_type": "TABLE",
-                        "chart_filters": {
-                            "SLICE_BY": [],
-                            "precision": 0
-                        },
-                        "chart_variables": {
-                            "parents": [],
-                            "exclude": [],
-                            "freeze": [
-                                "state",
-                                "parlimen"
-                            ]
-                        }
-                    }
-                }
-            },
-            {
-                "id": -1,
-                "name": "state",
-                "title_en": "State",
-                "title_bm": "Negeri",
-                "desc_en": "[String] 1 of 16 states",
-                "desc_bm": "[Rentetan] 1 antara 16 negeri"
-            },
-            {
-                "id": -1,
-                "name": "parlimen",
-                "title_en": "Parliament",
-                "title_bm": "Parlimen",
-                "desc_en": "[String] Name of seat as it appeared on the ballot on voting day",
-                "desc_bm": "[Rentetan] Nama kerusi seperti mana yang tertera di kertas undi pada hari mengundi"
-            },
-            {
-                "id": -1,
-                "name": "area_name",
-                "title_en": "Area Name",
-                "title_bm": "Nama Kawasan",
-                "desc_en": "[String] Name of the area, with seat code (P.xxx) stripped out, and area name historically harmonised. For example, Kota Baharu, Kota Bahru and Kota Bharu are all harmonised to the modern Kota Bharu.",
-                "desc_bm": "[Rentetan] Nama kawasan, tanpa kod kerusi (P.xxx) dan namanya diselaraskan mengambil kira perubahan dari zaman ke zaman. Contohnya, nama Kota Baharu, Kota Bahru, dan Kota Bharu semuanya diharmonikan kepada penggunaan moden iaitu Kota Bharu."
-            },
-            {
-                "id": -1,
-                "name": "ballot_order",
-                "title_en": "Ballot Order",
-                "title_bm": "Urutan Nama",
-                "desc_en": "[Integer] Order in which the candidate appears on the ballot",
-                "desc_bm": "[Integer] Urutan nama-nama yang tertera pada kertas undi"
-            },
-            {
-                "id": -1,
-                "name": "name",
-                "title_en": "Name",
-                "title_bm": "Nama",
-                "desc_en": "[String] Name of candidate as it appeared on the ballot on voting day; this may not be the same as their real name as candidates are free to choose the name they use for campaigning and voting",
-                "desc_bm": "[Rentetan] Nama calon seperti mana yang tertera di kertas undi pada hari mengundi; ini tidak semestinya sama dengan nama sebenar mereka kerana calon adalah bebas untuk memilih nama yang digunakan bagi tujuan kempen dan undi"
-            },
-            {
-                "id": -1,
-                "name": "candidate_uid",
-                "title_en": "Unique Candidate ID",
-                "title_bm": "ID Unik Calon",
-                "desc_en": "[Integer] Unique integer identifier to track candidates across elections",
-                "desc_bm": "[Integer] Integer unik untuk menjejaki keputusan seseorang calon merentasi pilihan raya"
-            },
-            {
-                "id": -1,
-                "name": "party",
-                "title_en": "Party",
-                "title_bm": "Parti",
-                "desc_en": "[String] Party of the candidate as it appeared on the ballot on voting day; this record is not amended to reflect unofficial information on parties and coalitions. For example, if a candidate competed under the flag of Party X despite being a member of Party Y, their party is recorded as Party X.",
-                "desc_bm": "[String] Parti calon seperti yang tertera pada kertas undi pada hari mengundi; rekod ini tidak dipinda untuk menggambarkan maklumat tidak rasmi mengenai parti dan gabungan. Sebagai contoh, jika calon bertanding bawah bendera Parti X walaupun menjadi ahli Parti Y, parti mereka direkodkan sebagai Parti X."
-            },
-            {
-                "id": -1,
-                "name": "votes",
-                "title_en": "Votes",
-                "title_bm": "Undi",
-                "desc_en": "Integer] Number of votes won by the candidate",
-                "desc_bm": "[Integer] Jumlah undi yang diperolehi oleh calon"
-            }
-        ]
-    }
+	"file": {
+		"manual_trigger": 0,
+		"bucket": "elections_federal",
+		"file_name": "ge02_ballots",
+		"category": "ELECTIONS",
+		"category_en": "Elections",
+		"category_bm": "Pilihanraya",
+		"subcategory": "FEDERAL",
+		"subcategory_en": "Federal",
+		"subcategory_bm": "Persekutuan",
+		"description": {
+			"en": "Ballots for every seat contested at the pre-Independence general election held in 1955.",
+			"bm": "Perincian undi bagi setiap kerusi yang dipertandingkan di pilihanraya umum pramerdeka yang diadakan pada tahun 1955."
+		},
+		"link_parquet": "https://storage.data.gov.my/elections/federal/ge02_ballots.parquet",
+		"link_csv": "https://storage.data.gov.my/elections/federal/ge02_ballots.csv",
+		"link_preview": "https://storage.data.gov.my/elections/federal/ge02_ballots.parquet",
+		"variables": [
+			{
+				"id": 0,
+				"name": "ge02_ballots",
+				"title_en": "GE-02: Ballots",
+				"title_bm": "PRU-02: Kertas Undi",
+				"desc_en": "Ballots for every seat contested at the pre-Independence general election held on 27 July 1955.",
+				"desc_bm": "Perincian undi bagi setiap kerusi yang dipertandingkan di pilihanraya umum pramerdeka yang diadakan pada 27 Julai 1955.",
+				"catalog_data": {
+					"catalog_filters": {
+						"frequency": "INFREQUENT",
+						"geography": ["PARLIMEN", "STATE", "NATIONAL"],
+						"demographic": [],
+						"start": "1964",
+						"end": "1964",
+						"data_source": ["SPR"]
+					},
+					"metadata_neutral": {
+						"data_as_of": "1955-08-31 23:59",
+						"last_updated": "2023-07-18 23:59",
+						"next_update": "-"
+					},
+					"metadata_lang": {
+						"en": {
+							"methodology": "This data is a digital representation of the physical election results tabulated and gazetted per the Electoral Regulations (Conduct of Elections). The digitalisation process was rigorously cross-checked against physical records to ensure consistency and accuracy of information.",
+							"caveat": "As of now, this data has not been verified by SPR, and is shown here on the staging site to provide easy access for exploring and checking the data.",
+							"publication": "-"
+						},
+						"bm": {
+							"methodology": "Data ini merupakan rekod digital keputusan pilihanraya yang dikira dan diwartakan selaras dengan Peraturan-Peraturan Pilihan Raya (Penjalanan Pilihan Raya). Proses pendigitalan disemak silang dengan rekod fizikal untuk memastikan ketepatan maklumat.",
+							"caveat": "Setakat sekarang, data ini belum disemak dan diabsahkan oleh SPR, maka hanya dipaparkan di portal UAT ini bagi tujuan memudahkan proses semakan.",
+							"publication": "-"
+						}
+					},
+					"chart": {
+						"chart_type": "TABLE",
+						"chart_filters": {
+							"SLICE_BY": [],
+							"precision": 0
+						},
+						"chart_variables": {
+							"parents": [],
+							"exclude": [],
+							"freeze": ["state", "parlimen"]
+						}
+					}
+				}
+			},
+			{
+				"id": -1,
+				"name": "state",
+				"title_en": "State",
+				"title_bm": "Negeri",
+				"desc_en": "[String] 1 of 16 states",
+				"desc_bm": "[Rentetan] 1 antara 16 negeri"
+			},
+			{
+				"id": -1,
+				"name": "parlimen",
+				"title_en": "Parliament",
+				"title_bm": "Parlimen",
+				"desc_en": "[String] Name of seat as it appeared on the ballot on voting day",
+				"desc_bm": "[Rentetan] Nama kerusi seperti mana yang tertera di kertas undi pada hari mengundi"
+			},
+			{
+				"id": -1,
+				"name": "area_name",
+				"title_en": "Area Name",
+				"title_bm": "Nama Kawasan",
+				"desc_en": "[String] Name of the area, with seat code (P.xxx) stripped out, and area name historically harmonised. For example, Kota Baharu, Kota Bahru and Kota Bharu are all harmonised to the modern Kota Bharu.",
+				"desc_bm": "[Rentetan] Nama kawasan, tanpa kod kerusi (P.xxx) dan namanya diselaraskan mengambil kira perubahan dari zaman ke zaman. Contohnya, nama Kota Baharu, Kota Bahru, dan Kota Bharu semuanya diharmonikan kepada penggunaan moden iaitu Kota Bharu."
+			},
+			{
+				"id": -1,
+				"name": "ballot_order",
+				"title_en": "Ballot Order",
+				"title_bm": "Urutan Nama",
+				"desc_en": "[Integer] Order in which the candidate appears on the ballot",
+				"desc_bm": "[Integer] Urutan nama-nama yang tertera pada kertas undi"
+			},
+			{
+				"id": -1,
+				"name": "name",
+				"title_en": "Name",
+				"title_bm": "Nama",
+				"desc_en": "[String] Name of candidate as it appeared on the ballot on voting day; this may not be the same as their real name as candidates are free to choose the name they use for campaigning and voting",
+				"desc_bm": "[Rentetan] Nama calon seperti mana yang tertera di kertas undi pada hari mengundi; ini tidak semestinya sama dengan nama sebenar mereka kerana calon adalah bebas untuk memilih nama yang digunakan bagi tujuan kempen dan undi"
+			},
+			{
+				"id": -1,
+				"name": "candidate_uid",
+				"title_en": "Unique Candidate ID",
+				"title_bm": "ID Unik Calon",
+				"desc_en": "[Integer] Unique integer identifier to track candidates across elections",
+				"desc_bm": "[Integer] Integer unik untuk menjejaki keputusan seseorang calon merentasi pilihan raya"
+			},
+			{
+				"id": -1,
+				"name": "party",
+				"title_en": "Party",
+				"title_bm": "Parti",
+				"desc_en": "[String] Party of the candidate as it appeared on the ballot on voting day; this record is not amended to reflect unofficial information on parties and coalitions. For example, if a candidate competed under the flag of Party X despite being a member of Party Y, their party is recorded as Party X.",
+				"desc_bm": "[String] Parti calon seperti yang tertera pada kertas undi pada hari mengundi; rekod ini tidak dipinda untuk menggambarkan maklumat tidak rasmi mengenai parti dan gabungan. Sebagai contoh, jika calon bertanding bawah bendera Parti X walaupun menjadi ahli Parti Y, parti mereka direkodkan sebagai Parti X."
+			},
+			{
+				"id": -1,
+				"name": "votes",
+				"title_en": "Votes",
+				"title_bm": "Undi",
+				"desc_en": "Integer] Number of votes won by the candidate",
+				"desc_bm": "[Integer] Jumlah undi yang diperolehi oleh calon"
+			}
+		]
+	}
 }

--- a/catalog/ge02_ballots.json
+++ b/catalog/ge02_ballots.json
@@ -28,7 +28,7 @@
 					"catalog_filters": {
 						"frequency": "INFREQUENT",
 						"geography": ["PARLIMEN", "STATE", "NATIONAL"],
-						"demographic": [],
+						"demography": [],
 						"start": "1964",
 						"end": "1964",
 						"data_source": ["SPR"]

--- a/catalog/ge02_summary.json
+++ b/catalog/ge02_summary.json
@@ -28,7 +28,7 @@
 					"catalog_filters": {
 						"frequency": "INFREQUENT",
 						"geography": ["PARLIMEN", "STATE", "NATIONAL"],
-						"demographic": [],
+						"demography": [],
 						"start": "1964",
 						"end": "1964",
 						"data_source": ["SPR"]

--- a/catalog/ge02_summary.json
+++ b/catalog/ge02_summary.json
@@ -1,150 +1,141 @@
 {
-    "file": {
-        "manual_trigger": 0,
-        "bucket": "elections_federal",
-        "file_name": "ge02_summary",
-        "category": "ELECTIONS",
-        "category_en": "Elections",
-        "category_bm": "Pilihanraya",
-        "subcategory": "FEDERAL",
-        "subcategory_en": "Federal",
-        "subcategory_bm": "Persekutuan",
-        "description": {
-            "en": "Analytical summary of the pre-Independence general election held in 1955.",
-            "bm": "Ringkasan analitik bagi pilihanraya umum pramerdeka yang diadakan pada tahun 1955."
-        },
-        "link_parquet": "https://storage.data.gov.my/elections/federal/ge02_summary.parquet",
-        "link_csv": "https://storage.data.gov.my/elections/federal/ge02_summary.csv",
-        "link_preview": "https://storage.data.gov.my/elections/federal/ge02_summary.parquet",
-        "variables": [
-            {
-                "id": 0,
-                "name": "ge02_summary",
-                "title_en": "GE-02: Summary",
-                "title_bm": "PRU-02: Rumusan",
-                "desc_en": "Analytical summary of the pre-Independence general election held on 27 July 1955.",
-                "desc_bm": "Ringkasan analitik bagi pilihanraya umum pramerdeka yang diadakan pada 27 Julai 1955.",
-                "catalog_data": {
-                    "catalog_filters": {
-                        "frequency": "INFREQUENT",
-                        "geographic": [
-                            "PARLIMEN",
-                            "STATE",
-                            "NATIONAL"
-                        ],
-                        "demographic": [],
-                        "start": "1964",
-                        "end": "1964",
-                        "data_source": [
-                            "SPR"
-                        ]
-                    },
-                    "metadata_neutral": {
-                        "data_as_of": "1955-08-31 23:59",
-                        "last_updated": "2023-07-18 23:59",
-                        "next_update": "-"
-                    },
-                    "metadata_lang": {
-                        "en": {
-                            "methodology": "This data is a digital representation of the physical election results tabulated and gazetted per the Electoral Regulations (Conduct of Elections). The digitalisation process was rigorously cross-checked against physical records to ensure consistency and accuracy of information.",
-                            "caveat": "As of now, this data has not been verified by SPR, and is shown here on the staging site to provide easy access for exploring and checking the data.",
-                            "publication": "-"
-                        },
-                        "bm": {
-                            "methodology": "Data ini merupakan rekod digital keputusan pilihanraya yang dikira dan diwartakan selaras dengan Peraturan-Peraturan Pilihan Raya (Penjalanan Pilihan Raya). Proses pendigitalan disemak silang dengan rekod fizikal untuk memastikan ketepatan maklumat.",
-                            "caveat": "Setakat sekarang, data ini belum disemak dan diabsahkan oleh SPR, maka hanya dipaparkan di portal UAT ini bagi tujuan memudahkan proses semakan.",
-                            "publication": "-"
-                        }
-                    },
-                    "chart": {
-                        "chart_type": "TABLE",
-                        "chart_filters": {
-                            "SLICE_BY": [],
-                            "precision": 0
-                        },
-                        "chart_variables": {
-                            "parents": [],
-                            "exclude": [],
-                            "freeze": [
-                                "state",
-                                "parlimen"
-                            ]
-                        }
-                    }
-                }
-            },
-            {
-                "id": -1,
-                "name": "state",
-                "title_en": "State",
-                "title_bm": "Negeri",
-                "desc_en": "[String] 1 of 16 states",
-                "desc_bm": "[Rentetan] 1 antara 16 negeri"
-            },
-            {
-                "id": -1,
-                "name": "parlimen",
-                "title_en": "Parliament",
-                "title_bm": "Parlimen",
-                "desc_en": "[String] Name of seat as it appeared on the ballot on voting day",
-                "desc_bm": "[Rentetan] Nama kerusi seperti mana yang tertera di kertas undi pada hari mengundi"
-            },
-            {
-                "id": -1,
-                "name": "area_name",
-                "title_en": "Area Name",
-                "title_bm": "Nama Kawasan",
-                "desc_en": "[String] Name of the area, with seat code (P.xxx) stripped out, and area name historically harmonised. For example, Kota Baharu, Kota Bahru and Kota Bharu are all harmonised to the modern Kota Bharu.",
-                "desc_bm": "[Rentetan] Nama kawasan, tanpa kod kerusi (P.xxx) dan namanya diselaraskan mengambil kira perubahan dari zaman ke zaman. Contohnya, nama Kota Baharu, Kota Bahru, dan Kota Bharu semuanya diharmonikan kepada penggunaan moden iaitu Kota Bharu."
-            },
-            {
-                "id": -1,
-                "name": "voters_total",
-                "title_en": "Total Voters",
-                "title_bm": "Jumlah Pengundi",
-                "desc_en": "[Integer] Number of voters registered to vote in that seat at that election",
-                "desc_bm": "[Integer] Jumlah pengundi yang didaftarkan untuk mengundi di kerusi tersebut semasa PRU-00"
-            },
-            {
-                "id": -1,
-                "name": "ballots_issued",
-                "title_en": "Ballots Issued",
-                "title_bm": "Undi Dikeluarkan",
-                "desc_en": "[Integer] Number of ballots issued, including postal ballots, but not inclduing ballots accidentally damaged and immediately replace during the voting procedure",
-                "desc_bm": "[Integer] Jumlah kertas undi yang dikeluarkan, termasuk kertas undi pos, tetapi tidak termasuk kertas undi yang rosak dan terus digantikan semasa urusan mengundi dijalankan"
-            },
-            {
-                "id": -1,
-                "name": "ballots_not_returned",
-                "title_en": "Ballots Not Returned",
-                "title_bm": "Undi Tidak Dikembalikan",
-                "desc_en": "[Integer] Number of ballots issued but not returned for counting, including postal ballots not returned to the counting centre in time, but excluding spoilt ballots (e.g. torn or stained) which were replaced and therefore not counted as ballots issued",
-                "desc_bm": "[Integer] Jumlah kertas undi yang dikeluarkan tetapi tidak dikembalikan untuk pengiraan undi, termasuk kertas undi pos yang tidak dikembalikan ke pusat kiraan undi, tetapi tidak termasuk kertas undi rosak (contohnya terkoyak atau ternoda) yang telah digantikan maka tidak dikira sebagai kertas undi yang dikeluarkan"
-            },
-            {
-                "id": -1,
-                "name": "votes_rejected",
-                "title_en": "Votes Rejected",
-                "title_bm": "Undi Ditolak",
-                "desc_en": "[Integer] Number of ballots returned but declared invalid during counting because the candidate could not be determined",
-                "desc_bm": "[Integer] Jumlah kertas undi yang telah dikembalikan tetapi ditolak semasa proses kiraan undi kerana calon yang diundi tidak dapat ditentukan"
-            },
-            {
-                "id": -1,
-                "name": "voter_turnout",
-                "title_en": "Voter Turnout",
-                "title_bm": "Peratus Keluar",
-                "desc_en": "[Float] Derived as: (ballots_issued / voters_total) * 100",
-                "desc_bm": " [Apung] Diperolehi dengan formula: (ballots_issued / voters_total) * 100"
-            },
-            {
-                "id": -1,
-                "name": "votes_rejected_perc",
-                "title_en": "Percentage Rejected",
-                "title_bm": "Peratus Ditolak",
-                "desc_en": "[Float] Derived as: (votes_rejected / (ballots_issued - ballots_not_returned)) * 100",
-                "desc_bm": " [Apung] Diperolehi dengan formula: (votes_rejected / (ballots_issued - ballots_not_returned)) * 100"
-            }
-        ]
-    }
+	"file": {
+		"manual_trigger": 0,
+		"bucket": "elections_federal",
+		"file_name": "ge02_summary",
+		"category": "ELECTIONS",
+		"category_en": "Elections",
+		"category_bm": "Pilihanraya",
+		"subcategory": "FEDERAL",
+		"subcategory_en": "Federal",
+		"subcategory_bm": "Persekutuan",
+		"description": {
+			"en": "Analytical summary of the pre-Independence general election held in 1955.",
+			"bm": "Ringkasan analitik bagi pilihanraya umum pramerdeka yang diadakan pada tahun 1955."
+		},
+		"link_parquet": "https://storage.data.gov.my/elections/federal/ge02_summary.parquet",
+		"link_csv": "https://storage.data.gov.my/elections/federal/ge02_summary.csv",
+		"link_preview": "https://storage.data.gov.my/elections/federal/ge02_summary.parquet",
+		"variables": [
+			{
+				"id": 0,
+				"name": "ge02_summary",
+				"title_en": "GE-02: Summary",
+				"title_bm": "PRU-02: Rumusan",
+				"desc_en": "Analytical summary of the pre-Independence general election held on 27 July 1955.",
+				"desc_bm": "Ringkasan analitik bagi pilihanraya umum pramerdeka yang diadakan pada 27 Julai 1955.",
+				"catalog_data": {
+					"catalog_filters": {
+						"frequency": "INFREQUENT",
+						"geography": ["PARLIMEN", "STATE", "NATIONAL"],
+						"demographic": [],
+						"start": "1964",
+						"end": "1964",
+						"data_source": ["SPR"]
+					},
+					"metadata_neutral": {
+						"data_as_of": "1955-08-31 23:59",
+						"last_updated": "2023-07-18 23:59",
+						"next_update": "-"
+					},
+					"metadata_lang": {
+						"en": {
+							"methodology": "This data is a digital representation of the physical election results tabulated and gazetted per the Electoral Regulations (Conduct of Elections). The digitalisation process was rigorously cross-checked against physical records to ensure consistency and accuracy of information.",
+							"caveat": "As of now, this data has not been verified by SPR, and is shown here on the staging site to provide easy access for exploring and checking the data.",
+							"publication": "-"
+						},
+						"bm": {
+							"methodology": "Data ini merupakan rekod digital keputusan pilihanraya yang dikira dan diwartakan selaras dengan Peraturan-Peraturan Pilihan Raya (Penjalanan Pilihan Raya). Proses pendigitalan disemak silang dengan rekod fizikal untuk memastikan ketepatan maklumat.",
+							"caveat": "Setakat sekarang, data ini belum disemak dan diabsahkan oleh SPR, maka hanya dipaparkan di portal UAT ini bagi tujuan memudahkan proses semakan.",
+							"publication": "-"
+						}
+					},
+					"chart": {
+						"chart_type": "TABLE",
+						"chart_filters": {
+							"SLICE_BY": [],
+							"precision": 0
+						},
+						"chart_variables": {
+							"parents": [],
+							"exclude": [],
+							"freeze": ["state", "parlimen"]
+						}
+					}
+				}
+			},
+			{
+				"id": -1,
+				"name": "state",
+				"title_en": "State",
+				"title_bm": "Negeri",
+				"desc_en": "[String] 1 of 16 states",
+				"desc_bm": "[Rentetan] 1 antara 16 negeri"
+			},
+			{
+				"id": -1,
+				"name": "parlimen",
+				"title_en": "Parliament",
+				"title_bm": "Parlimen",
+				"desc_en": "[String] Name of seat as it appeared on the ballot on voting day",
+				"desc_bm": "[Rentetan] Nama kerusi seperti mana yang tertera di kertas undi pada hari mengundi"
+			},
+			{
+				"id": -1,
+				"name": "area_name",
+				"title_en": "Area Name",
+				"title_bm": "Nama Kawasan",
+				"desc_en": "[String] Name of the area, with seat code (P.xxx) stripped out, and area name historically harmonised. For example, Kota Baharu, Kota Bahru and Kota Bharu are all harmonised to the modern Kota Bharu.",
+				"desc_bm": "[Rentetan] Nama kawasan, tanpa kod kerusi (P.xxx) dan namanya diselaraskan mengambil kira perubahan dari zaman ke zaman. Contohnya, nama Kota Baharu, Kota Bahru, dan Kota Bharu semuanya diharmonikan kepada penggunaan moden iaitu Kota Bharu."
+			},
+			{
+				"id": -1,
+				"name": "voters_total",
+				"title_en": "Total Voters",
+				"title_bm": "Jumlah Pengundi",
+				"desc_en": "[Integer] Number of voters registered to vote in that seat at that election",
+				"desc_bm": "[Integer] Jumlah pengundi yang didaftarkan untuk mengundi di kerusi tersebut semasa PRU-00"
+			},
+			{
+				"id": -1,
+				"name": "ballots_issued",
+				"title_en": "Ballots Issued",
+				"title_bm": "Undi Dikeluarkan",
+				"desc_en": "[Integer] Number of ballots issued, including postal ballots, but not inclduing ballots accidentally damaged and immediately replace during the voting procedure",
+				"desc_bm": "[Integer] Jumlah kertas undi yang dikeluarkan, termasuk kertas undi pos, tetapi tidak termasuk kertas undi yang rosak dan terus digantikan semasa urusan mengundi dijalankan"
+			},
+			{
+				"id": -1,
+				"name": "ballots_not_returned",
+				"title_en": "Ballots Not Returned",
+				"title_bm": "Undi Tidak Dikembalikan",
+				"desc_en": "[Integer] Number of ballots issued but not returned for counting, including postal ballots not returned to the counting centre in time, but excluding spoilt ballots (e.g. torn or stained) which were replaced and therefore not counted as ballots issued",
+				"desc_bm": "[Integer] Jumlah kertas undi yang dikeluarkan tetapi tidak dikembalikan untuk pengiraan undi, termasuk kertas undi pos yang tidak dikembalikan ke pusat kiraan undi, tetapi tidak termasuk kertas undi rosak (contohnya terkoyak atau ternoda) yang telah digantikan maka tidak dikira sebagai kertas undi yang dikeluarkan"
+			},
+			{
+				"id": -1,
+				"name": "votes_rejected",
+				"title_en": "Votes Rejected",
+				"title_bm": "Undi Ditolak",
+				"desc_en": "[Integer] Number of ballots returned but declared invalid during counting because the candidate could not be determined",
+				"desc_bm": "[Integer] Jumlah kertas undi yang telah dikembalikan tetapi ditolak semasa proses kiraan undi kerana calon yang diundi tidak dapat ditentukan"
+			},
+			{
+				"id": -1,
+				"name": "voter_turnout",
+				"title_en": "Voter Turnout",
+				"title_bm": "Peratus Keluar",
+				"desc_en": "[Float] Derived as: (ballots_issued / voters_total) * 100",
+				"desc_bm": " [Apung] Diperolehi dengan formula: (ballots_issued / voters_total) * 100"
+			},
+			{
+				"id": -1,
+				"name": "votes_rejected_perc",
+				"title_en": "Percentage Rejected",
+				"title_bm": "Peratus Ditolak",
+				"desc_en": "[Float] Derived as: (votes_rejected / (ballots_issued - ballots_not_returned)) * 100",
+				"desc_bm": " [Apung] Diperolehi dengan formula: (votes_rejected / (ballots_issued - ballots_not_returned)) * 100"
+			}
+		]
+	}
 }

--- a/catalog/ge03_ballots.json
+++ b/catalog/ge03_ballots.json
@@ -1,142 +1,133 @@
 {
-    "file": {
-        "manual_trigger": 0,
-        "bucket": "elections_federal",
-        "file_name": "ge03_ballots",
-        "category": "ELECTIONS",
-        "category_en": "Elections",
-        "category_bm": "Pilihanraya",
-        "subcategory": "FEDERAL",
-        "subcategory_en": "Federal",
-        "subcategory_bm": "Persekutuan",
-        "description": {
-            "en": "Ballots for every seat contested at the pre-Independence general election held in 1955.",
-            "bm": "Perincian undi bagi setiap kerusi yang dipertandingkan di pilihanraya umum pramerdeka yang diadakan pada tahun 1955."
-        },
-        "link_parquet": "https://storage.data.gov.my/elections/federal/ge03_ballots.parquet",
-        "link_csv": "https://storage.data.gov.my/elections/federal/ge03_ballots.csv",
-        "link_preview": "https://storage.data.gov.my/elections/federal/ge03_ballots.parquet",
-        "variables": [
-            {
-                "id": 0,
-                "name": "ge03_ballots",
-                "title_en": "GE-03: Ballots",
-                "title_bm": "PRU-03: Kertas Undi",
-                "desc_en": "Ballots for every seat contested at the pre-Independence general election held on 27 July 1955.",
-                "desc_bm": "Perincian undi bagi setiap kerusi yang dipertandingkan di pilihanraya umum pramerdeka yang diadakan pada 27 Julai 1955.",
-                "catalog_data": {
-                    "catalog_filters": {
-                        "frequency": "INFREQUENT",
-                        "geographic": [
-                            "PARLIMEN",
-                            "STATE",
-                            "NATIONAL"
-                        ],
-                        "demographic": [],
-                        "start": "1969",
-                        "end": "1969",
-                        "data_source": [
-                            "SPR"
-                        ]
-                    },
-                    "metadata_neutral": {
-                        "data_as_of": "1955-08-31 23:59",
-                        "last_updated": "2023-07-18 23:59",
-                        "next_update": "-"
-                    },
-                    "metadata_lang": {
-                        "en": {
-                            "methodology": "This data is a digital representation of the physical election results tabulated and gazetted per the Electoral Regulations (Conduct of Elections). The digitalisation process was rigorously cross-checked against physical records to ensure consistency and accuracy of information.",
-                            "caveat": "As of now, this data has not been verified by SPR, and is shown here on the staging site to provide easy access for exploring and checking the data.",
-                            "publication": "-"
-                        },
-                        "bm": {
-                            "methodology": "Data ini merupakan rekod digital keputusan pilihanraya yang dikira dan diwartakan selaras dengan Peraturan-Peraturan Pilihan Raya (Penjalanan Pilihan Raya). Proses pendigitalan disemak silang dengan rekod fizikal untuk memastikan ketepatan maklumat.",
-                            "caveat": "Setakat sekarang, data ini belum disemak dan diabsahkan oleh SPR, maka hanya dipaparkan di portal UAT ini bagi tujuan memudahkan proses semakan.",
-                            "publication": "-"
-                        }
-                    },
-                    "chart": {
-                        "chart_type": "TABLE",
-                        "chart_filters": {
-                            "SLICE_BY": [],
-                            "precision": 0
-                        },
-                        "chart_variables": {
-                            "parents": [],
-                            "exclude": [],
-                            "freeze": [
-                                "state",
-                                "parlimen"
-                            ]
-                        }
-                    }
-                }
-            },
-            {
-                "id": -1,
-                "name": "state",
-                "title_en": "State",
-                "title_bm": "Negeri",
-                "desc_en": "[String] 1 of 16 states",
-                "desc_bm": "[Rentetan] 1 antara 16 negeri"
-            },
-            {
-                "id": -1,
-                "name": "parlimen",
-                "title_en": "Parliament",
-                "title_bm": "Parlimen",
-                "desc_en": "[String] Name of seat as it appeared on the ballot on voting day",
-                "desc_bm": "[Rentetan] Nama kerusi seperti mana yang tertera di kertas undi pada hari mengundi"
-            },
-            {
-                "id": -1,
-                "name": "area_name",
-                "title_en": "Area Name",
-                "title_bm": "Nama Kawasan",
-                "desc_en": "[String] Name of the area, with seat code (P.xxx) stripped out, and area name historically harmonised. For example, Kota Baharu, Kota Bahru and Kota Bharu are all harmonised to the modern Kota Bharu.",
-                "desc_bm": "[Rentetan] Nama kawasan, tanpa kod kerusi (P.xxx) dan namanya diselaraskan mengambil kira perubahan dari zaman ke zaman. Contohnya, nama Kota Baharu, Kota Bahru, dan Kota Bharu semuanya diharmonikan kepada penggunaan moden iaitu Kota Bharu."
-            },
-            {
-                "id": -1,
-                "name": "ballot_order",
-                "title_en": "Ballot Order",
-                "title_bm": "Urutan Nama",
-                "desc_en": "[Integer] Order in which the candidate appears on the ballot",
-                "desc_bm": "[Integer] Urutan nama-nama yang tertera pada kertas undi"
-            },
-            {
-                "id": -1,
-                "name": "name",
-                "title_en": "Name",
-                "title_bm": "Nama",
-                "desc_en": "[String] Name of candidate as it appeared on the ballot on voting day; this may not be the same as their real name as candidates are free to choose the name they use for campaigning and voting",
-                "desc_bm": "[Rentetan] Nama calon seperti mana yang tertera di kertas undi pada hari mengundi; ini tidak semestinya sama dengan nama sebenar mereka kerana calon adalah bebas untuk memilih nama yang digunakan bagi tujuan kempen dan undi"
-            },
-            {
-                "id": -1,
-                "name": "candidate_uid",
-                "title_en": "Unique Candidate ID",
-                "title_bm": "ID Unik Calon",
-                "desc_en": "[Integer] Unique integer identifier to track candidates across elections",
-                "desc_bm": "[Integer] Integer unik untuk menjejaki keputusan seseorang calon merentasi pilihan raya"
-            },
-            {
-                "id": -1,
-                "name": "party",
-                "title_en": "Party",
-                "title_bm": "Parti",
-                "desc_en": "[String] Party of the candidate as it appeared on the ballot on voting day; this record is not amended to reflect unofficial information on parties and coalitions. For example, if a candidate competed under the flag of Party X despite being a member of Party Y, their party is recorded as Party X.",
-                "desc_bm": "[String] Parti calon seperti yang tertera pada kertas undi pada hari mengundi; rekod ini tidak dipinda untuk menggambarkan maklumat tidak rasmi mengenai parti dan gabungan. Sebagai contoh, jika calon bertanding bawah bendera Parti X walaupun menjadi ahli Parti Y, parti mereka direkodkan sebagai Parti X."
-            },
-            {
-                "id": -1,
-                "name": "votes",
-                "title_en": "Votes",
-                "title_bm": "Undi",
-                "desc_en": "Integer] Number of votes won by the candidate",
-                "desc_bm": "[Integer] Jumlah undi yang diperolehi oleh calon"
-            }
-        ]
-    }
+	"file": {
+		"manual_trigger": 0,
+		"bucket": "elections_federal",
+		"file_name": "ge03_ballots",
+		"category": "ELECTIONS",
+		"category_en": "Elections",
+		"category_bm": "Pilihanraya",
+		"subcategory": "FEDERAL",
+		"subcategory_en": "Federal",
+		"subcategory_bm": "Persekutuan",
+		"description": {
+			"en": "Ballots for every seat contested at the pre-Independence general election held in 1955.",
+			"bm": "Perincian undi bagi setiap kerusi yang dipertandingkan di pilihanraya umum pramerdeka yang diadakan pada tahun 1955."
+		},
+		"link_parquet": "https://storage.data.gov.my/elections/federal/ge03_ballots.parquet",
+		"link_csv": "https://storage.data.gov.my/elections/federal/ge03_ballots.csv",
+		"link_preview": "https://storage.data.gov.my/elections/federal/ge03_ballots.parquet",
+		"variables": [
+			{
+				"id": 0,
+				"name": "ge03_ballots",
+				"title_en": "GE-03: Ballots",
+				"title_bm": "PRU-03: Kertas Undi",
+				"desc_en": "Ballots for every seat contested at the pre-Independence general election held on 27 July 1955.",
+				"desc_bm": "Perincian undi bagi setiap kerusi yang dipertandingkan di pilihanraya umum pramerdeka yang diadakan pada 27 Julai 1955.",
+				"catalog_data": {
+					"catalog_filters": {
+						"frequency": "INFREQUENT",
+						"geography": ["PARLIMEN", "STATE", "NATIONAL"],
+						"demographic": [],
+						"start": "1969",
+						"end": "1969",
+						"data_source": ["SPR"]
+					},
+					"metadata_neutral": {
+						"data_as_of": "1955-08-31 23:59",
+						"last_updated": "2023-07-18 23:59",
+						"next_update": "-"
+					},
+					"metadata_lang": {
+						"en": {
+							"methodology": "This data is a digital representation of the physical election results tabulated and gazetted per the Electoral Regulations (Conduct of Elections). The digitalisation process was rigorously cross-checked against physical records to ensure consistency and accuracy of information.",
+							"caveat": "As of now, this data has not been verified by SPR, and is shown here on the staging site to provide easy access for exploring and checking the data.",
+							"publication": "-"
+						},
+						"bm": {
+							"methodology": "Data ini merupakan rekod digital keputusan pilihanraya yang dikira dan diwartakan selaras dengan Peraturan-Peraturan Pilihan Raya (Penjalanan Pilihan Raya). Proses pendigitalan disemak silang dengan rekod fizikal untuk memastikan ketepatan maklumat.",
+							"caveat": "Setakat sekarang, data ini belum disemak dan diabsahkan oleh SPR, maka hanya dipaparkan di portal UAT ini bagi tujuan memudahkan proses semakan.",
+							"publication": "-"
+						}
+					},
+					"chart": {
+						"chart_type": "TABLE",
+						"chart_filters": {
+							"SLICE_BY": [],
+							"precision": 0
+						},
+						"chart_variables": {
+							"parents": [],
+							"exclude": [],
+							"freeze": ["state", "parlimen"]
+						}
+					}
+				}
+			},
+			{
+				"id": -1,
+				"name": "state",
+				"title_en": "State",
+				"title_bm": "Negeri",
+				"desc_en": "[String] 1 of 16 states",
+				"desc_bm": "[Rentetan] 1 antara 16 negeri"
+			},
+			{
+				"id": -1,
+				"name": "parlimen",
+				"title_en": "Parliament",
+				"title_bm": "Parlimen",
+				"desc_en": "[String] Name of seat as it appeared on the ballot on voting day",
+				"desc_bm": "[Rentetan] Nama kerusi seperti mana yang tertera di kertas undi pada hari mengundi"
+			},
+			{
+				"id": -1,
+				"name": "area_name",
+				"title_en": "Area Name",
+				"title_bm": "Nama Kawasan",
+				"desc_en": "[String] Name of the area, with seat code (P.xxx) stripped out, and area name historically harmonised. For example, Kota Baharu, Kota Bahru and Kota Bharu are all harmonised to the modern Kota Bharu.",
+				"desc_bm": "[Rentetan] Nama kawasan, tanpa kod kerusi (P.xxx) dan namanya diselaraskan mengambil kira perubahan dari zaman ke zaman. Contohnya, nama Kota Baharu, Kota Bahru, dan Kota Bharu semuanya diharmonikan kepada penggunaan moden iaitu Kota Bharu."
+			},
+			{
+				"id": -1,
+				"name": "ballot_order",
+				"title_en": "Ballot Order",
+				"title_bm": "Urutan Nama",
+				"desc_en": "[Integer] Order in which the candidate appears on the ballot",
+				"desc_bm": "[Integer] Urutan nama-nama yang tertera pada kertas undi"
+			},
+			{
+				"id": -1,
+				"name": "name",
+				"title_en": "Name",
+				"title_bm": "Nama",
+				"desc_en": "[String] Name of candidate as it appeared on the ballot on voting day; this may not be the same as their real name as candidates are free to choose the name they use for campaigning and voting",
+				"desc_bm": "[Rentetan] Nama calon seperti mana yang tertera di kertas undi pada hari mengundi; ini tidak semestinya sama dengan nama sebenar mereka kerana calon adalah bebas untuk memilih nama yang digunakan bagi tujuan kempen dan undi"
+			},
+			{
+				"id": -1,
+				"name": "candidate_uid",
+				"title_en": "Unique Candidate ID",
+				"title_bm": "ID Unik Calon",
+				"desc_en": "[Integer] Unique integer identifier to track candidates across elections",
+				"desc_bm": "[Integer] Integer unik untuk menjejaki keputusan seseorang calon merentasi pilihan raya"
+			},
+			{
+				"id": -1,
+				"name": "party",
+				"title_en": "Party",
+				"title_bm": "Parti",
+				"desc_en": "[String] Party of the candidate as it appeared on the ballot on voting day; this record is not amended to reflect unofficial information on parties and coalitions. For example, if a candidate competed under the flag of Party X despite being a member of Party Y, their party is recorded as Party X.",
+				"desc_bm": "[String] Parti calon seperti yang tertera pada kertas undi pada hari mengundi; rekod ini tidak dipinda untuk menggambarkan maklumat tidak rasmi mengenai parti dan gabungan. Sebagai contoh, jika calon bertanding bawah bendera Parti X walaupun menjadi ahli Parti Y, parti mereka direkodkan sebagai Parti X."
+			},
+			{
+				"id": -1,
+				"name": "votes",
+				"title_en": "Votes",
+				"title_bm": "Undi",
+				"desc_en": "Integer] Number of votes won by the candidate",
+				"desc_bm": "[Integer] Jumlah undi yang diperolehi oleh calon"
+			}
+		]
+	}
 }

--- a/catalog/ge03_ballots.json
+++ b/catalog/ge03_ballots.json
@@ -28,7 +28,7 @@
 					"catalog_filters": {
 						"frequency": "INFREQUENT",
 						"geography": ["PARLIMEN", "STATE", "NATIONAL"],
-						"demographic": [],
+						"demography": [],
 						"start": "1969",
 						"end": "1969",
 						"data_source": ["SPR"]

--- a/catalog/ge03_summary.json
+++ b/catalog/ge03_summary.json
@@ -28,7 +28,7 @@
 					"catalog_filters": {
 						"frequency": "INFREQUENT",
 						"geography": ["PARLIMEN", "STATE", "NATIONAL"],
-						"demographic": [],
+						"demography": [],
 						"start": "1969",
 						"end": "1969",
 						"data_source": ["SPR"]

--- a/catalog/ge03_summary.json
+++ b/catalog/ge03_summary.json
@@ -1,150 +1,141 @@
 {
-    "file": {
-        "manual_trigger": 0,
-        "bucket": "elections_federal",
-        "file_name": "ge03_summary",
-        "category": "ELECTIONS",
-        "category_en": "Elections",
-        "category_bm": "Pilihanraya",
-        "subcategory": "FEDERAL",
-        "subcategory_en": "Federal",
-        "subcategory_bm": "Persekutuan",
-        "description": {
-            "en": "Analytical summary of the pre-Independence general election held in 1955.",
-            "bm": "Ringkasan analitik bagi pilihanraya umum pramerdeka yang diadakan pada tahun 1955."
-        },
-        "link_parquet": "https://storage.data.gov.my/elections/federal/ge03_summary.parquet",
-        "link_csv": "https://storage.data.gov.my/elections/federal/ge03_summary.csv",
-        "link_preview": "https://storage.data.gov.my/elections/federal/ge03_summary.parquet",
-        "variables": [
-            {
-                "id": 0,
-                "name": "ge03_summary",
-                "title_en": "GE-03: Summary",
-                "title_bm": "PRU-03: Rumusan",
-                "desc_en": "Analytical summary of the pre-Independence general election held on 27 July 1955.",
-                "desc_bm": "Ringkasan analitik bagi pilihanraya umum pramerdeka yang diadakan pada 27 Julai 1955.",
-                "catalog_data": {
-                    "catalog_filters": {
-                        "frequency": "INFREQUENT",
-                        "geographic": [
-                            "PARLIMEN",
-                            "STATE",
-                            "NATIONAL"
-                        ],
-                        "demographic": [],
-                        "start": "1969",
-                        "end": "1969",
-                        "data_source": [
-                            "SPR"
-                        ]
-                    },
-                    "metadata_neutral": {
-                        "data_as_of": "1955-08-31 23:59",
-                        "last_updated": "2023-07-18 23:59",
-                        "next_update": "-"
-                    },
-                    "metadata_lang": {
-                        "en": {
-                            "methodology": "This data is a digital representation of the physical election results tabulated and gazetted per the Electoral Regulations (Conduct of Elections). The digitalisation process was rigorously cross-checked against physical records to ensure consistency and accuracy of information.",
-                            "caveat": "As of now, this data has not been verified by SPR, and is shown here on the staging site to provide easy access for exploring and checking the data.",
-                            "publication": "-"
-                        },
-                        "bm": {
-                            "methodology": "Data ini merupakan rekod digital keputusan pilihanraya yang dikira dan diwartakan selaras dengan Peraturan-Peraturan Pilihan Raya (Penjalanan Pilihan Raya). Proses pendigitalan disemak silang dengan rekod fizikal untuk memastikan ketepatan maklumat.",
-                            "caveat": "Setakat sekarang, data ini belum disemak dan diabsahkan oleh SPR, maka hanya dipaparkan di portal UAT ini bagi tujuan memudahkan proses semakan.",
-                            "publication": "-"
-                        }
-                    },
-                    "chart": {
-                        "chart_type": "TABLE",
-                        "chart_filters": {
-                            "SLICE_BY": [],
-                            "precision": 0
-                        },
-                        "chart_variables": {
-                            "parents": [],
-                            "exclude": [],
-                            "freeze": [
-                                "state",
-                                "parlimen"
-                            ]
-                        }
-                    }
-                }
-            },
-            {
-                "id": -1,
-                "name": "state",
-                "title_en": "State",
-                "title_bm": "Negeri",
-                "desc_en": "[String] 1 of 16 states",
-                "desc_bm": "[Rentetan] 1 antara 16 negeri"
-            },
-            {
-                "id": -1,
-                "name": "parlimen",
-                "title_en": "Parliament",
-                "title_bm": "Parlimen",
-                "desc_en": "[String] Name of seat as it appeared on the ballot on voting day",
-                "desc_bm": "[Rentetan] Nama kerusi seperti mana yang tertera di kertas undi pada hari mengundi"
-            },
-            {
-                "id": -1,
-                "name": "area_name",
-                "title_en": "Area Name",
-                "title_bm": "Nama Kawasan",
-                "desc_en": "[String] Name of the area, with seat code (P.xxx) stripped out, and area name historically harmonised. For example, Kota Baharu, Kota Bahru and Kota Bharu are all harmonised to the modern Kota Bharu.",
-                "desc_bm": "[Rentetan] Nama kawasan, tanpa kod kerusi (P.xxx) dan namanya diselaraskan mengambil kira perubahan dari zaman ke zaman. Contohnya, nama Kota Baharu, Kota Bahru, dan Kota Bharu semuanya diharmonikan kepada penggunaan moden iaitu Kota Bharu."
-            },
-            {
-                "id": -1,
-                "name": "voters_total",
-                "title_en": "Total Voters",
-                "title_bm": "Jumlah Pengundi",
-                "desc_en": "[Integer] Number of voters registered to vote in that seat at that election",
-                "desc_bm": "[Integer] Jumlah pengundi yang didaftarkan untuk mengundi di kerusi tersebut semasa PRU-00"
-            },
-            {
-                "id": -1,
-                "name": "ballots_issued",
-                "title_en": "Ballots Issued",
-                "title_bm": "Undi Dikeluarkan",
-                "desc_en": "[Integer] Number of ballots issued, including postal ballots, but not inclduing ballots accidentally damaged and immediately replace during the voting procedure",
-                "desc_bm": "[Integer] Jumlah kertas undi yang dikeluarkan, termasuk kertas undi pos, tetapi tidak termasuk kertas undi yang rosak dan terus digantikan semasa urusan mengundi dijalankan"
-            },
-            {
-                "id": -1,
-                "name": "ballots_not_returned",
-                "title_en": "Ballots Not Returned",
-                "title_bm": "Undi Tidak Dikembalikan",
-                "desc_en": "[Integer] Number of ballots issued but not returned for counting, including postal ballots not returned to the counting centre in time, but excluding spoilt ballots (e.g. torn or stained) which were replaced and therefore not counted as ballots issued",
-                "desc_bm": "[Integer] Jumlah kertas undi yang dikeluarkan tetapi tidak dikembalikan untuk pengiraan undi, termasuk kertas undi pos yang tidak dikembalikan ke pusat kiraan undi, tetapi tidak termasuk kertas undi rosak (contohnya terkoyak atau ternoda) yang telah digantikan maka tidak dikira sebagai kertas undi yang dikeluarkan"
-            },
-            {
-                "id": -1,
-                "name": "votes_rejected",
-                "title_en": "Votes Rejected",
-                "title_bm": "Undi Ditolak",
-                "desc_en": "[Integer] Number of ballots returned but declared invalid during counting because the candidate could not be determined",
-                "desc_bm": "[Integer] Jumlah kertas undi yang telah dikembalikan tetapi ditolak semasa proses kiraan undi kerana calon yang diundi tidak dapat ditentukan"
-            },
-            {
-                "id": -1,
-                "name": "voter_turnout",
-                "title_en": "Voter Turnout",
-                "title_bm": "Peratus Keluar",
-                "desc_en": "[Float] Derived as: (ballots_issued / voters_total) * 100",
-                "desc_bm": " [Apung] Diperolehi dengan formula: (ballots_issued / voters_total) * 100"
-            },
-            {
-                "id": -1,
-                "name": "votes_rejected_perc",
-                "title_en": "Percentage Rejected",
-                "title_bm": "Peratus Ditolak",
-                "desc_en": "[Float] Derived as: (votes_rejected / (ballots_issued - ballots_not_returned)) * 100",
-                "desc_bm": " [Apung] Diperolehi dengan formula: (votes_rejected / (ballots_issued - ballots_not_returned)) * 100"
-            }
-        ]
-    }
+	"file": {
+		"manual_trigger": 0,
+		"bucket": "elections_federal",
+		"file_name": "ge03_summary",
+		"category": "ELECTIONS",
+		"category_en": "Elections",
+		"category_bm": "Pilihanraya",
+		"subcategory": "FEDERAL",
+		"subcategory_en": "Federal",
+		"subcategory_bm": "Persekutuan",
+		"description": {
+			"en": "Analytical summary of the pre-Independence general election held in 1955.",
+			"bm": "Ringkasan analitik bagi pilihanraya umum pramerdeka yang diadakan pada tahun 1955."
+		},
+		"link_parquet": "https://storage.data.gov.my/elections/federal/ge03_summary.parquet",
+		"link_csv": "https://storage.data.gov.my/elections/federal/ge03_summary.csv",
+		"link_preview": "https://storage.data.gov.my/elections/federal/ge03_summary.parquet",
+		"variables": [
+			{
+				"id": 0,
+				"name": "ge03_summary",
+				"title_en": "GE-03: Summary",
+				"title_bm": "PRU-03: Rumusan",
+				"desc_en": "Analytical summary of the pre-Independence general election held on 27 July 1955.",
+				"desc_bm": "Ringkasan analitik bagi pilihanraya umum pramerdeka yang diadakan pada 27 Julai 1955.",
+				"catalog_data": {
+					"catalog_filters": {
+						"frequency": "INFREQUENT",
+						"geography": ["PARLIMEN", "STATE", "NATIONAL"],
+						"demographic": [],
+						"start": "1969",
+						"end": "1969",
+						"data_source": ["SPR"]
+					},
+					"metadata_neutral": {
+						"data_as_of": "1955-08-31 23:59",
+						"last_updated": "2023-07-18 23:59",
+						"next_update": "-"
+					},
+					"metadata_lang": {
+						"en": {
+							"methodology": "This data is a digital representation of the physical election results tabulated and gazetted per the Electoral Regulations (Conduct of Elections). The digitalisation process was rigorously cross-checked against physical records to ensure consistency and accuracy of information.",
+							"caveat": "As of now, this data has not been verified by SPR, and is shown here on the staging site to provide easy access for exploring and checking the data.",
+							"publication": "-"
+						},
+						"bm": {
+							"methodology": "Data ini merupakan rekod digital keputusan pilihanraya yang dikira dan diwartakan selaras dengan Peraturan-Peraturan Pilihan Raya (Penjalanan Pilihan Raya). Proses pendigitalan disemak silang dengan rekod fizikal untuk memastikan ketepatan maklumat.",
+							"caveat": "Setakat sekarang, data ini belum disemak dan diabsahkan oleh SPR, maka hanya dipaparkan di portal UAT ini bagi tujuan memudahkan proses semakan.",
+							"publication": "-"
+						}
+					},
+					"chart": {
+						"chart_type": "TABLE",
+						"chart_filters": {
+							"SLICE_BY": [],
+							"precision": 0
+						},
+						"chart_variables": {
+							"parents": [],
+							"exclude": [],
+							"freeze": ["state", "parlimen"]
+						}
+					}
+				}
+			},
+			{
+				"id": -1,
+				"name": "state",
+				"title_en": "State",
+				"title_bm": "Negeri",
+				"desc_en": "[String] 1 of 16 states",
+				"desc_bm": "[Rentetan] 1 antara 16 negeri"
+			},
+			{
+				"id": -1,
+				"name": "parlimen",
+				"title_en": "Parliament",
+				"title_bm": "Parlimen",
+				"desc_en": "[String] Name of seat as it appeared on the ballot on voting day",
+				"desc_bm": "[Rentetan] Nama kerusi seperti mana yang tertera di kertas undi pada hari mengundi"
+			},
+			{
+				"id": -1,
+				"name": "area_name",
+				"title_en": "Area Name",
+				"title_bm": "Nama Kawasan",
+				"desc_en": "[String] Name of the area, with seat code (P.xxx) stripped out, and area name historically harmonised. For example, Kota Baharu, Kota Bahru and Kota Bharu are all harmonised to the modern Kota Bharu.",
+				"desc_bm": "[Rentetan] Nama kawasan, tanpa kod kerusi (P.xxx) dan namanya diselaraskan mengambil kira perubahan dari zaman ke zaman. Contohnya, nama Kota Baharu, Kota Bahru, dan Kota Bharu semuanya diharmonikan kepada penggunaan moden iaitu Kota Bharu."
+			},
+			{
+				"id": -1,
+				"name": "voters_total",
+				"title_en": "Total Voters",
+				"title_bm": "Jumlah Pengundi",
+				"desc_en": "[Integer] Number of voters registered to vote in that seat at that election",
+				"desc_bm": "[Integer] Jumlah pengundi yang didaftarkan untuk mengundi di kerusi tersebut semasa PRU-00"
+			},
+			{
+				"id": -1,
+				"name": "ballots_issued",
+				"title_en": "Ballots Issued",
+				"title_bm": "Undi Dikeluarkan",
+				"desc_en": "[Integer] Number of ballots issued, including postal ballots, but not inclduing ballots accidentally damaged and immediately replace during the voting procedure",
+				"desc_bm": "[Integer] Jumlah kertas undi yang dikeluarkan, termasuk kertas undi pos, tetapi tidak termasuk kertas undi yang rosak dan terus digantikan semasa urusan mengundi dijalankan"
+			},
+			{
+				"id": -1,
+				"name": "ballots_not_returned",
+				"title_en": "Ballots Not Returned",
+				"title_bm": "Undi Tidak Dikembalikan",
+				"desc_en": "[Integer] Number of ballots issued but not returned for counting, including postal ballots not returned to the counting centre in time, but excluding spoilt ballots (e.g. torn or stained) which were replaced and therefore not counted as ballots issued",
+				"desc_bm": "[Integer] Jumlah kertas undi yang dikeluarkan tetapi tidak dikembalikan untuk pengiraan undi, termasuk kertas undi pos yang tidak dikembalikan ke pusat kiraan undi, tetapi tidak termasuk kertas undi rosak (contohnya terkoyak atau ternoda) yang telah digantikan maka tidak dikira sebagai kertas undi yang dikeluarkan"
+			},
+			{
+				"id": -1,
+				"name": "votes_rejected",
+				"title_en": "Votes Rejected",
+				"title_bm": "Undi Ditolak",
+				"desc_en": "[Integer] Number of ballots returned but declared invalid during counting because the candidate could not be determined",
+				"desc_bm": "[Integer] Jumlah kertas undi yang telah dikembalikan tetapi ditolak semasa proses kiraan undi kerana calon yang diundi tidak dapat ditentukan"
+			},
+			{
+				"id": -1,
+				"name": "voter_turnout",
+				"title_en": "Voter Turnout",
+				"title_bm": "Peratus Keluar",
+				"desc_en": "[Float] Derived as: (ballots_issued / voters_total) * 100",
+				"desc_bm": " [Apung] Diperolehi dengan formula: (ballots_issued / voters_total) * 100"
+			},
+			{
+				"id": -1,
+				"name": "votes_rejected_perc",
+				"title_en": "Percentage Rejected",
+				"title_bm": "Peratus Ditolak",
+				"desc_en": "[Float] Derived as: (votes_rejected / (ballots_issued - ballots_not_returned)) * 100",
+				"desc_bm": " [Apung] Diperolehi dengan formula: (votes_rejected / (ballots_issued - ballots_not_returned)) * 100"
+			}
+		]
+	}
 }

--- a/catalog/ge04_ballots.json
+++ b/catalog/ge04_ballots.json
@@ -1,142 +1,133 @@
 {
-    "file": {
-        "manual_trigger": 0,
-        "bucket": "elections_federal",
-        "file_name": "ge04_ballots",
-        "category": "ELECTIONS",
-        "category_en": "Elections",
-        "category_bm": "Pilihanraya",
-        "subcategory": "FEDERAL",
-        "subcategory_en": "Federal",
-        "subcategory_bm": "Persekutuan",
-        "description": {
-            "en": "Ballots for every seat contested at the pre-Independence general election held in 1955.",
-            "bm": "Perincian undi bagi setiap kerusi yang dipertandingkan di pilihanraya umum pramerdeka yang diadakan pada tahun 1955."
-        },
-        "link_parquet": "https://storage.data.gov.my/elections/federal/ge04_ballots.parquet",
-        "link_csv": "https://storage.data.gov.my/elections/federal/ge04_ballots.csv",
-        "link_preview": "https://storage.data.gov.my/elections/federal/ge04_ballots.parquet",
-        "variables": [
-            {
-                "id": 0,
-                "name": "ge04_ballots",
-                "title_en": "GE-04: Ballots",
-                "title_bm": "PRU-04: Kertas Undi",
-                "desc_en": "Ballots for every seat contested at the pre-Independence general election held on 27 July 1955.",
-                "desc_bm": "Perincian undi bagi setiap kerusi yang dipertandingkan di pilihanraya umum pramerdeka yang diadakan pada 27 Julai 1955.",
-                "catalog_data": {
-                    "catalog_filters": {
-                        "frequency": "INFREQUENT",
-                        "geographic": [
-                            "PARLIMEN",
-                            "STATE",
-                            "NATIONAL"
-                        ],
-                        "demographic": [],
-                        "start": "1974",
-                        "end": "1974",
-                        "data_source": [
-                            "SPR"
-                        ]
-                    },
-                    "metadata_neutral": {
-                        "data_as_of": "1955-08-31 23:59",
-                        "last_updated": "2023-07-18 23:59",
-                        "next_update": "-"
-                    },
-                    "metadata_lang": {
-                        "en": {
-                            "methodology": "This data is a digital representation of the physical election results tabulated and gazetted per the Electoral Regulations (Conduct of Elections). The digitalisation process was rigorously cross-checked against physical records to ensure consistency and accuracy of information.",
-                            "caveat": "As of now, this data has not been verified by SPR, and is shown here on the staging site to provide easy access for exploring and checking the data.",
-                            "publication": "-"
-                        },
-                        "bm": {
-                            "methodology": "Data ini merupakan rekod digital keputusan pilihanraya yang dikira dan diwartakan selaras dengan Peraturan-Peraturan Pilihan Raya (Penjalanan Pilihan Raya). Proses pendigitalan disemak silang dengan rekod fizikal untuk memastikan ketepatan maklumat.",
-                            "caveat": "Setakat sekarang, data ini belum disemak dan diabsahkan oleh SPR, maka hanya dipaparkan di portal UAT ini bagi tujuan memudahkan proses semakan.",
-                            "publication": "-"
-                        }
-                    },
-                    "chart": {
-                        "chart_type": "TABLE",
-                        "chart_filters": {
-                            "SLICE_BY": [],
-                            "precision": 0
-                        },
-                        "chart_variables": {
-                            "parents": [],
-                            "exclude": [],
-                            "freeze": [
-                                "state",
-                                "parlimen"
-                            ]
-                        }
-                    }
-                }
-            },
-            {
-                "id": -1,
-                "name": "state",
-                "title_en": "State",
-                "title_bm": "Negeri",
-                "desc_en": "[String] 1 of 16 states",
-                "desc_bm": "[Rentetan] 1 antara 16 negeri"
-            },
-            {
-                "id": -1,
-                "name": "parlimen",
-                "title_en": "Parliament",
-                "title_bm": "Parlimen",
-                "desc_en": "[String] Name of seat as it appeared on the ballot on voting day",
-                "desc_bm": "[Rentetan] Nama kerusi seperti mana yang tertera di kertas undi pada hari mengundi"
-            },
-            {
-                "id": -1,
-                "name": "area_name",
-                "title_en": "Area Name",
-                "title_bm": "Nama Kawasan",
-                "desc_en": "[String] Name of the area, with seat code (P.xxx) stripped out, and area name historically harmonised. For example, Kota Baharu, Kota Bahru and Kota Bharu are all harmonised to the modern Kota Bharu.",
-                "desc_bm": "[Rentetan] Nama kawasan, tanpa kod kerusi (P.xxx) dan namanya diselaraskan mengambil kira perubahan dari zaman ke zaman. Contohnya, nama Kota Baharu, Kota Bahru, dan Kota Bharu semuanya diharmonikan kepada penggunaan moden iaitu Kota Bharu."
-            },
-            {
-                "id": -1,
-                "name": "ballot_order",
-                "title_en": "Ballot Order",
-                "title_bm": "Urutan Nama",
-                "desc_en": "[Integer] Order in which the candidate appears on the ballot",
-                "desc_bm": "[Integer] Urutan nama-nama yang tertera pada kertas undi"
-            },
-            {
-                "id": -1,
-                "name": "name",
-                "title_en": "Name",
-                "title_bm": "Nama",
-                "desc_en": "[String] Name of candidate as it appeared on the ballot on voting day; this may not be the same as their real name as candidates are free to choose the name they use for campaigning and voting",
-                "desc_bm": "[Rentetan] Nama calon seperti mana yang tertera di kertas undi pada hari mengundi; ini tidak semestinya sama dengan nama sebenar mereka kerana calon adalah bebas untuk memilih nama yang digunakan bagi tujuan kempen dan undi"
-            },
-            {
-                "id": -1,
-                "name": "candidate_uid",
-                "title_en": "Unique Candidate ID",
-                "title_bm": "ID Unik Calon",
-                "desc_en": "[Integer] Unique integer identifier to track candidates across elections",
-                "desc_bm": "[Integer] Integer unik untuk menjejaki keputusan seseorang calon merentasi pilihan raya"
-            },
-            {
-                "id": -1,
-                "name": "party",
-                "title_en": "Party",
-                "title_bm": "Parti",
-                "desc_en": "[String] Party of the candidate as it appeared on the ballot on voting day; this record is not amended to reflect unofficial information on parties and coalitions. For example, if a candidate competed under the flag of Party X despite being a member of Party Y, their party is recorded as Party X.",
-                "desc_bm": "[String] Parti calon seperti yang tertera pada kertas undi pada hari mengundi; rekod ini tidak dipinda untuk menggambarkan maklumat tidak rasmi mengenai parti dan gabungan. Sebagai contoh, jika calon bertanding bawah bendera Parti X walaupun menjadi ahli Parti Y, parti mereka direkodkan sebagai Parti X."
-            },
-            {
-                "id": -1,
-                "name": "votes",
-                "title_en": "Votes",
-                "title_bm": "Undi",
-                "desc_en": "Integer] Number of votes won by the candidate",
-                "desc_bm": "[Integer] Jumlah undi yang diperolehi oleh calon"
-            }
-        ]
-    }
+	"file": {
+		"manual_trigger": 0,
+		"bucket": "elections_federal",
+		"file_name": "ge04_ballots",
+		"category": "ELECTIONS",
+		"category_en": "Elections",
+		"category_bm": "Pilihanraya",
+		"subcategory": "FEDERAL",
+		"subcategory_en": "Federal",
+		"subcategory_bm": "Persekutuan",
+		"description": {
+			"en": "Ballots for every seat contested at the pre-Independence general election held in 1955.",
+			"bm": "Perincian undi bagi setiap kerusi yang dipertandingkan di pilihanraya umum pramerdeka yang diadakan pada tahun 1955."
+		},
+		"link_parquet": "https://storage.data.gov.my/elections/federal/ge04_ballots.parquet",
+		"link_csv": "https://storage.data.gov.my/elections/federal/ge04_ballots.csv",
+		"link_preview": "https://storage.data.gov.my/elections/federal/ge04_ballots.parquet",
+		"variables": [
+			{
+				"id": 0,
+				"name": "ge04_ballots",
+				"title_en": "GE-04: Ballots",
+				"title_bm": "PRU-04: Kertas Undi",
+				"desc_en": "Ballots for every seat contested at the pre-Independence general election held on 27 July 1955.",
+				"desc_bm": "Perincian undi bagi setiap kerusi yang dipertandingkan di pilihanraya umum pramerdeka yang diadakan pada 27 Julai 1955.",
+				"catalog_data": {
+					"catalog_filters": {
+						"frequency": "INFREQUENT",
+						"geography": ["PARLIMEN", "STATE", "NATIONAL"],
+						"demographic": [],
+						"start": "1974",
+						"end": "1974",
+						"data_source": ["SPR"]
+					},
+					"metadata_neutral": {
+						"data_as_of": "1955-08-31 23:59",
+						"last_updated": "2023-07-18 23:59",
+						"next_update": "-"
+					},
+					"metadata_lang": {
+						"en": {
+							"methodology": "This data is a digital representation of the physical election results tabulated and gazetted per the Electoral Regulations (Conduct of Elections). The digitalisation process was rigorously cross-checked against physical records to ensure consistency and accuracy of information.",
+							"caveat": "As of now, this data has not been verified by SPR, and is shown here on the staging site to provide easy access for exploring and checking the data.",
+							"publication": "-"
+						},
+						"bm": {
+							"methodology": "Data ini merupakan rekod digital keputusan pilihanraya yang dikira dan diwartakan selaras dengan Peraturan-Peraturan Pilihan Raya (Penjalanan Pilihan Raya). Proses pendigitalan disemak silang dengan rekod fizikal untuk memastikan ketepatan maklumat.",
+							"caveat": "Setakat sekarang, data ini belum disemak dan diabsahkan oleh SPR, maka hanya dipaparkan di portal UAT ini bagi tujuan memudahkan proses semakan.",
+							"publication": "-"
+						}
+					},
+					"chart": {
+						"chart_type": "TABLE",
+						"chart_filters": {
+							"SLICE_BY": [],
+							"precision": 0
+						},
+						"chart_variables": {
+							"parents": [],
+							"exclude": [],
+							"freeze": ["state", "parlimen"]
+						}
+					}
+				}
+			},
+			{
+				"id": -1,
+				"name": "state",
+				"title_en": "State",
+				"title_bm": "Negeri",
+				"desc_en": "[String] 1 of 16 states",
+				"desc_bm": "[Rentetan] 1 antara 16 negeri"
+			},
+			{
+				"id": -1,
+				"name": "parlimen",
+				"title_en": "Parliament",
+				"title_bm": "Parlimen",
+				"desc_en": "[String] Name of seat as it appeared on the ballot on voting day",
+				"desc_bm": "[Rentetan] Nama kerusi seperti mana yang tertera di kertas undi pada hari mengundi"
+			},
+			{
+				"id": -1,
+				"name": "area_name",
+				"title_en": "Area Name",
+				"title_bm": "Nama Kawasan",
+				"desc_en": "[String] Name of the area, with seat code (P.xxx) stripped out, and area name historically harmonised. For example, Kota Baharu, Kota Bahru and Kota Bharu are all harmonised to the modern Kota Bharu.",
+				"desc_bm": "[Rentetan] Nama kawasan, tanpa kod kerusi (P.xxx) dan namanya diselaraskan mengambil kira perubahan dari zaman ke zaman. Contohnya, nama Kota Baharu, Kota Bahru, dan Kota Bharu semuanya diharmonikan kepada penggunaan moden iaitu Kota Bharu."
+			},
+			{
+				"id": -1,
+				"name": "ballot_order",
+				"title_en": "Ballot Order",
+				"title_bm": "Urutan Nama",
+				"desc_en": "[Integer] Order in which the candidate appears on the ballot",
+				"desc_bm": "[Integer] Urutan nama-nama yang tertera pada kertas undi"
+			},
+			{
+				"id": -1,
+				"name": "name",
+				"title_en": "Name",
+				"title_bm": "Nama",
+				"desc_en": "[String] Name of candidate as it appeared on the ballot on voting day; this may not be the same as their real name as candidates are free to choose the name they use for campaigning and voting",
+				"desc_bm": "[Rentetan] Nama calon seperti mana yang tertera di kertas undi pada hari mengundi; ini tidak semestinya sama dengan nama sebenar mereka kerana calon adalah bebas untuk memilih nama yang digunakan bagi tujuan kempen dan undi"
+			},
+			{
+				"id": -1,
+				"name": "candidate_uid",
+				"title_en": "Unique Candidate ID",
+				"title_bm": "ID Unik Calon",
+				"desc_en": "[Integer] Unique integer identifier to track candidates across elections",
+				"desc_bm": "[Integer] Integer unik untuk menjejaki keputusan seseorang calon merentasi pilihan raya"
+			},
+			{
+				"id": -1,
+				"name": "party",
+				"title_en": "Party",
+				"title_bm": "Parti",
+				"desc_en": "[String] Party of the candidate as it appeared on the ballot on voting day; this record is not amended to reflect unofficial information on parties and coalitions. For example, if a candidate competed under the flag of Party X despite being a member of Party Y, their party is recorded as Party X.",
+				"desc_bm": "[String] Parti calon seperti yang tertera pada kertas undi pada hari mengundi; rekod ini tidak dipinda untuk menggambarkan maklumat tidak rasmi mengenai parti dan gabungan. Sebagai contoh, jika calon bertanding bawah bendera Parti X walaupun menjadi ahli Parti Y, parti mereka direkodkan sebagai Parti X."
+			},
+			{
+				"id": -1,
+				"name": "votes",
+				"title_en": "Votes",
+				"title_bm": "Undi",
+				"desc_en": "Integer] Number of votes won by the candidate",
+				"desc_bm": "[Integer] Jumlah undi yang diperolehi oleh calon"
+			}
+		]
+	}
 }

--- a/catalog/ge04_ballots.json
+++ b/catalog/ge04_ballots.json
@@ -28,7 +28,7 @@
 					"catalog_filters": {
 						"frequency": "INFREQUENT",
 						"geography": ["PARLIMEN", "STATE", "NATIONAL"],
-						"demographic": [],
+						"demography": [],
 						"start": "1974",
 						"end": "1974",
 						"data_source": ["SPR"]

--- a/catalog/ge04_summary.json
+++ b/catalog/ge04_summary.json
@@ -1,150 +1,141 @@
 {
-    "file": {
-        "manual_trigger": 0,
-        "bucket": "elections_federal",
-        "file_name": "ge04_summary",
-        "category": "ELECTIONS",
-        "category_en": "Elections",
-        "category_bm": "Pilihanraya",
-        "subcategory": "FEDERAL",
-        "subcategory_en": "Federal",
-        "subcategory_bm": "Persekutuan",
-        "description": {
-            "en": "Analytical summary of the pre-Independence general election held in 1955.",
-            "bm": "Ringkasan analitik bagi pilihanraya umum pramerdeka yang diadakan pada tahun 1955."
-        },
-        "link_parquet": "https://storage.data.gov.my/elections/federal/ge04_summary.parquet",
-        "link_csv": "https://storage.data.gov.my/elections/federal/ge04_summary.csv",
-        "link_preview": "https://storage.data.gov.my/elections/federal/ge04_summary.parquet",
-        "variables": [
-            {
-                "id": 0,
-                "name": "ge04_summary",
-                "title_en": "GE-04: Summary",
-                "title_bm": "PRU-04: Rumusan",
-                "desc_en": "Analytical summary of the pre-Independence general election held on 27 July 1955.",
-                "desc_bm": "Ringkasan analitik bagi pilihanraya umum pramerdeka yang diadakan pada 27 Julai 1955.",
-                "catalog_data": {
-                    "catalog_filters": {
-                        "frequency": "INFREQUENT",
-                        "geographic": [
-                            "PARLIMEN",
-                            "STATE",
-                            "NATIONAL"
-                        ],
-                        "demographic": [],
-                        "start": "1974",
-                        "end": "1974",
-                        "data_source": [
-                            "SPR"
-                        ]
-                    },
-                    "metadata_neutral": {
-                        "data_as_of": "1955-08-31 23:59",
-                        "last_updated": "2023-07-18 23:59",
-                        "next_update": "-"
-                    },
-                    "metadata_lang": {
-                        "en": {
-                            "methodology": "This data is a digital representation of the physical election results tabulated and gazetted per the Electoral Regulations (Conduct of Elections). The digitalisation process was rigorously cross-checked against physical records to ensure consistency and accuracy of information.",
-                            "caveat": "As of now, this data has not been verified by SPR, and is shown here on the staging site to provide easy access for exploring and checking the data.",
-                            "publication": "-"
-                        },
-                        "bm": {
-                            "methodology": "Data ini merupakan rekod digital keputusan pilihanraya yang dikira dan diwartakan selaras dengan Peraturan-Peraturan Pilihan Raya (Penjalanan Pilihan Raya). Proses pendigitalan disemak silang dengan rekod fizikal untuk memastikan ketepatan maklumat.",
-                            "caveat": "Setakat sekarang, data ini belum disemak dan diabsahkan oleh SPR, maka hanya dipaparkan di portal UAT ini bagi tujuan memudahkan proses semakan.",
-                            "publication": "-"
-                        }
-                    },
-                    "chart": {
-                        "chart_type": "TABLE",
-                        "chart_filters": {
-                            "SLICE_BY": [],
-                            "precision": 0
-                        },
-                        "chart_variables": {
-                            "parents": [],
-                            "exclude": [],
-                            "freeze": [
-                                "state",
-                                "parlimen"
-                            ]
-                        }
-                    }
-                }
-            },
-            {
-                "id": -1,
-                "name": "state",
-                "title_en": "State",
-                "title_bm": "Negeri",
-                "desc_en": "[String] 1 of 16 states",
-                "desc_bm": "[Rentetan] 1 antara 16 negeri"
-            },
-            {
-                "id": -1,
-                "name": "parlimen",
-                "title_en": "Parliament",
-                "title_bm": "Parlimen",
-                "desc_en": "[String] Name of seat as it appeared on the ballot on voting day",
-                "desc_bm": "[Rentetan] Nama kerusi seperti mana yang tertera di kertas undi pada hari mengundi"
-            },
-            {
-                "id": -1,
-                "name": "area_name",
-                "title_en": "Area Name",
-                "title_bm": "Nama Kawasan",
-                "desc_en": "[String] Name of the area, with seat code (P.xxx) stripped out, and area name historically harmonised. For example, Kota Baharu, Kota Bahru and Kota Bharu are all harmonised to the modern Kota Bharu.",
-                "desc_bm": "[Rentetan] Nama kawasan, tanpa kod kerusi (P.xxx) dan namanya diselaraskan mengambil kira perubahan dari zaman ke zaman. Contohnya, nama Kota Baharu, Kota Bahru, dan Kota Bharu semuanya diharmonikan kepada penggunaan moden iaitu Kota Bharu."
-            },
-            {
-                "id": -1,
-                "name": "voters_total",
-                "title_en": "Total Voters",
-                "title_bm": "Jumlah Pengundi",
-                "desc_en": "[Integer] Number of voters registered to vote in that seat at that election",
-                "desc_bm": "[Integer] Jumlah pengundi yang didaftarkan untuk mengundi di kerusi tersebut semasa PRU-00"
-            },
-            {
-                "id": -1,
-                "name": "ballots_issued",
-                "title_en": "Ballots Issued",
-                "title_bm": "Undi Dikeluarkan",
-                "desc_en": "[Integer] Number of ballots issued, including postal ballots, but not inclduing ballots accidentally damaged and immediately replace during the voting procedure",
-                "desc_bm": "[Integer] Jumlah kertas undi yang dikeluarkan, termasuk kertas undi pos, tetapi tidak termasuk kertas undi yang rosak dan terus digantikan semasa urusan mengundi dijalankan"
-            },
-            {
-                "id": -1,
-                "name": "ballots_not_returned",
-                "title_en": "Ballots Not Returned",
-                "title_bm": "Undi Tidak Dikembalikan",
-                "desc_en": "[Integer] Number of ballots issued but not returned for counting, including postal ballots not returned to the counting centre in time, but excluding spoilt ballots (e.g. torn or stained) which were replaced and therefore not counted as ballots issued",
-                "desc_bm": "[Integer] Jumlah kertas undi yang dikeluarkan tetapi tidak dikembalikan untuk pengiraan undi, termasuk kertas undi pos yang tidak dikembalikan ke pusat kiraan undi, tetapi tidak termasuk kertas undi rosak (contohnya terkoyak atau ternoda) yang telah digantikan maka tidak dikira sebagai kertas undi yang dikeluarkan"
-            },
-            {
-                "id": -1,
-                "name": "votes_rejected",
-                "title_en": "Votes Rejected",
-                "title_bm": "Undi Ditolak",
-                "desc_en": "[Integer] Number of ballots returned but declared invalid during counting because the candidate could not be determined",
-                "desc_bm": "[Integer] Jumlah kertas undi yang telah dikembalikan tetapi ditolak semasa proses kiraan undi kerana calon yang diundi tidak dapat ditentukan"
-            },
-            {
-                "id": -1,
-                "name": "voter_turnout",
-                "title_en": "Voter Turnout",
-                "title_bm": "Peratus Keluar",
-                "desc_en": "[Float] Derived as: (ballots_issued / voters_total) * 100",
-                "desc_bm": " [Apung] Diperolehi dengan formula: (ballots_issued / voters_total) * 100"
-            },
-            {
-                "id": -1,
-                "name": "votes_rejected_perc",
-                "title_en": "Percentage Rejected",
-                "title_bm": "Peratus Ditolak",
-                "desc_en": "[Float] Derived as: (votes_rejected / (ballots_issued - ballots_not_returned)) * 100",
-                "desc_bm": " [Apung] Diperolehi dengan formula: (votes_rejected / (ballots_issued - ballots_not_returned)) * 100"
-            }
-        ]
-    }
+	"file": {
+		"manual_trigger": 0,
+		"bucket": "elections_federal",
+		"file_name": "ge04_summary",
+		"category": "ELECTIONS",
+		"category_en": "Elections",
+		"category_bm": "Pilihanraya",
+		"subcategory": "FEDERAL",
+		"subcategory_en": "Federal",
+		"subcategory_bm": "Persekutuan",
+		"description": {
+			"en": "Analytical summary of the pre-Independence general election held in 1955.",
+			"bm": "Ringkasan analitik bagi pilihanraya umum pramerdeka yang diadakan pada tahun 1955."
+		},
+		"link_parquet": "https://storage.data.gov.my/elections/federal/ge04_summary.parquet",
+		"link_csv": "https://storage.data.gov.my/elections/federal/ge04_summary.csv",
+		"link_preview": "https://storage.data.gov.my/elections/federal/ge04_summary.parquet",
+		"variables": [
+			{
+				"id": 0,
+				"name": "ge04_summary",
+				"title_en": "GE-04: Summary",
+				"title_bm": "PRU-04: Rumusan",
+				"desc_en": "Analytical summary of the pre-Independence general election held on 27 July 1955.",
+				"desc_bm": "Ringkasan analitik bagi pilihanraya umum pramerdeka yang diadakan pada 27 Julai 1955.",
+				"catalog_data": {
+					"catalog_filters": {
+						"frequency": "INFREQUENT",
+						"geography": ["PARLIMEN", "STATE", "NATIONAL"],
+						"demographic": [],
+						"start": "1974",
+						"end": "1974",
+						"data_source": ["SPR"]
+					},
+					"metadata_neutral": {
+						"data_as_of": "1955-08-31 23:59",
+						"last_updated": "2023-07-18 23:59",
+						"next_update": "-"
+					},
+					"metadata_lang": {
+						"en": {
+							"methodology": "This data is a digital representation of the physical election results tabulated and gazetted per the Electoral Regulations (Conduct of Elections). The digitalisation process was rigorously cross-checked against physical records to ensure consistency and accuracy of information.",
+							"caveat": "As of now, this data has not been verified by SPR, and is shown here on the staging site to provide easy access for exploring and checking the data.",
+							"publication": "-"
+						},
+						"bm": {
+							"methodology": "Data ini merupakan rekod digital keputusan pilihanraya yang dikira dan diwartakan selaras dengan Peraturan-Peraturan Pilihan Raya (Penjalanan Pilihan Raya). Proses pendigitalan disemak silang dengan rekod fizikal untuk memastikan ketepatan maklumat.",
+							"caveat": "Setakat sekarang, data ini belum disemak dan diabsahkan oleh SPR, maka hanya dipaparkan di portal UAT ini bagi tujuan memudahkan proses semakan.",
+							"publication": "-"
+						}
+					},
+					"chart": {
+						"chart_type": "TABLE",
+						"chart_filters": {
+							"SLICE_BY": [],
+							"precision": 0
+						},
+						"chart_variables": {
+							"parents": [],
+							"exclude": [],
+							"freeze": ["state", "parlimen"]
+						}
+					}
+				}
+			},
+			{
+				"id": -1,
+				"name": "state",
+				"title_en": "State",
+				"title_bm": "Negeri",
+				"desc_en": "[String] 1 of 16 states",
+				"desc_bm": "[Rentetan] 1 antara 16 negeri"
+			},
+			{
+				"id": -1,
+				"name": "parlimen",
+				"title_en": "Parliament",
+				"title_bm": "Parlimen",
+				"desc_en": "[String] Name of seat as it appeared on the ballot on voting day",
+				"desc_bm": "[Rentetan] Nama kerusi seperti mana yang tertera di kertas undi pada hari mengundi"
+			},
+			{
+				"id": -1,
+				"name": "area_name",
+				"title_en": "Area Name",
+				"title_bm": "Nama Kawasan",
+				"desc_en": "[String] Name of the area, with seat code (P.xxx) stripped out, and area name historically harmonised. For example, Kota Baharu, Kota Bahru and Kota Bharu are all harmonised to the modern Kota Bharu.",
+				"desc_bm": "[Rentetan] Nama kawasan, tanpa kod kerusi (P.xxx) dan namanya diselaraskan mengambil kira perubahan dari zaman ke zaman. Contohnya, nama Kota Baharu, Kota Bahru, dan Kota Bharu semuanya diharmonikan kepada penggunaan moden iaitu Kota Bharu."
+			},
+			{
+				"id": -1,
+				"name": "voters_total",
+				"title_en": "Total Voters",
+				"title_bm": "Jumlah Pengundi",
+				"desc_en": "[Integer] Number of voters registered to vote in that seat at that election",
+				"desc_bm": "[Integer] Jumlah pengundi yang didaftarkan untuk mengundi di kerusi tersebut semasa PRU-00"
+			},
+			{
+				"id": -1,
+				"name": "ballots_issued",
+				"title_en": "Ballots Issued",
+				"title_bm": "Undi Dikeluarkan",
+				"desc_en": "[Integer] Number of ballots issued, including postal ballots, but not inclduing ballots accidentally damaged and immediately replace during the voting procedure",
+				"desc_bm": "[Integer] Jumlah kertas undi yang dikeluarkan, termasuk kertas undi pos, tetapi tidak termasuk kertas undi yang rosak dan terus digantikan semasa urusan mengundi dijalankan"
+			},
+			{
+				"id": -1,
+				"name": "ballots_not_returned",
+				"title_en": "Ballots Not Returned",
+				"title_bm": "Undi Tidak Dikembalikan",
+				"desc_en": "[Integer] Number of ballots issued but not returned for counting, including postal ballots not returned to the counting centre in time, but excluding spoilt ballots (e.g. torn or stained) which were replaced and therefore not counted as ballots issued",
+				"desc_bm": "[Integer] Jumlah kertas undi yang dikeluarkan tetapi tidak dikembalikan untuk pengiraan undi, termasuk kertas undi pos yang tidak dikembalikan ke pusat kiraan undi, tetapi tidak termasuk kertas undi rosak (contohnya terkoyak atau ternoda) yang telah digantikan maka tidak dikira sebagai kertas undi yang dikeluarkan"
+			},
+			{
+				"id": -1,
+				"name": "votes_rejected",
+				"title_en": "Votes Rejected",
+				"title_bm": "Undi Ditolak",
+				"desc_en": "[Integer] Number of ballots returned but declared invalid during counting because the candidate could not be determined",
+				"desc_bm": "[Integer] Jumlah kertas undi yang telah dikembalikan tetapi ditolak semasa proses kiraan undi kerana calon yang diundi tidak dapat ditentukan"
+			},
+			{
+				"id": -1,
+				"name": "voter_turnout",
+				"title_en": "Voter Turnout",
+				"title_bm": "Peratus Keluar",
+				"desc_en": "[Float] Derived as: (ballots_issued / voters_total) * 100",
+				"desc_bm": " [Apung] Diperolehi dengan formula: (ballots_issued / voters_total) * 100"
+			},
+			{
+				"id": -1,
+				"name": "votes_rejected_perc",
+				"title_en": "Percentage Rejected",
+				"title_bm": "Peratus Ditolak",
+				"desc_en": "[Float] Derived as: (votes_rejected / (ballots_issued - ballots_not_returned)) * 100",
+				"desc_bm": " [Apung] Diperolehi dengan formula: (votes_rejected / (ballots_issued - ballots_not_returned)) * 100"
+			}
+		]
+	}
 }

--- a/catalog/ge04_summary.json
+++ b/catalog/ge04_summary.json
@@ -28,7 +28,7 @@
 					"catalog_filters": {
 						"frequency": "INFREQUENT",
 						"geography": ["PARLIMEN", "STATE", "NATIONAL"],
-						"demographic": [],
+						"demography": [],
 						"start": "1974",
 						"end": "1974",
 						"data_source": ["SPR"]

--- a/catalog/ge05_ballots.json
+++ b/catalog/ge05_ballots.json
@@ -1,142 +1,133 @@
 {
-    "file": {
-        "manual_trigger": 0,
-        "bucket": "elections_federal",
-        "file_name": "ge05_ballots",
-        "category": "ELECTIONS",
-        "category_en": "Elections",
-        "category_bm": "Pilihanraya",
-        "subcategory": "FEDERAL",
-        "subcategory_en": "Federal",
-        "subcategory_bm": "Persekutuan",
-        "description": {
-            "en": "Ballots for every seat contested at the pre-Independence general election held in 1955.",
-            "bm": "Perincian undi bagi setiap kerusi yang dipertandingkan di pilihanraya umum pramerdeka yang diadakan pada tahun 1955."
-        },
-        "link_parquet": "https://storage.data.gov.my/elections/federal/ge05_ballots.parquet",
-        "link_csv": "https://storage.data.gov.my/elections/federal/ge05_ballots.csv",
-        "link_preview": "https://storage.data.gov.my/elections/federal/ge05_ballots.parquet",
-        "variables": [
-            {
-                "id": 0,
-                "name": "ge05_ballots",
-                "title_en": "GE-05: Ballots",
-                "title_bm": "PRU-05: Kertas Undi",
-                "desc_en": "Ballots for every seat contested at the pre-Independence general election held on 27 July 1955.",
-                "desc_bm": "Perincian undi bagi setiap kerusi yang dipertandingkan di pilihanraya umum pramerdeka yang diadakan pada 27 Julai 1955.",
-                "catalog_data": {
-                    "catalog_filters": {
-                        "frequency": "INFREQUENT",
-                        "geographic": [
-                            "PARLIMEN",
-                            "STATE",
-                            "NATIONAL"
-                        ],
-                        "demographic": [],
-                        "start": "1978",
-                        "end": "1978",
-                        "data_source": [
-                            "SPR"
-                        ]
-                    },
-                    "metadata_neutral": {
-                        "data_as_of": "1955-08-31 23:59",
-                        "last_updated": "2023-07-18 23:59",
-                        "next_update": "-"
-                    },
-                    "metadata_lang": {
-                        "en": {
-                            "methodology": "This data is a digital representation of the physical election results tabulated and gazetted per the Electoral Regulations (Conduct of Elections). The digitalisation process was rigorously cross-checked against physical records to ensure consistency and accuracy of information.",
-                            "caveat": "As of now, this data has not been verified by SPR, and is shown here on the staging site to provide easy access for exploring and checking the data.",
-                            "publication": "-"
-                        },
-                        "bm": {
-                            "methodology": "Data ini merupakan rekod digital keputusan pilihanraya yang dikira dan diwartakan selaras dengan Peraturan-Peraturan Pilihan Raya (Penjalanan Pilihan Raya). Proses pendigitalan disemak silang dengan rekod fizikal untuk memastikan ketepatan maklumat.",
-                            "caveat": "Setakat sekarang, data ini belum disemak dan diabsahkan oleh SPR, maka hanya dipaparkan di portal UAT ini bagi tujuan memudahkan proses semakan.",
-                            "publication": "-"
-                        }
-                    },
-                    "chart": {
-                        "chart_type": "TABLE",
-                        "chart_filters": {
-                            "SLICE_BY": [],
-                            "precision": 0
-                        },
-                        "chart_variables": {
-                            "parents": [],
-                            "exclude": [],
-                            "freeze": [
-                                "state",
-                                "parlimen"
-                            ]
-                        }
-                    }
-                }
-            },
-            {
-                "id": -1,
-                "name": "state",
-                "title_en": "State",
-                "title_bm": "Negeri",
-                "desc_en": "[String] 1 of 16 states",
-                "desc_bm": "[Rentetan] 1 antara 16 negeri"
-            },
-            {
-                "id": -1,
-                "name": "parlimen",
-                "title_en": "Parliament",
-                "title_bm": "Parlimen",
-                "desc_en": "[String] Name of seat as it appeared on the ballot on voting day",
-                "desc_bm": "[Rentetan] Nama kerusi seperti mana yang tertera di kertas undi pada hari mengundi"
-            },
-            {
-                "id": -1,
-                "name": "area_name",
-                "title_en": "Area Name",
-                "title_bm": "Nama Kawasan",
-                "desc_en": "[String] Name of the area, with seat code (P.xxx) stripped out, and area name historically harmonised. For example, Kota Baharu, Kota Bahru and Kota Bharu are all harmonised to the modern Kota Bharu.",
-                "desc_bm": "[Rentetan] Nama kawasan, tanpa kod kerusi (P.xxx) dan namanya diselaraskan mengambil kira perubahan dari zaman ke zaman. Contohnya, nama Kota Baharu, Kota Bahru, dan Kota Bharu semuanya diharmonikan kepada penggunaan moden iaitu Kota Bharu."
-            },
-            {
-                "id": -1,
-                "name": "ballot_order",
-                "title_en": "Ballot Order",
-                "title_bm": "Urutan Nama",
-                "desc_en": "[Integer] Order in which the candidate appears on the ballot",
-                "desc_bm": "[Integer] Urutan nama-nama yang tertera pada kertas undi"
-            },
-            {
-                "id": -1,
-                "name": "name",
-                "title_en": "Name",
-                "title_bm": "Nama",
-                "desc_en": "[String] Name of candidate as it appeared on the ballot on voting day; this may not be the same as their real name as candidates are free to choose the name they use for campaigning and voting",
-                "desc_bm": "[Rentetan] Nama calon seperti mana yang tertera di kertas undi pada hari mengundi; ini tidak semestinya sama dengan nama sebenar mereka kerana calon adalah bebas untuk memilih nama yang digunakan bagi tujuan kempen dan undi"
-            },
-            {
-                "id": -1,
-                "name": "candidate_uid",
-                "title_en": "Unique Candidate ID",
-                "title_bm": "ID Unik Calon",
-                "desc_en": "[Integer] Unique integer identifier to track candidates across elections",
-                "desc_bm": "[Integer] Integer unik untuk menjejaki keputusan seseorang calon merentasi pilihan raya"
-            },
-            {
-                "id": -1,
-                "name": "party",
-                "title_en": "Party",
-                "title_bm": "Parti",
-                "desc_en": "[String] Party of the candidate as it appeared on the ballot on voting day; this record is not amended to reflect unofficial information on parties and coalitions. For example, if a candidate competed under the flag of Party X despite being a member of Party Y, their party is recorded as Party X.",
-                "desc_bm": "[String] Parti calon seperti yang tertera pada kertas undi pada hari mengundi; rekod ini tidak dipinda untuk menggambarkan maklumat tidak rasmi mengenai parti dan gabungan. Sebagai contoh, jika calon bertanding bawah bendera Parti X walaupun menjadi ahli Parti Y, parti mereka direkodkan sebagai Parti X."
-            },
-            {
-                "id": -1,
-                "name": "votes",
-                "title_en": "Votes",
-                "title_bm": "Undi",
-                "desc_en": "Integer] Number of votes won by the candidate",
-                "desc_bm": "[Integer] Jumlah undi yang diperolehi oleh calon"
-            }
-        ]
-    }
+	"file": {
+		"manual_trigger": 0,
+		"bucket": "elections_federal",
+		"file_name": "ge05_ballots",
+		"category": "ELECTIONS",
+		"category_en": "Elections",
+		"category_bm": "Pilihanraya",
+		"subcategory": "FEDERAL",
+		"subcategory_en": "Federal",
+		"subcategory_bm": "Persekutuan",
+		"description": {
+			"en": "Ballots for every seat contested at the pre-Independence general election held in 1955.",
+			"bm": "Perincian undi bagi setiap kerusi yang dipertandingkan di pilihanraya umum pramerdeka yang diadakan pada tahun 1955."
+		},
+		"link_parquet": "https://storage.data.gov.my/elections/federal/ge05_ballots.parquet",
+		"link_csv": "https://storage.data.gov.my/elections/federal/ge05_ballots.csv",
+		"link_preview": "https://storage.data.gov.my/elections/federal/ge05_ballots.parquet",
+		"variables": [
+			{
+				"id": 0,
+				"name": "ge05_ballots",
+				"title_en": "GE-05: Ballots",
+				"title_bm": "PRU-05: Kertas Undi",
+				"desc_en": "Ballots for every seat contested at the pre-Independence general election held on 27 July 1955.",
+				"desc_bm": "Perincian undi bagi setiap kerusi yang dipertandingkan di pilihanraya umum pramerdeka yang diadakan pada 27 Julai 1955.",
+				"catalog_data": {
+					"catalog_filters": {
+						"frequency": "INFREQUENT",
+						"geography": ["PARLIMEN", "STATE", "NATIONAL"],
+						"demographic": [],
+						"start": "1978",
+						"end": "1978",
+						"data_source": ["SPR"]
+					},
+					"metadata_neutral": {
+						"data_as_of": "1955-08-31 23:59",
+						"last_updated": "2023-07-18 23:59",
+						"next_update": "-"
+					},
+					"metadata_lang": {
+						"en": {
+							"methodology": "This data is a digital representation of the physical election results tabulated and gazetted per the Electoral Regulations (Conduct of Elections). The digitalisation process was rigorously cross-checked against physical records to ensure consistency and accuracy of information.",
+							"caveat": "As of now, this data has not been verified by SPR, and is shown here on the staging site to provide easy access for exploring and checking the data.",
+							"publication": "-"
+						},
+						"bm": {
+							"methodology": "Data ini merupakan rekod digital keputusan pilihanraya yang dikira dan diwartakan selaras dengan Peraturan-Peraturan Pilihan Raya (Penjalanan Pilihan Raya). Proses pendigitalan disemak silang dengan rekod fizikal untuk memastikan ketepatan maklumat.",
+							"caveat": "Setakat sekarang, data ini belum disemak dan diabsahkan oleh SPR, maka hanya dipaparkan di portal UAT ini bagi tujuan memudahkan proses semakan.",
+							"publication": "-"
+						}
+					},
+					"chart": {
+						"chart_type": "TABLE",
+						"chart_filters": {
+							"SLICE_BY": [],
+							"precision": 0
+						},
+						"chart_variables": {
+							"parents": [],
+							"exclude": [],
+							"freeze": ["state", "parlimen"]
+						}
+					}
+				}
+			},
+			{
+				"id": -1,
+				"name": "state",
+				"title_en": "State",
+				"title_bm": "Negeri",
+				"desc_en": "[String] 1 of 16 states",
+				"desc_bm": "[Rentetan] 1 antara 16 negeri"
+			},
+			{
+				"id": -1,
+				"name": "parlimen",
+				"title_en": "Parliament",
+				"title_bm": "Parlimen",
+				"desc_en": "[String] Name of seat as it appeared on the ballot on voting day",
+				"desc_bm": "[Rentetan] Nama kerusi seperti mana yang tertera di kertas undi pada hari mengundi"
+			},
+			{
+				"id": -1,
+				"name": "area_name",
+				"title_en": "Area Name",
+				"title_bm": "Nama Kawasan",
+				"desc_en": "[String] Name of the area, with seat code (P.xxx) stripped out, and area name historically harmonised. For example, Kota Baharu, Kota Bahru and Kota Bharu are all harmonised to the modern Kota Bharu.",
+				"desc_bm": "[Rentetan] Nama kawasan, tanpa kod kerusi (P.xxx) dan namanya diselaraskan mengambil kira perubahan dari zaman ke zaman. Contohnya, nama Kota Baharu, Kota Bahru, dan Kota Bharu semuanya diharmonikan kepada penggunaan moden iaitu Kota Bharu."
+			},
+			{
+				"id": -1,
+				"name": "ballot_order",
+				"title_en": "Ballot Order",
+				"title_bm": "Urutan Nama",
+				"desc_en": "[Integer] Order in which the candidate appears on the ballot",
+				"desc_bm": "[Integer] Urutan nama-nama yang tertera pada kertas undi"
+			},
+			{
+				"id": -1,
+				"name": "name",
+				"title_en": "Name",
+				"title_bm": "Nama",
+				"desc_en": "[String] Name of candidate as it appeared on the ballot on voting day; this may not be the same as their real name as candidates are free to choose the name they use for campaigning and voting",
+				"desc_bm": "[Rentetan] Nama calon seperti mana yang tertera di kertas undi pada hari mengundi; ini tidak semestinya sama dengan nama sebenar mereka kerana calon adalah bebas untuk memilih nama yang digunakan bagi tujuan kempen dan undi"
+			},
+			{
+				"id": -1,
+				"name": "candidate_uid",
+				"title_en": "Unique Candidate ID",
+				"title_bm": "ID Unik Calon",
+				"desc_en": "[Integer] Unique integer identifier to track candidates across elections",
+				"desc_bm": "[Integer] Integer unik untuk menjejaki keputusan seseorang calon merentasi pilihan raya"
+			},
+			{
+				"id": -1,
+				"name": "party",
+				"title_en": "Party",
+				"title_bm": "Parti",
+				"desc_en": "[String] Party of the candidate as it appeared on the ballot on voting day; this record is not amended to reflect unofficial information on parties and coalitions. For example, if a candidate competed under the flag of Party X despite being a member of Party Y, their party is recorded as Party X.",
+				"desc_bm": "[String] Parti calon seperti yang tertera pada kertas undi pada hari mengundi; rekod ini tidak dipinda untuk menggambarkan maklumat tidak rasmi mengenai parti dan gabungan. Sebagai contoh, jika calon bertanding bawah bendera Parti X walaupun menjadi ahli Parti Y, parti mereka direkodkan sebagai Parti X."
+			},
+			{
+				"id": -1,
+				"name": "votes",
+				"title_en": "Votes",
+				"title_bm": "Undi",
+				"desc_en": "Integer] Number of votes won by the candidate",
+				"desc_bm": "[Integer] Jumlah undi yang diperolehi oleh calon"
+			}
+		]
+	}
 }

--- a/catalog/ge05_ballots.json
+++ b/catalog/ge05_ballots.json
@@ -28,7 +28,7 @@
 					"catalog_filters": {
 						"frequency": "INFREQUENT",
 						"geography": ["PARLIMEN", "STATE", "NATIONAL"],
-						"demographic": [],
+						"demography": [],
 						"start": "1978",
 						"end": "1978",
 						"data_source": ["SPR"]

--- a/catalog/ge05_summary.json
+++ b/catalog/ge05_summary.json
@@ -1,150 +1,141 @@
 {
-    "file": {
-        "manual_trigger": 0,
-        "bucket": "elections_federal",
-        "file_name": "ge05_summary",
-        "category": "ELECTIONS",
-        "category_en": "Elections",
-        "category_bm": "Pilihanraya",
-        "subcategory": "FEDERAL",
-        "subcategory_en": "Federal",
-        "subcategory_bm": "Persekutuan",
-        "description": {
-            "en": "Analytical summary of the pre-Independence general election held in 1955.",
-            "bm": "Ringkasan analitik bagi pilihanraya umum pramerdeka yang diadakan pada tahun 1955."
-        },
-        "link_parquet": "https://storage.data.gov.my/elections/federal/ge05_summary.parquet",
-        "link_csv": "https://storage.data.gov.my/elections/federal/ge05_summary.csv",
-        "link_preview": "https://storage.data.gov.my/elections/federal/ge05_summary.parquet",
-        "variables": [
-            {
-                "id": 0,
-                "name": "ge05_summary",
-                "title_en": "GE-05: Summary",
-                "title_bm": "PRU-05: Rumusan",
-                "desc_en": "Analytical summary of the pre-Independence general election held on 27 July 1955.",
-                "desc_bm": "Ringkasan analitik bagi pilihanraya umum pramerdeka yang diadakan pada 27 Julai 1955.",
-                "catalog_data": {
-                    "catalog_filters": {
-                        "frequency": "INFREQUENT",
-                        "geographic": [
-                            "PARLIMEN",
-                            "STATE",
-                            "NATIONAL"
-                        ],
-                        "demographic": [],
-                        "start": "1978",
-                        "end": "1978",
-                        "data_source": [
-                            "SPR"
-                        ]
-                    },
-                    "metadata_neutral": {
-                        "data_as_of": "1955-08-31 23:59",
-                        "last_updated": "2023-07-18 23:59",
-                        "next_update": "-"
-                    },
-                    "metadata_lang": {
-                        "en": {
-                            "methodology": "This data is a digital representation of the physical election results tabulated and gazetted per the Electoral Regulations (Conduct of Elections). The digitalisation process was rigorously cross-checked against physical records to ensure consistency and accuracy of information.",
-                            "caveat": "As of now, this data has not been verified by SPR, and is shown here on the staging site to provide easy access for exploring and checking the data.",
-                            "publication": "-"
-                        },
-                        "bm": {
-                            "methodology": "Data ini merupakan rekod digital keputusan pilihanraya yang dikira dan diwartakan selaras dengan Peraturan-Peraturan Pilihan Raya (Penjalanan Pilihan Raya). Proses pendigitalan disemak silang dengan rekod fizikal untuk memastikan ketepatan maklumat.",
-                            "caveat": "Setakat sekarang, data ini belum disemak dan diabsahkan oleh SPR, maka hanya dipaparkan di portal UAT ini bagi tujuan memudahkan proses semakan.",
-                            "publication": "-"
-                        }
-                    },
-                    "chart": {
-                        "chart_type": "TABLE",
-                        "chart_filters": {
-                            "SLICE_BY": [],
-                            "precision": 0
-                        },
-                        "chart_variables": {
-                            "parents": [],
-                            "exclude": [],
-                            "freeze": [
-                                "state",
-                                "parlimen"
-                            ]
-                        }
-                    }
-                }
-            },
-            {
-                "id": -1,
-                "name": "state",
-                "title_en": "State",
-                "title_bm": "Negeri",
-                "desc_en": "[String] 1 of 16 states",
-                "desc_bm": "[Rentetan] 1 antara 16 negeri"
-            },
-            {
-                "id": -1,
-                "name": "parlimen",
-                "title_en": "Parliament",
-                "title_bm": "Parlimen",
-                "desc_en": "[String] Name of seat as it appeared on the ballot on voting day",
-                "desc_bm": "[Rentetan] Nama kerusi seperti mana yang tertera di kertas undi pada hari mengundi"
-            },
-            {
-                "id": -1,
-                "name": "area_name",
-                "title_en": "Area Name",
-                "title_bm": "Nama Kawasan",
-                "desc_en": "[String] Name of the area, with seat code (P.xxx) stripped out, and area name historically harmonised. For example, Kota Baharu, Kota Bahru and Kota Bharu are all harmonised to the modern Kota Bharu.",
-                "desc_bm": "[Rentetan] Nama kawasan, tanpa kod kerusi (P.xxx) dan namanya diselaraskan mengambil kira perubahan dari zaman ke zaman. Contohnya, nama Kota Baharu, Kota Bahru, dan Kota Bharu semuanya diharmonikan kepada penggunaan moden iaitu Kota Bharu."
-            },
-            {
-                "id": -1,
-                "name": "voters_total",
-                "title_en": "Total Voters",
-                "title_bm": "Jumlah Pengundi",
-                "desc_en": "[Integer] Number of voters registered to vote in that seat at that election",
-                "desc_bm": "[Integer] Jumlah pengundi yang didaftarkan untuk mengundi di kerusi tersebut semasa PRU-00"
-            },
-            {
-                "id": -1,
-                "name": "ballots_issued",
-                "title_en": "Ballots Issued",
-                "title_bm": "Undi Dikeluarkan",
-                "desc_en": "[Integer] Number of ballots issued, including postal ballots, but not inclduing ballots accidentally damaged and immediately replace during the voting procedure",
-                "desc_bm": "[Integer] Jumlah kertas undi yang dikeluarkan, termasuk kertas undi pos, tetapi tidak termasuk kertas undi yang rosak dan terus digantikan semasa urusan mengundi dijalankan"
-            },
-            {
-                "id": -1,
-                "name": "ballots_not_returned",
-                "title_en": "Ballots Not Returned",
-                "title_bm": "Undi Tidak Dikembalikan",
-                "desc_en": "[Integer] Number of ballots issued but not returned for counting, including postal ballots not returned to the counting centre in time, but excluding spoilt ballots (e.g. torn or stained) which were replaced and therefore not counted as ballots issued",
-                "desc_bm": "[Integer] Jumlah kertas undi yang dikeluarkan tetapi tidak dikembalikan untuk pengiraan undi, termasuk kertas undi pos yang tidak dikembalikan ke pusat kiraan undi, tetapi tidak termasuk kertas undi rosak (contohnya terkoyak atau ternoda) yang telah digantikan maka tidak dikira sebagai kertas undi yang dikeluarkan"
-            },
-            {
-                "id": -1,
-                "name": "votes_rejected",
-                "title_en": "Votes Rejected",
-                "title_bm": "Undi Ditolak",
-                "desc_en": "[Integer] Number of ballots returned but declared invalid during counting because the candidate could not be determined",
-                "desc_bm": "[Integer] Jumlah kertas undi yang telah dikembalikan tetapi ditolak semasa proses kiraan undi kerana calon yang diundi tidak dapat ditentukan"
-            },
-            {
-                "id": -1,
-                "name": "voter_turnout",
-                "title_en": "Voter Turnout",
-                "title_bm": "Peratus Keluar",
-                "desc_en": "[Float] Derived as: (ballots_issued / voters_total) * 100",
-                "desc_bm": " [Apung] Diperolehi dengan formula: (ballots_issued / voters_total) * 100"
-            },
-            {
-                "id": -1,
-                "name": "votes_rejected_perc",
-                "title_en": "Percentage Rejected",
-                "title_bm": "Peratus Ditolak",
-                "desc_en": "[Float] Derived as: (votes_rejected / (ballots_issued - ballots_not_returned)) * 100",
-                "desc_bm": " [Apung] Diperolehi dengan formula: (votes_rejected / (ballots_issued - ballots_not_returned)) * 100"
-            }
-        ]
-    }
+	"file": {
+		"manual_trigger": 0,
+		"bucket": "elections_federal",
+		"file_name": "ge05_summary",
+		"category": "ELECTIONS",
+		"category_en": "Elections",
+		"category_bm": "Pilihanraya",
+		"subcategory": "FEDERAL",
+		"subcategory_en": "Federal",
+		"subcategory_bm": "Persekutuan",
+		"description": {
+			"en": "Analytical summary of the pre-Independence general election held in 1955.",
+			"bm": "Ringkasan analitik bagi pilihanraya umum pramerdeka yang diadakan pada tahun 1955."
+		},
+		"link_parquet": "https://storage.data.gov.my/elections/federal/ge05_summary.parquet",
+		"link_csv": "https://storage.data.gov.my/elections/federal/ge05_summary.csv",
+		"link_preview": "https://storage.data.gov.my/elections/federal/ge05_summary.parquet",
+		"variables": [
+			{
+				"id": 0,
+				"name": "ge05_summary",
+				"title_en": "GE-05: Summary",
+				"title_bm": "PRU-05: Rumusan",
+				"desc_en": "Analytical summary of the pre-Independence general election held on 27 July 1955.",
+				"desc_bm": "Ringkasan analitik bagi pilihanraya umum pramerdeka yang diadakan pada 27 Julai 1955.",
+				"catalog_data": {
+					"catalog_filters": {
+						"frequency": "INFREQUENT",
+						"geography": ["PARLIMEN", "STATE", "NATIONAL"],
+						"demographic": [],
+						"start": "1978",
+						"end": "1978",
+						"data_source": ["SPR"]
+					},
+					"metadata_neutral": {
+						"data_as_of": "1955-08-31 23:59",
+						"last_updated": "2023-07-18 23:59",
+						"next_update": "-"
+					},
+					"metadata_lang": {
+						"en": {
+							"methodology": "This data is a digital representation of the physical election results tabulated and gazetted per the Electoral Regulations (Conduct of Elections). The digitalisation process was rigorously cross-checked against physical records to ensure consistency and accuracy of information.",
+							"caveat": "As of now, this data has not been verified by SPR, and is shown here on the staging site to provide easy access for exploring and checking the data.",
+							"publication": "-"
+						},
+						"bm": {
+							"methodology": "Data ini merupakan rekod digital keputusan pilihanraya yang dikira dan diwartakan selaras dengan Peraturan-Peraturan Pilihan Raya (Penjalanan Pilihan Raya). Proses pendigitalan disemak silang dengan rekod fizikal untuk memastikan ketepatan maklumat.",
+							"caveat": "Setakat sekarang, data ini belum disemak dan diabsahkan oleh SPR, maka hanya dipaparkan di portal UAT ini bagi tujuan memudahkan proses semakan.",
+							"publication": "-"
+						}
+					},
+					"chart": {
+						"chart_type": "TABLE",
+						"chart_filters": {
+							"SLICE_BY": [],
+							"precision": 0
+						},
+						"chart_variables": {
+							"parents": [],
+							"exclude": [],
+							"freeze": ["state", "parlimen"]
+						}
+					}
+				}
+			},
+			{
+				"id": -1,
+				"name": "state",
+				"title_en": "State",
+				"title_bm": "Negeri",
+				"desc_en": "[String] 1 of 16 states",
+				"desc_bm": "[Rentetan] 1 antara 16 negeri"
+			},
+			{
+				"id": -1,
+				"name": "parlimen",
+				"title_en": "Parliament",
+				"title_bm": "Parlimen",
+				"desc_en": "[String] Name of seat as it appeared on the ballot on voting day",
+				"desc_bm": "[Rentetan] Nama kerusi seperti mana yang tertera di kertas undi pada hari mengundi"
+			},
+			{
+				"id": -1,
+				"name": "area_name",
+				"title_en": "Area Name",
+				"title_bm": "Nama Kawasan",
+				"desc_en": "[String] Name of the area, with seat code (P.xxx) stripped out, and area name historically harmonised. For example, Kota Baharu, Kota Bahru and Kota Bharu are all harmonised to the modern Kota Bharu.",
+				"desc_bm": "[Rentetan] Nama kawasan, tanpa kod kerusi (P.xxx) dan namanya diselaraskan mengambil kira perubahan dari zaman ke zaman. Contohnya, nama Kota Baharu, Kota Bahru, dan Kota Bharu semuanya diharmonikan kepada penggunaan moden iaitu Kota Bharu."
+			},
+			{
+				"id": -1,
+				"name": "voters_total",
+				"title_en": "Total Voters",
+				"title_bm": "Jumlah Pengundi",
+				"desc_en": "[Integer] Number of voters registered to vote in that seat at that election",
+				"desc_bm": "[Integer] Jumlah pengundi yang didaftarkan untuk mengundi di kerusi tersebut semasa PRU-00"
+			},
+			{
+				"id": -1,
+				"name": "ballots_issued",
+				"title_en": "Ballots Issued",
+				"title_bm": "Undi Dikeluarkan",
+				"desc_en": "[Integer] Number of ballots issued, including postal ballots, but not inclduing ballots accidentally damaged and immediately replace during the voting procedure",
+				"desc_bm": "[Integer] Jumlah kertas undi yang dikeluarkan, termasuk kertas undi pos, tetapi tidak termasuk kertas undi yang rosak dan terus digantikan semasa urusan mengundi dijalankan"
+			},
+			{
+				"id": -1,
+				"name": "ballots_not_returned",
+				"title_en": "Ballots Not Returned",
+				"title_bm": "Undi Tidak Dikembalikan",
+				"desc_en": "[Integer] Number of ballots issued but not returned for counting, including postal ballots not returned to the counting centre in time, but excluding spoilt ballots (e.g. torn or stained) which were replaced and therefore not counted as ballots issued",
+				"desc_bm": "[Integer] Jumlah kertas undi yang dikeluarkan tetapi tidak dikembalikan untuk pengiraan undi, termasuk kertas undi pos yang tidak dikembalikan ke pusat kiraan undi, tetapi tidak termasuk kertas undi rosak (contohnya terkoyak atau ternoda) yang telah digantikan maka tidak dikira sebagai kertas undi yang dikeluarkan"
+			},
+			{
+				"id": -1,
+				"name": "votes_rejected",
+				"title_en": "Votes Rejected",
+				"title_bm": "Undi Ditolak",
+				"desc_en": "[Integer] Number of ballots returned but declared invalid during counting because the candidate could not be determined",
+				"desc_bm": "[Integer] Jumlah kertas undi yang telah dikembalikan tetapi ditolak semasa proses kiraan undi kerana calon yang diundi tidak dapat ditentukan"
+			},
+			{
+				"id": -1,
+				"name": "voter_turnout",
+				"title_en": "Voter Turnout",
+				"title_bm": "Peratus Keluar",
+				"desc_en": "[Float] Derived as: (ballots_issued / voters_total) * 100",
+				"desc_bm": " [Apung] Diperolehi dengan formula: (ballots_issued / voters_total) * 100"
+			},
+			{
+				"id": -1,
+				"name": "votes_rejected_perc",
+				"title_en": "Percentage Rejected",
+				"title_bm": "Peratus Ditolak",
+				"desc_en": "[Float] Derived as: (votes_rejected / (ballots_issued - ballots_not_returned)) * 100",
+				"desc_bm": " [Apung] Diperolehi dengan formula: (votes_rejected / (ballots_issued - ballots_not_returned)) * 100"
+			}
+		]
+	}
 }

--- a/catalog/ge05_summary.json
+++ b/catalog/ge05_summary.json
@@ -28,7 +28,7 @@
 					"catalog_filters": {
 						"frequency": "INFREQUENT",
 						"geography": ["PARLIMEN", "STATE", "NATIONAL"],
-						"demographic": [],
+						"demography": [],
 						"start": "1978",
 						"end": "1978",
 						"data_source": ["SPR"]

--- a/catalog/ge06_ballots.json
+++ b/catalog/ge06_ballots.json
@@ -28,7 +28,7 @@
 					"catalog_filters": {
 						"frequency": "INFREQUENT",
 						"geography": ["PARLIMEN", "STATE", "NATIONAL"],
-						"demographic": [],
+						"demography": [],
 						"start": "1982",
 						"end": "1982",
 						"data_source": ["SPR"]

--- a/catalog/ge06_ballots.json
+++ b/catalog/ge06_ballots.json
@@ -1,142 +1,133 @@
 {
-    "file": {
-        "manual_trigger": 0,
-        "bucket": "elections_federal",
-        "file_name": "ge06_ballots",
-        "category": "ELECTIONS",
-        "category_en": "Elections",
-        "category_bm": "Pilihanraya",
-        "subcategory": "FEDERAL",
-        "subcategory_en": "Federal",
-        "subcategory_bm": "Persekutuan",
-        "description": {
-            "en": "Ballots for every seat contested at the pre-Independence general election held in 1955.",
-            "bm": "Perincian undi bagi setiap kerusi yang dipertandingkan di pilihanraya umum pramerdeka yang diadakan pada tahun 1955."
-        },
-        "link_parquet": "https://storage.data.gov.my/elections/federal/ge06_ballots.parquet",
-        "link_csv": "https://storage.data.gov.my/elections/federal/ge06_ballots.csv",
-        "link_preview": "https://storage.data.gov.my/elections/federal/ge06_ballots.parquet",
-        "variables": [
-            {
-                "id": 0,
-                "name": "ge06_ballots",
-                "title_en": "GE-06: Ballots",
-                "title_bm": "PRU-06: Kertas Undi",
-                "desc_en": "Ballots for every seat contested at the pre-Independence general election held on 27 July 1955.",
-                "desc_bm": "Perincian undi bagi setiap kerusi yang dipertandingkan di pilihanraya umum pramerdeka yang diadakan pada 27 Julai 1955.",
-                "catalog_data": {
-                    "catalog_filters": {
-                        "frequency": "INFREQUENT",
-                        "geographic": [
-                            "PARLIMEN",
-                            "STATE",
-                            "NATIONAL"
-                        ],
-                        "demographic": [],
-                        "start": "1982",
-                        "end": "1982",
-                        "data_source": [
-                            "SPR"
-                        ]
-                    },
-                    "metadata_neutral": {
-                        "data_as_of": "1955-08-31 23:59",
-                        "last_updated": "2023-07-18 23:59",
-                        "next_update": "-"
-                    },
-                    "metadata_lang": {
-                        "en": {
-                            "methodology": "This data is a digital representation of the physical election results tabulated and gazetted per the Electoral Regulations (Conduct of Elections). The digitalisation process was rigorously cross-checked against physical records to ensure consistency and accuracy of information.",
-                            "caveat": "As of now, this data has not been verified by SPR, and is shown here on the staging site to provide easy access for exploring and checking the data.",
-                            "publication": "-"
-                        },
-                        "bm": {
-                            "methodology": "Data ini merupakan rekod digital keputusan pilihanraya yang dikira dan diwartakan selaras dengan Peraturan-Peraturan Pilihan Raya (Penjalanan Pilihan Raya). Proses pendigitalan disemak silang dengan rekod fizikal untuk memastikan ketepatan maklumat.",
-                            "caveat": "Setakat sekarang, data ini belum disemak dan diabsahkan oleh SPR, maka hanya dipaparkan di portal UAT ini bagi tujuan memudahkan proses semakan.",
-                            "publication": "-"
-                        }
-                    },
-                    "chart": {
-                        "chart_type": "TABLE",
-                        "chart_filters": {
-                            "SLICE_BY": [],
-                            "precision": 0
-                        },
-                        "chart_variables": {
-                            "parents": [],
-                            "exclude": [],
-                            "freeze": [
-                                "state",
-                                "parlimen"
-                            ]
-                        }
-                    }
-                }
-            },
-            {
-                "id": -1,
-                "name": "state",
-                "title_en": "State",
-                "title_bm": "Negeri",
-                "desc_en": "[String] 1 of 16 states",
-                "desc_bm": "[Rentetan] 1 antara 16 negeri"
-            },
-            {
-                "id": -1,
-                "name": "parlimen",
-                "title_en": "Parliament",
-                "title_bm": "Parlimen",
-                "desc_en": "[String] Name of seat as it appeared on the ballot on voting day",
-                "desc_bm": "[Rentetan] Nama kerusi seperti mana yang tertera di kertas undi pada hari mengundi"
-            },
-            {
-                "id": -1,
-                "name": "area_name",
-                "title_en": "Area Name",
-                "title_bm": "Nama Kawasan",
-                "desc_en": "[String] Name of the area, with seat code (P.xxx) stripped out, and area name historically harmonised. For example, Kota Baharu, Kota Bahru and Kota Bharu are all harmonised to the modern Kota Bharu.",
-                "desc_bm": "[Rentetan] Nama kawasan, tanpa kod kerusi (P.xxx) dan namanya diselaraskan mengambil kira perubahan dari zaman ke zaman. Contohnya, nama Kota Baharu, Kota Bahru, dan Kota Bharu semuanya diharmonikan kepada penggunaan moden iaitu Kota Bharu."
-            },
-            {
-                "id": -1,
-                "name": "ballot_order",
-                "title_en": "Ballot Order",
-                "title_bm": "Urutan Nama",
-                "desc_en": "[Integer] Order in which the candidate appears on the ballot",
-                "desc_bm": "[Integer] Urutan nama-nama yang tertera pada kertas undi"
-            },
-            {
-                "id": -1,
-                "name": "name",
-                "title_en": "Name",
-                "title_bm": "Nama",
-                "desc_en": "[String] Name of candidate as it appeared on the ballot on voting day; this may not be the same as their real name as candidates are free to choose the name they use for campaigning and voting",
-                "desc_bm": "[Rentetan] Nama calon seperti mana yang tertera di kertas undi pada hari mengundi; ini tidak semestinya sama dengan nama sebenar mereka kerana calon adalah bebas untuk memilih nama yang digunakan bagi tujuan kempen dan undi"
-            },
-            {
-                "id": -1,
-                "name": "candidate_uid",
-                "title_en": "Unique Candidate ID",
-                "title_bm": "ID Unik Calon",
-                "desc_en": "[Integer] Unique integer identifier to track candidates across elections",
-                "desc_bm": "[Integer] Integer unik untuk menjejaki keputusan seseorang calon merentasi pilihan raya"
-            },
-            {
-                "id": -1,
-                "name": "party",
-                "title_en": "Party",
-                "title_bm": "Parti",
-                "desc_en": "[String] Party of the candidate as it appeared on the ballot on voting day; this record is not amended to reflect unofficial information on parties and coalitions. For example, if a candidate competed under the flag of Party X despite being a member of Party Y, their party is recorded as Party X.",
-                "desc_bm": "[String] Parti calon seperti yang tertera pada kertas undi pada hari mengundi; rekod ini tidak dipinda untuk menggambarkan maklumat tidak rasmi mengenai parti dan gabungan. Sebagai contoh, jika calon bertanding bawah bendera Parti X walaupun menjadi ahli Parti Y, parti mereka direkodkan sebagai Parti X."
-            },
-            {
-                "id": -1,
-                "name": "votes",
-                "title_en": "Votes",
-                "title_bm": "Undi",
-                "desc_en": "Integer] Number of votes won by the candidate",
-                "desc_bm": "[Integer] Jumlah undi yang diperolehi oleh calon"
-            }
-        ]
-    }
+	"file": {
+		"manual_trigger": 0,
+		"bucket": "elections_federal",
+		"file_name": "ge06_ballots",
+		"category": "ELECTIONS",
+		"category_en": "Elections",
+		"category_bm": "Pilihanraya",
+		"subcategory": "FEDERAL",
+		"subcategory_en": "Federal",
+		"subcategory_bm": "Persekutuan",
+		"description": {
+			"en": "Ballots for every seat contested at the pre-Independence general election held in 1955.",
+			"bm": "Perincian undi bagi setiap kerusi yang dipertandingkan di pilihanraya umum pramerdeka yang diadakan pada tahun 1955."
+		},
+		"link_parquet": "https://storage.data.gov.my/elections/federal/ge06_ballots.parquet",
+		"link_csv": "https://storage.data.gov.my/elections/federal/ge06_ballots.csv",
+		"link_preview": "https://storage.data.gov.my/elections/federal/ge06_ballots.parquet",
+		"variables": [
+			{
+				"id": 0,
+				"name": "ge06_ballots",
+				"title_en": "GE-06: Ballots",
+				"title_bm": "PRU-06: Kertas Undi",
+				"desc_en": "Ballots for every seat contested at the pre-Independence general election held on 27 July 1955.",
+				"desc_bm": "Perincian undi bagi setiap kerusi yang dipertandingkan di pilihanraya umum pramerdeka yang diadakan pada 27 Julai 1955.",
+				"catalog_data": {
+					"catalog_filters": {
+						"frequency": "INFREQUENT",
+						"geography": ["PARLIMEN", "STATE", "NATIONAL"],
+						"demographic": [],
+						"start": "1982",
+						"end": "1982",
+						"data_source": ["SPR"]
+					},
+					"metadata_neutral": {
+						"data_as_of": "1955-08-31 23:59",
+						"last_updated": "2023-07-18 23:59",
+						"next_update": "-"
+					},
+					"metadata_lang": {
+						"en": {
+							"methodology": "This data is a digital representation of the physical election results tabulated and gazetted per the Electoral Regulations (Conduct of Elections). The digitalisation process was rigorously cross-checked against physical records to ensure consistency and accuracy of information.",
+							"caveat": "As of now, this data has not been verified by SPR, and is shown here on the staging site to provide easy access for exploring and checking the data.",
+							"publication": "-"
+						},
+						"bm": {
+							"methodology": "Data ini merupakan rekod digital keputusan pilihanraya yang dikira dan diwartakan selaras dengan Peraturan-Peraturan Pilihan Raya (Penjalanan Pilihan Raya). Proses pendigitalan disemak silang dengan rekod fizikal untuk memastikan ketepatan maklumat.",
+							"caveat": "Setakat sekarang, data ini belum disemak dan diabsahkan oleh SPR, maka hanya dipaparkan di portal UAT ini bagi tujuan memudahkan proses semakan.",
+							"publication": "-"
+						}
+					},
+					"chart": {
+						"chart_type": "TABLE",
+						"chart_filters": {
+							"SLICE_BY": [],
+							"precision": 0
+						},
+						"chart_variables": {
+							"parents": [],
+							"exclude": [],
+							"freeze": ["state", "parlimen"]
+						}
+					}
+				}
+			},
+			{
+				"id": -1,
+				"name": "state",
+				"title_en": "State",
+				"title_bm": "Negeri",
+				"desc_en": "[String] 1 of 16 states",
+				"desc_bm": "[Rentetan] 1 antara 16 negeri"
+			},
+			{
+				"id": -1,
+				"name": "parlimen",
+				"title_en": "Parliament",
+				"title_bm": "Parlimen",
+				"desc_en": "[String] Name of seat as it appeared on the ballot on voting day",
+				"desc_bm": "[Rentetan] Nama kerusi seperti mana yang tertera di kertas undi pada hari mengundi"
+			},
+			{
+				"id": -1,
+				"name": "area_name",
+				"title_en": "Area Name",
+				"title_bm": "Nama Kawasan",
+				"desc_en": "[String] Name of the area, with seat code (P.xxx) stripped out, and area name historically harmonised. For example, Kota Baharu, Kota Bahru and Kota Bharu are all harmonised to the modern Kota Bharu.",
+				"desc_bm": "[Rentetan] Nama kawasan, tanpa kod kerusi (P.xxx) dan namanya diselaraskan mengambil kira perubahan dari zaman ke zaman. Contohnya, nama Kota Baharu, Kota Bahru, dan Kota Bharu semuanya diharmonikan kepada penggunaan moden iaitu Kota Bharu."
+			},
+			{
+				"id": -1,
+				"name": "ballot_order",
+				"title_en": "Ballot Order",
+				"title_bm": "Urutan Nama",
+				"desc_en": "[Integer] Order in which the candidate appears on the ballot",
+				"desc_bm": "[Integer] Urutan nama-nama yang tertera pada kertas undi"
+			},
+			{
+				"id": -1,
+				"name": "name",
+				"title_en": "Name",
+				"title_bm": "Nama",
+				"desc_en": "[String] Name of candidate as it appeared on the ballot on voting day; this may not be the same as their real name as candidates are free to choose the name they use for campaigning and voting",
+				"desc_bm": "[Rentetan] Nama calon seperti mana yang tertera di kertas undi pada hari mengundi; ini tidak semestinya sama dengan nama sebenar mereka kerana calon adalah bebas untuk memilih nama yang digunakan bagi tujuan kempen dan undi"
+			},
+			{
+				"id": -1,
+				"name": "candidate_uid",
+				"title_en": "Unique Candidate ID",
+				"title_bm": "ID Unik Calon",
+				"desc_en": "[Integer] Unique integer identifier to track candidates across elections",
+				"desc_bm": "[Integer] Integer unik untuk menjejaki keputusan seseorang calon merentasi pilihan raya"
+			},
+			{
+				"id": -1,
+				"name": "party",
+				"title_en": "Party",
+				"title_bm": "Parti",
+				"desc_en": "[String] Party of the candidate as it appeared on the ballot on voting day; this record is not amended to reflect unofficial information on parties and coalitions. For example, if a candidate competed under the flag of Party X despite being a member of Party Y, their party is recorded as Party X.",
+				"desc_bm": "[String] Parti calon seperti yang tertera pada kertas undi pada hari mengundi; rekod ini tidak dipinda untuk menggambarkan maklumat tidak rasmi mengenai parti dan gabungan. Sebagai contoh, jika calon bertanding bawah bendera Parti X walaupun menjadi ahli Parti Y, parti mereka direkodkan sebagai Parti X."
+			},
+			{
+				"id": -1,
+				"name": "votes",
+				"title_en": "Votes",
+				"title_bm": "Undi",
+				"desc_en": "Integer] Number of votes won by the candidate",
+				"desc_bm": "[Integer] Jumlah undi yang diperolehi oleh calon"
+			}
+		]
+	}
 }

--- a/catalog/ge06_summary.json
+++ b/catalog/ge06_summary.json
@@ -1,150 +1,141 @@
 {
-    "file": {
-        "manual_trigger": 0,
-        "bucket": "elections_federal",
-        "file_name": "ge06_summary",
-        "category": "ELECTIONS",
-        "category_en": "Elections",
-        "category_bm": "Pilihanraya",
-        "subcategory": "FEDERAL",
-        "subcategory_en": "Federal",
-        "subcategory_bm": "Persekutuan",
-        "description": {
-            "en": "Analytical summary of the pre-Independence general election held in 1955.",
-            "bm": "Ringkasan analitik bagi pilihanraya umum pramerdeka yang diadakan pada tahun 1955."
-        },
-        "link_parquet": "https://storage.data.gov.my/elections/federal/ge06_summary.parquet",
-        "link_csv": "https://storage.data.gov.my/elections/federal/ge06_summary.csv",
-        "link_preview": "https://storage.data.gov.my/elections/federal/ge06_summary.parquet",
-        "variables": [
-            {
-                "id": 0,
-                "name": "ge06_summary",
-                "title_en": "GE-06: Summary",
-                "title_bm": "PRU-06: Rumusan",
-                "desc_en": "Analytical summary of the pre-Independence general election held on 27 July 1955.",
-                "desc_bm": "Ringkasan analitik bagi pilihanraya umum pramerdeka yang diadakan pada 27 Julai 1955.",
-                "catalog_data": {
-                    "catalog_filters": {
-                        "frequency": "INFREQUENT",
-                        "geographic": [
-                            "PARLIMEN",
-                            "STATE",
-                            "NATIONAL"
-                        ],
-                        "demographic": [],
-                        "start": "1982",
-                        "end": "1982",
-                        "data_source": [
-                            "SPR"
-                        ]
-                    },
-                    "metadata_neutral": {
-                        "data_as_of": "1955-08-31 23:59",
-                        "last_updated": "2023-07-18 23:59",
-                        "next_update": "-"
-                    },
-                    "metadata_lang": {
-                        "en": {
-                            "methodology": "This data is a digital representation of the physical election results tabulated and gazetted per the Electoral Regulations (Conduct of Elections). The digitalisation process was rigorously cross-checked against physical records to ensure consistency and accuracy of information.",
-                            "caveat": "As of now, this data has not been verified by SPR, and is shown here on the staging site to provide easy access for exploring and checking the data.",
-                            "publication": "-"
-                        },
-                        "bm": {
-                            "methodology": "Data ini merupakan rekod digital keputusan pilihanraya yang dikira dan diwartakan selaras dengan Peraturan-Peraturan Pilihan Raya (Penjalanan Pilihan Raya). Proses pendigitalan disemak silang dengan rekod fizikal untuk memastikan ketepatan maklumat.",
-                            "caveat": "Setakat sekarang, data ini belum disemak dan diabsahkan oleh SPR, maka hanya dipaparkan di portal UAT ini bagi tujuan memudahkan proses semakan.",
-                            "publication": "-"
-                        }
-                    },
-                    "chart": {
-                        "chart_type": "TABLE",
-                        "chart_filters": {
-                            "SLICE_BY": [],
-                            "precision": 0
-                        },
-                        "chart_variables": {
-                            "parents": [],
-                            "exclude": [],
-                            "freeze": [
-                                "state",
-                                "parlimen"
-                            ]
-                        }
-                    }
-                }
-            },
-            {
-                "id": -1,
-                "name": "state",
-                "title_en": "State",
-                "title_bm": "Negeri",
-                "desc_en": "[String] 1 of 16 states",
-                "desc_bm": "[Rentetan] 1 antara 16 negeri"
-            },
-            {
-                "id": -1,
-                "name": "parlimen",
-                "title_en": "Parliament",
-                "title_bm": "Parlimen",
-                "desc_en": "[String] Name of seat as it appeared on the ballot on voting day",
-                "desc_bm": "[Rentetan] Nama kerusi seperti mana yang tertera di kertas undi pada hari mengundi"
-            },
-            {
-                "id": -1,
-                "name": "area_name",
-                "title_en": "Area Name",
-                "title_bm": "Nama Kawasan",
-                "desc_en": "[String] Name of the area, with seat code (P.xxx) stripped out, and area name historically harmonised. For example, Kota Baharu, Kota Bahru and Kota Bharu are all harmonised to the modern Kota Bharu.",
-                "desc_bm": "[Rentetan] Nama kawasan, tanpa kod kerusi (P.xxx) dan namanya diselaraskan mengambil kira perubahan dari zaman ke zaman. Contohnya, nama Kota Baharu, Kota Bahru, dan Kota Bharu semuanya diharmonikan kepada penggunaan moden iaitu Kota Bharu."
-            },
-            {
-                "id": -1,
-                "name": "voters_total",
-                "title_en": "Total Voters",
-                "title_bm": "Jumlah Pengundi",
-                "desc_en": "[Integer] Number of voters registered to vote in that seat at that election",
-                "desc_bm": "[Integer] Jumlah pengundi yang didaftarkan untuk mengundi di kerusi tersebut semasa PRU-00"
-            },
-            {
-                "id": -1,
-                "name": "ballots_issued",
-                "title_en": "Ballots Issued",
-                "title_bm": "Undi Dikeluarkan",
-                "desc_en": "[Integer] Number of ballots issued, including postal ballots, but not inclduing ballots accidentally damaged and immediately replace during the voting procedure",
-                "desc_bm": "[Integer] Jumlah kertas undi yang dikeluarkan, termasuk kertas undi pos, tetapi tidak termasuk kertas undi yang rosak dan terus digantikan semasa urusan mengundi dijalankan"
-            },
-            {
-                "id": -1,
-                "name": "ballots_not_returned",
-                "title_en": "Ballots Not Returned",
-                "title_bm": "Undi Tidak Dikembalikan",
-                "desc_en": "[Integer] Number of ballots issued but not returned for counting, including postal ballots not returned to the counting centre in time, but excluding spoilt ballots (e.g. torn or stained) which were replaced and therefore not counted as ballots issued",
-                "desc_bm": "[Integer] Jumlah kertas undi yang dikeluarkan tetapi tidak dikembalikan untuk pengiraan undi, termasuk kertas undi pos yang tidak dikembalikan ke pusat kiraan undi, tetapi tidak termasuk kertas undi rosak (contohnya terkoyak atau ternoda) yang telah digantikan maka tidak dikira sebagai kertas undi yang dikeluarkan"
-            },
-            {
-                "id": -1,
-                "name": "votes_rejected",
-                "title_en": "Votes Rejected",
-                "title_bm": "Undi Ditolak",
-                "desc_en": "[Integer] Number of ballots returned but declared invalid during counting because the candidate could not be determined",
-                "desc_bm": "[Integer] Jumlah kertas undi yang telah dikembalikan tetapi ditolak semasa proses kiraan undi kerana calon yang diundi tidak dapat ditentukan"
-            },
-            {
-                "id": -1,
-                "name": "voter_turnout",
-                "title_en": "Voter Turnout",
-                "title_bm": "Peratus Keluar",
-                "desc_en": "[Float] Derived as: (ballots_issued / voters_total) * 100",
-                "desc_bm": " [Apung] Diperolehi dengan formula: (ballots_issued / voters_total) * 100"
-            },
-            {
-                "id": -1,
-                "name": "votes_rejected_perc",
-                "title_en": "Percentage Rejected",
-                "title_bm": "Peratus Ditolak",
-                "desc_en": "[Float] Derived as: (votes_rejected / (ballots_issued - ballots_not_returned)) * 100",
-                "desc_bm": " [Apung] Diperolehi dengan formula: (votes_rejected / (ballots_issued - ballots_not_returned)) * 100"
-            }
-        ]
-    }
+	"file": {
+		"manual_trigger": 0,
+		"bucket": "elections_federal",
+		"file_name": "ge06_summary",
+		"category": "ELECTIONS",
+		"category_en": "Elections",
+		"category_bm": "Pilihanraya",
+		"subcategory": "FEDERAL",
+		"subcategory_en": "Federal",
+		"subcategory_bm": "Persekutuan",
+		"description": {
+			"en": "Analytical summary of the pre-Independence general election held in 1955.",
+			"bm": "Ringkasan analitik bagi pilihanraya umum pramerdeka yang diadakan pada tahun 1955."
+		},
+		"link_parquet": "https://storage.data.gov.my/elections/federal/ge06_summary.parquet",
+		"link_csv": "https://storage.data.gov.my/elections/federal/ge06_summary.csv",
+		"link_preview": "https://storage.data.gov.my/elections/federal/ge06_summary.parquet",
+		"variables": [
+			{
+				"id": 0,
+				"name": "ge06_summary",
+				"title_en": "GE-06: Summary",
+				"title_bm": "PRU-06: Rumusan",
+				"desc_en": "Analytical summary of the pre-Independence general election held on 27 July 1955.",
+				"desc_bm": "Ringkasan analitik bagi pilihanraya umum pramerdeka yang diadakan pada 27 Julai 1955.",
+				"catalog_data": {
+					"catalog_filters": {
+						"frequency": "INFREQUENT",
+						"geography": ["PARLIMEN", "STATE", "NATIONAL"],
+						"demographic": [],
+						"start": "1982",
+						"end": "1982",
+						"data_source": ["SPR"]
+					},
+					"metadata_neutral": {
+						"data_as_of": "1955-08-31 23:59",
+						"last_updated": "2023-07-18 23:59",
+						"next_update": "-"
+					},
+					"metadata_lang": {
+						"en": {
+							"methodology": "This data is a digital representation of the physical election results tabulated and gazetted per the Electoral Regulations (Conduct of Elections). The digitalisation process was rigorously cross-checked against physical records to ensure consistency and accuracy of information.",
+							"caveat": "As of now, this data has not been verified by SPR, and is shown here on the staging site to provide easy access for exploring and checking the data.",
+							"publication": "-"
+						},
+						"bm": {
+							"methodology": "Data ini merupakan rekod digital keputusan pilihanraya yang dikira dan diwartakan selaras dengan Peraturan-Peraturan Pilihan Raya (Penjalanan Pilihan Raya). Proses pendigitalan disemak silang dengan rekod fizikal untuk memastikan ketepatan maklumat.",
+							"caveat": "Setakat sekarang, data ini belum disemak dan diabsahkan oleh SPR, maka hanya dipaparkan di portal UAT ini bagi tujuan memudahkan proses semakan.",
+							"publication": "-"
+						}
+					},
+					"chart": {
+						"chart_type": "TABLE",
+						"chart_filters": {
+							"SLICE_BY": [],
+							"precision": 0
+						},
+						"chart_variables": {
+							"parents": [],
+							"exclude": [],
+							"freeze": ["state", "parlimen"]
+						}
+					}
+				}
+			},
+			{
+				"id": -1,
+				"name": "state",
+				"title_en": "State",
+				"title_bm": "Negeri",
+				"desc_en": "[String] 1 of 16 states",
+				"desc_bm": "[Rentetan] 1 antara 16 negeri"
+			},
+			{
+				"id": -1,
+				"name": "parlimen",
+				"title_en": "Parliament",
+				"title_bm": "Parlimen",
+				"desc_en": "[String] Name of seat as it appeared on the ballot on voting day",
+				"desc_bm": "[Rentetan] Nama kerusi seperti mana yang tertera di kertas undi pada hari mengundi"
+			},
+			{
+				"id": -1,
+				"name": "area_name",
+				"title_en": "Area Name",
+				"title_bm": "Nama Kawasan",
+				"desc_en": "[String] Name of the area, with seat code (P.xxx) stripped out, and area name historically harmonised. For example, Kota Baharu, Kota Bahru and Kota Bharu are all harmonised to the modern Kota Bharu.",
+				"desc_bm": "[Rentetan] Nama kawasan, tanpa kod kerusi (P.xxx) dan namanya diselaraskan mengambil kira perubahan dari zaman ke zaman. Contohnya, nama Kota Baharu, Kota Bahru, dan Kota Bharu semuanya diharmonikan kepada penggunaan moden iaitu Kota Bharu."
+			},
+			{
+				"id": -1,
+				"name": "voters_total",
+				"title_en": "Total Voters",
+				"title_bm": "Jumlah Pengundi",
+				"desc_en": "[Integer] Number of voters registered to vote in that seat at that election",
+				"desc_bm": "[Integer] Jumlah pengundi yang didaftarkan untuk mengundi di kerusi tersebut semasa PRU-00"
+			},
+			{
+				"id": -1,
+				"name": "ballots_issued",
+				"title_en": "Ballots Issued",
+				"title_bm": "Undi Dikeluarkan",
+				"desc_en": "[Integer] Number of ballots issued, including postal ballots, but not inclduing ballots accidentally damaged and immediately replace during the voting procedure",
+				"desc_bm": "[Integer] Jumlah kertas undi yang dikeluarkan, termasuk kertas undi pos, tetapi tidak termasuk kertas undi yang rosak dan terus digantikan semasa urusan mengundi dijalankan"
+			},
+			{
+				"id": -1,
+				"name": "ballots_not_returned",
+				"title_en": "Ballots Not Returned",
+				"title_bm": "Undi Tidak Dikembalikan",
+				"desc_en": "[Integer] Number of ballots issued but not returned for counting, including postal ballots not returned to the counting centre in time, but excluding spoilt ballots (e.g. torn or stained) which were replaced and therefore not counted as ballots issued",
+				"desc_bm": "[Integer] Jumlah kertas undi yang dikeluarkan tetapi tidak dikembalikan untuk pengiraan undi, termasuk kertas undi pos yang tidak dikembalikan ke pusat kiraan undi, tetapi tidak termasuk kertas undi rosak (contohnya terkoyak atau ternoda) yang telah digantikan maka tidak dikira sebagai kertas undi yang dikeluarkan"
+			},
+			{
+				"id": -1,
+				"name": "votes_rejected",
+				"title_en": "Votes Rejected",
+				"title_bm": "Undi Ditolak",
+				"desc_en": "[Integer] Number of ballots returned but declared invalid during counting because the candidate could not be determined",
+				"desc_bm": "[Integer] Jumlah kertas undi yang telah dikembalikan tetapi ditolak semasa proses kiraan undi kerana calon yang diundi tidak dapat ditentukan"
+			},
+			{
+				"id": -1,
+				"name": "voter_turnout",
+				"title_en": "Voter Turnout",
+				"title_bm": "Peratus Keluar",
+				"desc_en": "[Float] Derived as: (ballots_issued / voters_total) * 100",
+				"desc_bm": " [Apung] Diperolehi dengan formula: (ballots_issued / voters_total) * 100"
+			},
+			{
+				"id": -1,
+				"name": "votes_rejected_perc",
+				"title_en": "Percentage Rejected",
+				"title_bm": "Peratus Ditolak",
+				"desc_en": "[Float] Derived as: (votes_rejected / (ballots_issued - ballots_not_returned)) * 100",
+				"desc_bm": " [Apung] Diperolehi dengan formula: (votes_rejected / (ballots_issued - ballots_not_returned)) * 100"
+			}
+		]
+	}
 }

--- a/catalog/ge06_summary.json
+++ b/catalog/ge06_summary.json
@@ -28,7 +28,7 @@
 					"catalog_filters": {
 						"frequency": "INFREQUENT",
 						"geography": ["PARLIMEN", "STATE", "NATIONAL"],
-						"demographic": [],
+						"demography": [],
 						"start": "1982",
 						"end": "1982",
 						"data_source": ["SPR"]

--- a/catalog/ge07_ballots.json
+++ b/catalog/ge07_ballots.json
@@ -28,7 +28,7 @@
 					"catalog_filters": {
 						"frequency": "INFREQUENT",
 						"geography": ["PARLIMEN", "STATE", "NATIONAL"],
-						"demographic": [],
+						"demography": [],
 						"start": "1986",
 						"end": "1986",
 						"data_source": ["SPR"]

--- a/catalog/ge07_ballots.json
+++ b/catalog/ge07_ballots.json
@@ -1,142 +1,133 @@
 {
-    "file": {
-        "manual_trigger": 0,
-        "bucket": "elections_federal",
-        "file_name": "ge07_ballots",
-        "category": "ELECTIONS",
-        "category_en": "Elections",
-        "category_bm": "Pilihanraya",
-        "subcategory": "FEDERAL",
-        "subcategory_en": "Federal",
-        "subcategory_bm": "Persekutuan",
-        "description": {
-            "en": "Ballots for every seat contested at the pre-Independence general election held in 1955.",
-            "bm": "Perincian undi bagi setiap kerusi yang dipertandingkan di pilihanraya umum pramerdeka yang diadakan pada tahun 1955."
-        },
-        "link_parquet": "https://storage.data.gov.my/elections/federal/ge07_ballots.parquet",
-        "link_csv": "https://storage.data.gov.my/elections/federal/ge07_ballots.csv",
-        "link_preview": "https://storage.data.gov.my/elections/federal/ge07_ballots.parquet",
-        "variables": [
-            {
-                "id": 0,
-                "name": "ge07_ballots",
-                "title_en": "GE-07: Ballots",
-                "title_bm": "PRU-07: Kertas Undi",
-                "desc_en": "Ballots for every seat contested at the pre-Independence general election held on 27 July 1955.",
-                "desc_bm": "Perincian undi bagi setiap kerusi yang dipertandingkan di pilihanraya umum pramerdeka yang diadakan pada 27 Julai 1955.",
-                "catalog_data": {
-                    "catalog_filters": {
-                        "frequency": "INFREQUENT",
-                        "geographic": [
-                            "PARLIMEN",
-                            "STATE",
-                            "NATIONAL"
-                        ],
-                        "demographic": [],
-                        "start": "1986",
-                        "end": "1986",
-                        "data_source": [
-                            "SPR"
-                        ]
-                    },
-                    "metadata_neutral": {
-                        "data_as_of": "1955-08-31 23:59",
-                        "last_updated": "2023-07-18 23:59",
-                        "next_update": "-"
-                    },
-                    "metadata_lang": {
-                        "en": {
-                            "methodology": "This data is a digital representation of the physical election results tabulated and gazetted per the Electoral Regulations (Conduct of Elections). The digitalisation process was rigorously cross-checked against physical records to ensure consistency and accuracy of information.",
-                            "caveat": "As of now, this data has not been verified by SPR, and is shown here on the staging site to provide easy access for exploring and checking the data.",
-                            "publication": "-"
-                        },
-                        "bm": {
-                            "methodology": "Data ini merupakan rekod digital keputusan pilihanraya yang dikira dan diwartakan selaras dengan Peraturan-Peraturan Pilihan Raya (Penjalanan Pilihan Raya). Proses pendigitalan disemak silang dengan rekod fizikal untuk memastikan ketepatan maklumat.",
-                            "caveat": "Setakat sekarang, data ini belum disemak dan diabsahkan oleh SPR, maka hanya dipaparkan di portal UAT ini bagi tujuan memudahkan proses semakan.",
-                            "publication": "-"
-                        }
-                    },
-                    "chart": {
-                        "chart_type": "TABLE",
-                        "chart_filters": {
-                            "SLICE_BY": [],
-                            "precision": 0
-                        },
-                        "chart_variables": {
-                            "parents": [],
-                            "exclude": [],
-                            "freeze": [
-                                "state",
-                                "parlimen"
-                            ]
-                        }
-                    }
-                }
-            },
-            {
-                "id": -1,
-                "name": "state",
-                "title_en": "State",
-                "title_bm": "Negeri",
-                "desc_en": "[String] 1 of 16 states",
-                "desc_bm": "[Rentetan] 1 antara 16 negeri"
-            },
-            {
-                "id": -1,
-                "name": "parlimen",
-                "title_en": "Parliament",
-                "title_bm": "Parlimen",
-                "desc_en": "[String] Name of seat as it appeared on the ballot on voting day",
-                "desc_bm": "[Rentetan] Nama kerusi seperti mana yang tertera di kertas undi pada hari mengundi"
-            },
-            {
-                "id": -1,
-                "name": "area_name",
-                "title_en": "Area Name",
-                "title_bm": "Nama Kawasan",
-                "desc_en": "[String] Name of the area, with seat code (P.xxx) stripped out, and area name historically harmonised. For example, Kota Baharu, Kota Bahru and Kota Bharu are all harmonised to the modern Kota Bharu.",
-                "desc_bm": "[Rentetan] Nama kawasan, tanpa kod kerusi (P.xxx) dan namanya diselaraskan mengambil kira perubahan dari zaman ke zaman. Contohnya, nama Kota Baharu, Kota Bahru, dan Kota Bharu semuanya diharmonikan kepada penggunaan moden iaitu Kota Bharu."
-            },
-            {
-                "id": -1,
-                "name": "ballot_order",
-                "title_en": "Ballot Order",
-                "title_bm": "Urutan Nama",
-                "desc_en": "[Integer] Order in which the candidate appears on the ballot",
-                "desc_bm": "[Integer] Urutan nama-nama yang tertera pada kertas undi"
-            },
-            {
-                "id": -1,
-                "name": "name",
-                "title_en": "Name",
-                "title_bm": "Nama",
-                "desc_en": "[String] Name of candidate as it appeared on the ballot on voting day; this may not be the same as their real name as candidates are free to choose the name they use for campaigning and voting",
-                "desc_bm": "[Rentetan] Nama calon seperti mana yang tertera di kertas undi pada hari mengundi; ini tidak semestinya sama dengan nama sebenar mereka kerana calon adalah bebas untuk memilih nama yang digunakan bagi tujuan kempen dan undi"
-            },
-            {
-                "id": -1,
-                "name": "candidate_uid",
-                "title_en": "Unique Candidate ID",
-                "title_bm": "ID Unik Calon",
-                "desc_en": "[Integer] Unique integer identifier to track candidates across elections",
-                "desc_bm": "[Integer] Integer unik untuk menjejaki keputusan seseorang calon merentasi pilihan raya"
-            },
-            {
-                "id": -1,
-                "name": "party",
-                "title_en": "Party",
-                "title_bm": "Parti",
-                "desc_en": "[String] Party of the candidate as it appeared on the ballot on voting day; this record is not amended to reflect unofficial information on parties and coalitions. For example, if a candidate competed under the flag of Party X despite being a member of Party Y, their party is recorded as Party X.",
-                "desc_bm": "[String] Parti calon seperti yang tertera pada kertas undi pada hari mengundi; rekod ini tidak dipinda untuk menggambarkan maklumat tidak rasmi mengenai parti dan gabungan. Sebagai contoh, jika calon bertanding bawah bendera Parti X walaupun menjadi ahli Parti Y, parti mereka direkodkan sebagai Parti X."
-            },
-            {
-                "id": -1,
-                "name": "votes",
-                "title_en": "Votes",
-                "title_bm": "Undi",
-                "desc_en": "Integer] Number of votes won by the candidate",
-                "desc_bm": "[Integer] Jumlah undi yang diperolehi oleh calon"
-            }
-        ]
-    }
+	"file": {
+		"manual_trigger": 0,
+		"bucket": "elections_federal",
+		"file_name": "ge07_ballots",
+		"category": "ELECTIONS",
+		"category_en": "Elections",
+		"category_bm": "Pilihanraya",
+		"subcategory": "FEDERAL",
+		"subcategory_en": "Federal",
+		"subcategory_bm": "Persekutuan",
+		"description": {
+			"en": "Ballots for every seat contested at the pre-Independence general election held in 1955.",
+			"bm": "Perincian undi bagi setiap kerusi yang dipertandingkan di pilihanraya umum pramerdeka yang diadakan pada tahun 1955."
+		},
+		"link_parquet": "https://storage.data.gov.my/elections/federal/ge07_ballots.parquet",
+		"link_csv": "https://storage.data.gov.my/elections/federal/ge07_ballots.csv",
+		"link_preview": "https://storage.data.gov.my/elections/federal/ge07_ballots.parquet",
+		"variables": [
+			{
+				"id": 0,
+				"name": "ge07_ballots",
+				"title_en": "GE-07: Ballots",
+				"title_bm": "PRU-07: Kertas Undi",
+				"desc_en": "Ballots for every seat contested at the pre-Independence general election held on 27 July 1955.",
+				"desc_bm": "Perincian undi bagi setiap kerusi yang dipertandingkan di pilihanraya umum pramerdeka yang diadakan pada 27 Julai 1955.",
+				"catalog_data": {
+					"catalog_filters": {
+						"frequency": "INFREQUENT",
+						"geography": ["PARLIMEN", "STATE", "NATIONAL"],
+						"demographic": [],
+						"start": "1986",
+						"end": "1986",
+						"data_source": ["SPR"]
+					},
+					"metadata_neutral": {
+						"data_as_of": "1955-08-31 23:59",
+						"last_updated": "2023-07-18 23:59",
+						"next_update": "-"
+					},
+					"metadata_lang": {
+						"en": {
+							"methodology": "This data is a digital representation of the physical election results tabulated and gazetted per the Electoral Regulations (Conduct of Elections). The digitalisation process was rigorously cross-checked against physical records to ensure consistency and accuracy of information.",
+							"caveat": "As of now, this data has not been verified by SPR, and is shown here on the staging site to provide easy access for exploring and checking the data.",
+							"publication": "-"
+						},
+						"bm": {
+							"methodology": "Data ini merupakan rekod digital keputusan pilihanraya yang dikira dan diwartakan selaras dengan Peraturan-Peraturan Pilihan Raya (Penjalanan Pilihan Raya). Proses pendigitalan disemak silang dengan rekod fizikal untuk memastikan ketepatan maklumat.",
+							"caveat": "Setakat sekarang, data ini belum disemak dan diabsahkan oleh SPR, maka hanya dipaparkan di portal UAT ini bagi tujuan memudahkan proses semakan.",
+							"publication": "-"
+						}
+					},
+					"chart": {
+						"chart_type": "TABLE",
+						"chart_filters": {
+							"SLICE_BY": [],
+							"precision": 0
+						},
+						"chart_variables": {
+							"parents": [],
+							"exclude": [],
+							"freeze": ["state", "parlimen"]
+						}
+					}
+				}
+			},
+			{
+				"id": -1,
+				"name": "state",
+				"title_en": "State",
+				"title_bm": "Negeri",
+				"desc_en": "[String] 1 of 16 states",
+				"desc_bm": "[Rentetan] 1 antara 16 negeri"
+			},
+			{
+				"id": -1,
+				"name": "parlimen",
+				"title_en": "Parliament",
+				"title_bm": "Parlimen",
+				"desc_en": "[String] Name of seat as it appeared on the ballot on voting day",
+				"desc_bm": "[Rentetan] Nama kerusi seperti mana yang tertera di kertas undi pada hari mengundi"
+			},
+			{
+				"id": -1,
+				"name": "area_name",
+				"title_en": "Area Name",
+				"title_bm": "Nama Kawasan",
+				"desc_en": "[String] Name of the area, with seat code (P.xxx) stripped out, and area name historically harmonised. For example, Kota Baharu, Kota Bahru and Kota Bharu are all harmonised to the modern Kota Bharu.",
+				"desc_bm": "[Rentetan] Nama kawasan, tanpa kod kerusi (P.xxx) dan namanya diselaraskan mengambil kira perubahan dari zaman ke zaman. Contohnya, nama Kota Baharu, Kota Bahru, dan Kota Bharu semuanya diharmonikan kepada penggunaan moden iaitu Kota Bharu."
+			},
+			{
+				"id": -1,
+				"name": "ballot_order",
+				"title_en": "Ballot Order",
+				"title_bm": "Urutan Nama",
+				"desc_en": "[Integer] Order in which the candidate appears on the ballot",
+				"desc_bm": "[Integer] Urutan nama-nama yang tertera pada kertas undi"
+			},
+			{
+				"id": -1,
+				"name": "name",
+				"title_en": "Name",
+				"title_bm": "Nama",
+				"desc_en": "[String] Name of candidate as it appeared on the ballot on voting day; this may not be the same as their real name as candidates are free to choose the name they use for campaigning and voting",
+				"desc_bm": "[Rentetan] Nama calon seperti mana yang tertera di kertas undi pada hari mengundi; ini tidak semestinya sama dengan nama sebenar mereka kerana calon adalah bebas untuk memilih nama yang digunakan bagi tujuan kempen dan undi"
+			},
+			{
+				"id": -1,
+				"name": "candidate_uid",
+				"title_en": "Unique Candidate ID",
+				"title_bm": "ID Unik Calon",
+				"desc_en": "[Integer] Unique integer identifier to track candidates across elections",
+				"desc_bm": "[Integer] Integer unik untuk menjejaki keputusan seseorang calon merentasi pilihan raya"
+			},
+			{
+				"id": -1,
+				"name": "party",
+				"title_en": "Party",
+				"title_bm": "Parti",
+				"desc_en": "[String] Party of the candidate as it appeared on the ballot on voting day; this record is not amended to reflect unofficial information on parties and coalitions. For example, if a candidate competed under the flag of Party X despite being a member of Party Y, their party is recorded as Party X.",
+				"desc_bm": "[String] Parti calon seperti yang tertera pada kertas undi pada hari mengundi; rekod ini tidak dipinda untuk menggambarkan maklumat tidak rasmi mengenai parti dan gabungan. Sebagai contoh, jika calon bertanding bawah bendera Parti X walaupun menjadi ahli Parti Y, parti mereka direkodkan sebagai Parti X."
+			},
+			{
+				"id": -1,
+				"name": "votes",
+				"title_en": "Votes",
+				"title_bm": "Undi",
+				"desc_en": "Integer] Number of votes won by the candidate",
+				"desc_bm": "[Integer] Jumlah undi yang diperolehi oleh calon"
+			}
+		]
+	}
 }

--- a/catalog/ge07_summary.json
+++ b/catalog/ge07_summary.json
@@ -28,7 +28,7 @@
 					"catalog_filters": {
 						"frequency": "INFREQUENT",
 						"geography": ["PARLIMEN", "STATE", "NATIONAL"],
-						"demographic": [],
+						"demography": [],
 						"start": "1986",
 						"end": "1986",
 						"data_source": ["SPR"]

--- a/catalog/ge07_summary.json
+++ b/catalog/ge07_summary.json
@@ -1,150 +1,141 @@
 {
-    "file": {
-        "manual_trigger": 0,
-        "bucket": "elections_federal",
-        "file_name": "ge07_summary",
-        "category": "ELECTIONS",
-        "category_en": "Elections",
-        "category_bm": "Pilihanraya",
-        "subcategory": "FEDERAL",
-        "subcategory_en": "Federal",
-        "subcategory_bm": "Persekutuan",
-        "description": {
-            "en": "Analytical summary of the pre-Independence general election held in 1955.",
-            "bm": "Ringkasan analitik bagi pilihanraya umum pramerdeka yang diadakan pada tahun 1955."
-        },
-        "link_parquet": "https://storage.data.gov.my/elections/federal/ge07_summary.parquet",
-        "link_csv": "https://storage.data.gov.my/elections/federal/ge07_summary.csv",
-        "link_preview": "https://storage.data.gov.my/elections/federal/ge07_summary.parquet",
-        "variables": [
-            {
-                "id": 0,
-                "name": "ge07_summary",
-                "title_en": "GE-07: Summary",
-                "title_bm": "PRU-07: Rumusan",
-                "desc_en": "Analytical summary of the pre-Independence general election held on 27 July 1955.",
-                "desc_bm": "Ringkasan analitik bagi pilihanraya umum pramerdeka yang diadakan pada 27 Julai 1955.",
-                "catalog_data": {
-                    "catalog_filters": {
-                        "frequency": "INFREQUENT",
-                        "geographic": [
-                            "PARLIMEN",
-                            "STATE",
-                            "NATIONAL"
-                        ],
-                        "demographic": [],
-                        "start": "1986",
-                        "end": "1986",
-                        "data_source": [
-                            "SPR"
-                        ]
-                    },
-                    "metadata_neutral": {
-                        "data_as_of": "1955-08-31 23:59",
-                        "last_updated": "2023-07-18 23:59",
-                        "next_update": "-"
-                    },
-                    "metadata_lang": {
-                        "en": {
-                            "methodology": "This data is a digital representation of the physical election results tabulated and gazetted per the Electoral Regulations (Conduct of Elections). The digitalisation process was rigorously cross-checked against physical records to ensure consistency and accuracy of information.",
-                            "caveat": "As of now, this data has not been verified by SPR, and is shown here on the staging site to provide easy access for exploring and checking the data.",
-                            "publication": "-"
-                        },
-                        "bm": {
-                            "methodology": "Data ini merupakan rekod digital keputusan pilihanraya yang dikira dan diwartakan selaras dengan Peraturan-Peraturan Pilihan Raya (Penjalanan Pilihan Raya). Proses pendigitalan disemak silang dengan rekod fizikal untuk memastikan ketepatan maklumat.",
-                            "caveat": "Setakat sekarang, data ini belum disemak dan diabsahkan oleh SPR, maka hanya dipaparkan di portal UAT ini bagi tujuan memudahkan proses semakan.",
-                            "publication": "-"
-                        }
-                    },
-                    "chart": {
-                        "chart_type": "TABLE",
-                        "chart_filters": {
-                            "SLICE_BY": [],
-                            "precision": 0
-                        },
-                        "chart_variables": {
-                            "parents": [],
-                            "exclude": [],
-                            "freeze": [
-                                "state",
-                                "parlimen"
-                            ]
-                        }
-                    }
-                }
-            },
-            {
-                "id": -1,
-                "name": "state",
-                "title_en": "State",
-                "title_bm": "Negeri",
-                "desc_en": "[String] 1 of 16 states",
-                "desc_bm": "[Rentetan] 1 antara 16 negeri"
-            },
-            {
-                "id": -1,
-                "name": "parlimen",
-                "title_en": "Parliament",
-                "title_bm": "Parlimen",
-                "desc_en": "[String] Name of seat as it appeared on the ballot on voting day",
-                "desc_bm": "[Rentetan] Nama kerusi seperti mana yang tertera di kertas undi pada hari mengundi"
-            },
-            {
-                "id": -1,
-                "name": "area_name",
-                "title_en": "Area Name",
-                "title_bm": "Nama Kawasan",
-                "desc_en": "[String] Name of the area, with seat code (P.xxx) stripped out, and area name historically harmonised. For example, Kota Baharu, Kota Bahru and Kota Bharu are all harmonised to the modern Kota Bharu.",
-                "desc_bm": "[Rentetan] Nama kawasan, tanpa kod kerusi (P.xxx) dan namanya diselaraskan mengambil kira perubahan dari zaman ke zaman. Contohnya, nama Kota Baharu, Kota Bahru, dan Kota Bharu semuanya diharmonikan kepada penggunaan moden iaitu Kota Bharu."
-            },
-            {
-                "id": -1,
-                "name": "voters_total",
-                "title_en": "Total Voters",
-                "title_bm": "Jumlah Pengundi",
-                "desc_en": "[Integer] Number of voters registered to vote in that seat at that election",
-                "desc_bm": "[Integer] Jumlah pengundi yang didaftarkan untuk mengundi di kerusi tersebut semasa PRU-00"
-            },
-            {
-                "id": -1,
-                "name": "ballots_issued",
-                "title_en": "Ballots Issued",
-                "title_bm": "Undi Dikeluarkan",
-                "desc_en": "[Integer] Number of ballots issued, including postal ballots, but not inclduing ballots accidentally damaged and immediately replace during the voting procedure",
-                "desc_bm": "[Integer] Jumlah kertas undi yang dikeluarkan, termasuk kertas undi pos, tetapi tidak termasuk kertas undi yang rosak dan terus digantikan semasa urusan mengundi dijalankan"
-            },
-            {
-                "id": -1,
-                "name": "ballots_not_returned",
-                "title_en": "Ballots Not Returned",
-                "title_bm": "Undi Tidak Dikembalikan",
-                "desc_en": "[Integer] Number of ballots issued but not returned for counting, including postal ballots not returned to the counting centre in time, but excluding spoilt ballots (e.g. torn or stained) which were replaced and therefore not counted as ballots issued",
-                "desc_bm": "[Integer] Jumlah kertas undi yang dikeluarkan tetapi tidak dikembalikan untuk pengiraan undi, termasuk kertas undi pos yang tidak dikembalikan ke pusat kiraan undi, tetapi tidak termasuk kertas undi rosak (contohnya terkoyak atau ternoda) yang telah digantikan maka tidak dikira sebagai kertas undi yang dikeluarkan"
-            },
-            {
-                "id": -1,
-                "name": "votes_rejected",
-                "title_en": "Votes Rejected",
-                "title_bm": "Undi Ditolak",
-                "desc_en": "[Integer] Number of ballots returned but declared invalid during counting because the candidate could not be determined",
-                "desc_bm": "[Integer] Jumlah kertas undi yang telah dikembalikan tetapi ditolak semasa proses kiraan undi kerana calon yang diundi tidak dapat ditentukan"
-            },
-            {
-                "id": -1,
-                "name": "voter_turnout",
-                "title_en": "Voter Turnout",
-                "title_bm": "Peratus Keluar",
-                "desc_en": "[Float] Derived as: (ballots_issued / voters_total) * 100",
-                "desc_bm": " [Apung] Diperolehi dengan formula: (ballots_issued / voters_total) * 100"
-            },
-            {
-                "id": -1,
-                "name": "votes_rejected_perc",
-                "title_en": "Percentage Rejected",
-                "title_bm": "Peratus Ditolak",
-                "desc_en": "[Float] Derived as: (votes_rejected / (ballots_issued - ballots_not_returned)) * 100",
-                "desc_bm": " [Apung] Diperolehi dengan formula: (votes_rejected / (ballots_issued - ballots_not_returned)) * 100"
-            }
-        ]
-    }
+	"file": {
+		"manual_trigger": 0,
+		"bucket": "elections_federal",
+		"file_name": "ge07_summary",
+		"category": "ELECTIONS",
+		"category_en": "Elections",
+		"category_bm": "Pilihanraya",
+		"subcategory": "FEDERAL",
+		"subcategory_en": "Federal",
+		"subcategory_bm": "Persekutuan",
+		"description": {
+			"en": "Analytical summary of the pre-Independence general election held in 1955.",
+			"bm": "Ringkasan analitik bagi pilihanraya umum pramerdeka yang diadakan pada tahun 1955."
+		},
+		"link_parquet": "https://storage.data.gov.my/elections/federal/ge07_summary.parquet",
+		"link_csv": "https://storage.data.gov.my/elections/federal/ge07_summary.csv",
+		"link_preview": "https://storage.data.gov.my/elections/federal/ge07_summary.parquet",
+		"variables": [
+			{
+				"id": 0,
+				"name": "ge07_summary",
+				"title_en": "GE-07: Summary",
+				"title_bm": "PRU-07: Rumusan",
+				"desc_en": "Analytical summary of the pre-Independence general election held on 27 July 1955.",
+				"desc_bm": "Ringkasan analitik bagi pilihanraya umum pramerdeka yang diadakan pada 27 Julai 1955.",
+				"catalog_data": {
+					"catalog_filters": {
+						"frequency": "INFREQUENT",
+						"geography": ["PARLIMEN", "STATE", "NATIONAL"],
+						"demographic": [],
+						"start": "1986",
+						"end": "1986",
+						"data_source": ["SPR"]
+					},
+					"metadata_neutral": {
+						"data_as_of": "1955-08-31 23:59",
+						"last_updated": "2023-07-18 23:59",
+						"next_update": "-"
+					},
+					"metadata_lang": {
+						"en": {
+							"methodology": "This data is a digital representation of the physical election results tabulated and gazetted per the Electoral Regulations (Conduct of Elections). The digitalisation process was rigorously cross-checked against physical records to ensure consistency and accuracy of information.",
+							"caveat": "As of now, this data has not been verified by SPR, and is shown here on the staging site to provide easy access for exploring and checking the data.",
+							"publication": "-"
+						},
+						"bm": {
+							"methodology": "Data ini merupakan rekod digital keputusan pilihanraya yang dikira dan diwartakan selaras dengan Peraturan-Peraturan Pilihan Raya (Penjalanan Pilihan Raya). Proses pendigitalan disemak silang dengan rekod fizikal untuk memastikan ketepatan maklumat.",
+							"caveat": "Setakat sekarang, data ini belum disemak dan diabsahkan oleh SPR, maka hanya dipaparkan di portal UAT ini bagi tujuan memudahkan proses semakan.",
+							"publication": "-"
+						}
+					},
+					"chart": {
+						"chart_type": "TABLE",
+						"chart_filters": {
+							"SLICE_BY": [],
+							"precision": 0
+						},
+						"chart_variables": {
+							"parents": [],
+							"exclude": [],
+							"freeze": ["state", "parlimen"]
+						}
+					}
+				}
+			},
+			{
+				"id": -1,
+				"name": "state",
+				"title_en": "State",
+				"title_bm": "Negeri",
+				"desc_en": "[String] 1 of 16 states",
+				"desc_bm": "[Rentetan] 1 antara 16 negeri"
+			},
+			{
+				"id": -1,
+				"name": "parlimen",
+				"title_en": "Parliament",
+				"title_bm": "Parlimen",
+				"desc_en": "[String] Name of seat as it appeared on the ballot on voting day",
+				"desc_bm": "[Rentetan] Nama kerusi seperti mana yang tertera di kertas undi pada hari mengundi"
+			},
+			{
+				"id": -1,
+				"name": "area_name",
+				"title_en": "Area Name",
+				"title_bm": "Nama Kawasan",
+				"desc_en": "[String] Name of the area, with seat code (P.xxx) stripped out, and area name historically harmonised. For example, Kota Baharu, Kota Bahru and Kota Bharu are all harmonised to the modern Kota Bharu.",
+				"desc_bm": "[Rentetan] Nama kawasan, tanpa kod kerusi (P.xxx) dan namanya diselaraskan mengambil kira perubahan dari zaman ke zaman. Contohnya, nama Kota Baharu, Kota Bahru, dan Kota Bharu semuanya diharmonikan kepada penggunaan moden iaitu Kota Bharu."
+			},
+			{
+				"id": -1,
+				"name": "voters_total",
+				"title_en": "Total Voters",
+				"title_bm": "Jumlah Pengundi",
+				"desc_en": "[Integer] Number of voters registered to vote in that seat at that election",
+				"desc_bm": "[Integer] Jumlah pengundi yang didaftarkan untuk mengundi di kerusi tersebut semasa PRU-00"
+			},
+			{
+				"id": -1,
+				"name": "ballots_issued",
+				"title_en": "Ballots Issued",
+				"title_bm": "Undi Dikeluarkan",
+				"desc_en": "[Integer] Number of ballots issued, including postal ballots, but not inclduing ballots accidentally damaged and immediately replace during the voting procedure",
+				"desc_bm": "[Integer] Jumlah kertas undi yang dikeluarkan, termasuk kertas undi pos, tetapi tidak termasuk kertas undi yang rosak dan terus digantikan semasa urusan mengundi dijalankan"
+			},
+			{
+				"id": -1,
+				"name": "ballots_not_returned",
+				"title_en": "Ballots Not Returned",
+				"title_bm": "Undi Tidak Dikembalikan",
+				"desc_en": "[Integer] Number of ballots issued but not returned for counting, including postal ballots not returned to the counting centre in time, but excluding spoilt ballots (e.g. torn or stained) which were replaced and therefore not counted as ballots issued",
+				"desc_bm": "[Integer] Jumlah kertas undi yang dikeluarkan tetapi tidak dikembalikan untuk pengiraan undi, termasuk kertas undi pos yang tidak dikembalikan ke pusat kiraan undi, tetapi tidak termasuk kertas undi rosak (contohnya terkoyak atau ternoda) yang telah digantikan maka tidak dikira sebagai kertas undi yang dikeluarkan"
+			},
+			{
+				"id": -1,
+				"name": "votes_rejected",
+				"title_en": "Votes Rejected",
+				"title_bm": "Undi Ditolak",
+				"desc_en": "[Integer] Number of ballots returned but declared invalid during counting because the candidate could not be determined",
+				"desc_bm": "[Integer] Jumlah kertas undi yang telah dikembalikan tetapi ditolak semasa proses kiraan undi kerana calon yang diundi tidak dapat ditentukan"
+			},
+			{
+				"id": -1,
+				"name": "voter_turnout",
+				"title_en": "Voter Turnout",
+				"title_bm": "Peratus Keluar",
+				"desc_en": "[Float] Derived as: (ballots_issued / voters_total) * 100",
+				"desc_bm": " [Apung] Diperolehi dengan formula: (ballots_issued / voters_total) * 100"
+			},
+			{
+				"id": -1,
+				"name": "votes_rejected_perc",
+				"title_en": "Percentage Rejected",
+				"title_bm": "Peratus Ditolak",
+				"desc_en": "[Float] Derived as: (votes_rejected / (ballots_issued - ballots_not_returned)) * 100",
+				"desc_bm": " [Apung] Diperolehi dengan formula: (votes_rejected / (ballots_issued - ballots_not_returned)) * 100"
+			}
+		]
+	}
 }

--- a/catalog/ge08_ballots.json
+++ b/catalog/ge08_ballots.json
@@ -28,7 +28,7 @@
 					"catalog_filters": {
 						"frequency": "INFREQUENT",
 						"geography": ["PARLIMEN", "STATE", "NATIONAL"],
-						"demographic": [],
+						"demography": [],
 						"start": "1990",
 						"end": "1990",
 						"data_source": ["SPR"]

--- a/catalog/ge08_ballots.json
+++ b/catalog/ge08_ballots.json
@@ -1,142 +1,133 @@
 {
-    "file": {
-        "manual_trigger": 0,
-        "bucket": "elections_federal",
-        "file_name": "ge08_ballots",
-        "category": "ELECTIONS",
-        "category_en": "Elections",
-        "category_bm": "Pilihanraya",
-        "subcategory": "FEDERAL",
-        "subcategory_en": "Federal",
-        "subcategory_bm": "Persekutuan",
-        "description": {
-            "en": "Ballots for every seat contested at the pre-Independence general election held in 1955.",
-            "bm": "Perincian undi bagi setiap kerusi yang dipertandingkan di pilihanraya umum pramerdeka yang diadakan pada tahun 1955."
-        },
-        "link_parquet": "https://storage.data.gov.my/elections/federal/ge08_ballots.parquet",
-        "link_csv": "https://storage.data.gov.my/elections/federal/ge08_ballots.csv",
-        "link_preview": "https://storage.data.gov.my/elections/federal/ge08_ballots.parquet",
-        "variables": [
-            {
-                "id": 0,
-                "name": "ge08_ballots",
-                "title_en": "GE-08: Ballots",
-                "title_bm": "PRU-08: Kertas Undi",
-                "desc_en": "Ballots for every seat contested at the pre-Independence general election held on 27 July 1955.",
-                "desc_bm": "Perincian undi bagi setiap kerusi yang dipertandingkan di pilihanraya umum pramerdeka yang diadakan pada 27 Julai 1955.",
-                "catalog_data": {
-                    "catalog_filters": {
-                        "frequency": "INFREQUENT",
-                        "geographic": [
-                            "PARLIMEN",
-                            "STATE",
-                            "NATIONAL"
-                        ],
-                        "demographic": [],
-                        "start": "1990",
-                        "end": "1990",
-                        "data_source": [
-                            "SPR"
-                        ]
-                    },
-                    "metadata_neutral": {
-                        "data_as_of": "1955-08-31 23:59",
-                        "last_updated": "2023-07-18 23:59",
-                        "next_update": "-"
-                    },
-                    "metadata_lang": {
-                        "en": {
-                            "methodology": "This data is a digital representation of the physical election results tabulated and gazetted per the Electoral Regulations (Conduct of Elections). The digitalisation process was rigorously cross-checked against physical records to ensure consistency and accuracy of information.",
-                            "caveat": "As of now, this data has not been verified by SPR, and is shown here on the staging site to provide easy access for exploring and checking the data.",
-                            "publication": "-"
-                        },
-                        "bm": {
-                            "methodology": "Data ini merupakan rekod digital keputusan pilihanraya yang dikira dan diwartakan selaras dengan Peraturan-Peraturan Pilihan Raya (Penjalanan Pilihan Raya). Proses pendigitalan disemak silang dengan rekod fizikal untuk memastikan ketepatan maklumat.",
-                            "caveat": "Setakat sekarang, data ini belum disemak dan diabsahkan oleh SPR, maka hanya dipaparkan di portal UAT ini bagi tujuan memudahkan proses semakan.",
-                            "publication": "-"
-                        }
-                    },
-                    "chart": {
-                        "chart_type": "TABLE",
-                        "chart_filters": {
-                            "SLICE_BY": [],
-                            "precision": 0
-                        },
-                        "chart_variables": {
-                            "parents": [],
-                            "exclude": [],
-                            "freeze": [
-                                "state",
-                                "parlimen"
-                            ]
-                        }
-                    }
-                }
-            },
-            {
-                "id": -1,
-                "name": "state",
-                "title_en": "State",
-                "title_bm": "Negeri",
-                "desc_en": "[String] 1 of 16 states",
-                "desc_bm": "[Rentetan] 1 antara 16 negeri"
-            },
-            {
-                "id": -1,
-                "name": "parlimen",
-                "title_en": "Parliament",
-                "title_bm": "Parlimen",
-                "desc_en": "[String] Name of seat as it appeared on the ballot on voting day",
-                "desc_bm": "[Rentetan] Nama kerusi seperti mana yang tertera di kertas undi pada hari mengundi"
-            },
-            {
-                "id": -1,
-                "name": "area_name",
-                "title_en": "Area Name",
-                "title_bm": "Nama Kawasan",
-                "desc_en": "[String] Name of the area, with seat code (P.xxx) stripped out, and area name historically harmonised. For example, Kota Baharu, Kota Bahru and Kota Bharu are all harmonised to the modern Kota Bharu.",
-                "desc_bm": "[Rentetan] Nama kawasan, tanpa kod kerusi (P.xxx) dan namanya diselaraskan mengambil kira perubahan dari zaman ke zaman. Contohnya, nama Kota Baharu, Kota Bahru, dan Kota Bharu semuanya diharmonikan kepada penggunaan moden iaitu Kota Bharu."
-            },
-            {
-                "id": -1,
-                "name": "ballot_order",
-                "title_en": "Ballot Order",
-                "title_bm": "Urutan Nama",
-                "desc_en": "[Integer] Order in which the candidate appears on the ballot",
-                "desc_bm": "[Integer] Urutan nama-nama yang tertera pada kertas undi"
-            },
-            {
-                "id": -1,
-                "name": "name",
-                "title_en": "Name",
-                "title_bm": "Nama",
-                "desc_en": "[String] Name of candidate as it appeared on the ballot on voting day; this may not be the same as their real name as candidates are free to choose the name they use for campaigning and voting",
-                "desc_bm": "[Rentetan] Nama calon seperti mana yang tertera di kertas undi pada hari mengundi; ini tidak semestinya sama dengan nama sebenar mereka kerana calon adalah bebas untuk memilih nama yang digunakan bagi tujuan kempen dan undi"
-            },
-            {
-                "id": -1,
-                "name": "candidate_uid",
-                "title_en": "Unique Candidate ID",
-                "title_bm": "ID Unik Calon",
-                "desc_en": "[Integer] Unique integer identifier to track candidates across elections",
-                "desc_bm": "[Integer] Integer unik untuk menjejaki keputusan seseorang calon merentasi pilihan raya"
-            },
-            {
-                "id": -1,
-                "name": "party",
-                "title_en": "Party",
-                "title_bm": "Parti",
-                "desc_en": "[String] Party of the candidate as it appeared on the ballot on voting day; this record is not amended to reflect unofficial information on parties and coalitions. For example, if a candidate competed under the flag of Party X despite being a member of Party Y, their party is recorded as Party X.",
-                "desc_bm": "[String] Parti calon seperti yang tertera pada kertas undi pada hari mengundi; rekod ini tidak dipinda untuk menggambarkan maklumat tidak rasmi mengenai parti dan gabungan. Sebagai contoh, jika calon bertanding bawah bendera Parti X walaupun menjadi ahli Parti Y, parti mereka direkodkan sebagai Parti X."
-            },
-            {
-                "id": -1,
-                "name": "votes",
-                "title_en": "Votes",
-                "title_bm": "Undi",
-                "desc_en": "Integer] Number of votes won by the candidate",
-                "desc_bm": "[Integer] Jumlah undi yang diperolehi oleh calon"
-            }
-        ]
-    }
+	"file": {
+		"manual_trigger": 0,
+		"bucket": "elections_federal",
+		"file_name": "ge08_ballots",
+		"category": "ELECTIONS",
+		"category_en": "Elections",
+		"category_bm": "Pilihanraya",
+		"subcategory": "FEDERAL",
+		"subcategory_en": "Federal",
+		"subcategory_bm": "Persekutuan",
+		"description": {
+			"en": "Ballots for every seat contested at the pre-Independence general election held in 1955.",
+			"bm": "Perincian undi bagi setiap kerusi yang dipertandingkan di pilihanraya umum pramerdeka yang diadakan pada tahun 1955."
+		},
+		"link_parquet": "https://storage.data.gov.my/elections/federal/ge08_ballots.parquet",
+		"link_csv": "https://storage.data.gov.my/elections/federal/ge08_ballots.csv",
+		"link_preview": "https://storage.data.gov.my/elections/federal/ge08_ballots.parquet",
+		"variables": [
+			{
+				"id": 0,
+				"name": "ge08_ballots",
+				"title_en": "GE-08: Ballots",
+				"title_bm": "PRU-08: Kertas Undi",
+				"desc_en": "Ballots for every seat contested at the pre-Independence general election held on 27 July 1955.",
+				"desc_bm": "Perincian undi bagi setiap kerusi yang dipertandingkan di pilihanraya umum pramerdeka yang diadakan pada 27 Julai 1955.",
+				"catalog_data": {
+					"catalog_filters": {
+						"frequency": "INFREQUENT",
+						"geography": ["PARLIMEN", "STATE", "NATIONAL"],
+						"demographic": [],
+						"start": "1990",
+						"end": "1990",
+						"data_source": ["SPR"]
+					},
+					"metadata_neutral": {
+						"data_as_of": "1955-08-31 23:59",
+						"last_updated": "2023-07-18 23:59",
+						"next_update": "-"
+					},
+					"metadata_lang": {
+						"en": {
+							"methodology": "This data is a digital representation of the physical election results tabulated and gazetted per the Electoral Regulations (Conduct of Elections). The digitalisation process was rigorously cross-checked against physical records to ensure consistency and accuracy of information.",
+							"caveat": "As of now, this data has not been verified by SPR, and is shown here on the staging site to provide easy access for exploring and checking the data.",
+							"publication": "-"
+						},
+						"bm": {
+							"methodology": "Data ini merupakan rekod digital keputusan pilihanraya yang dikira dan diwartakan selaras dengan Peraturan-Peraturan Pilihan Raya (Penjalanan Pilihan Raya). Proses pendigitalan disemak silang dengan rekod fizikal untuk memastikan ketepatan maklumat.",
+							"caveat": "Setakat sekarang, data ini belum disemak dan diabsahkan oleh SPR, maka hanya dipaparkan di portal UAT ini bagi tujuan memudahkan proses semakan.",
+							"publication": "-"
+						}
+					},
+					"chart": {
+						"chart_type": "TABLE",
+						"chart_filters": {
+							"SLICE_BY": [],
+							"precision": 0
+						},
+						"chart_variables": {
+							"parents": [],
+							"exclude": [],
+							"freeze": ["state", "parlimen"]
+						}
+					}
+				}
+			},
+			{
+				"id": -1,
+				"name": "state",
+				"title_en": "State",
+				"title_bm": "Negeri",
+				"desc_en": "[String] 1 of 16 states",
+				"desc_bm": "[Rentetan] 1 antara 16 negeri"
+			},
+			{
+				"id": -1,
+				"name": "parlimen",
+				"title_en": "Parliament",
+				"title_bm": "Parlimen",
+				"desc_en": "[String] Name of seat as it appeared on the ballot on voting day",
+				"desc_bm": "[Rentetan] Nama kerusi seperti mana yang tertera di kertas undi pada hari mengundi"
+			},
+			{
+				"id": -1,
+				"name": "area_name",
+				"title_en": "Area Name",
+				"title_bm": "Nama Kawasan",
+				"desc_en": "[String] Name of the area, with seat code (P.xxx) stripped out, and area name historically harmonised. For example, Kota Baharu, Kota Bahru and Kota Bharu are all harmonised to the modern Kota Bharu.",
+				"desc_bm": "[Rentetan] Nama kawasan, tanpa kod kerusi (P.xxx) dan namanya diselaraskan mengambil kira perubahan dari zaman ke zaman. Contohnya, nama Kota Baharu, Kota Bahru, dan Kota Bharu semuanya diharmonikan kepada penggunaan moden iaitu Kota Bharu."
+			},
+			{
+				"id": -1,
+				"name": "ballot_order",
+				"title_en": "Ballot Order",
+				"title_bm": "Urutan Nama",
+				"desc_en": "[Integer] Order in which the candidate appears on the ballot",
+				"desc_bm": "[Integer] Urutan nama-nama yang tertera pada kertas undi"
+			},
+			{
+				"id": -1,
+				"name": "name",
+				"title_en": "Name",
+				"title_bm": "Nama",
+				"desc_en": "[String] Name of candidate as it appeared on the ballot on voting day; this may not be the same as their real name as candidates are free to choose the name they use for campaigning and voting",
+				"desc_bm": "[Rentetan] Nama calon seperti mana yang tertera di kertas undi pada hari mengundi; ini tidak semestinya sama dengan nama sebenar mereka kerana calon adalah bebas untuk memilih nama yang digunakan bagi tujuan kempen dan undi"
+			},
+			{
+				"id": -1,
+				"name": "candidate_uid",
+				"title_en": "Unique Candidate ID",
+				"title_bm": "ID Unik Calon",
+				"desc_en": "[Integer] Unique integer identifier to track candidates across elections",
+				"desc_bm": "[Integer] Integer unik untuk menjejaki keputusan seseorang calon merentasi pilihan raya"
+			},
+			{
+				"id": -1,
+				"name": "party",
+				"title_en": "Party",
+				"title_bm": "Parti",
+				"desc_en": "[String] Party of the candidate as it appeared on the ballot on voting day; this record is not amended to reflect unofficial information on parties and coalitions. For example, if a candidate competed under the flag of Party X despite being a member of Party Y, their party is recorded as Party X.",
+				"desc_bm": "[String] Parti calon seperti yang tertera pada kertas undi pada hari mengundi; rekod ini tidak dipinda untuk menggambarkan maklumat tidak rasmi mengenai parti dan gabungan. Sebagai contoh, jika calon bertanding bawah bendera Parti X walaupun menjadi ahli Parti Y, parti mereka direkodkan sebagai Parti X."
+			},
+			{
+				"id": -1,
+				"name": "votes",
+				"title_en": "Votes",
+				"title_bm": "Undi",
+				"desc_en": "Integer] Number of votes won by the candidate",
+				"desc_bm": "[Integer] Jumlah undi yang diperolehi oleh calon"
+			}
+		]
+	}
 }

--- a/catalog/ge08_summary.json
+++ b/catalog/ge08_summary.json
@@ -1,150 +1,141 @@
 {
-    "file": {
-        "manual_trigger": 0,
-        "bucket": "elections_federal",
-        "file_name": "ge08_summary",
-        "category": "ELECTIONS",
-        "category_en": "Elections",
-        "category_bm": "Pilihanraya",
-        "subcategory": "FEDERAL",
-        "subcategory_en": "Federal",
-        "subcategory_bm": "Persekutuan",
-        "description": {
-            "en": "Analytical summary of the pre-Independence general election held in 1955.",
-            "bm": "Ringkasan analitik bagi pilihanraya umum pramerdeka yang diadakan pada tahun 1955."
-        },
-        "link_parquet": "https://storage.data.gov.my/elections/federal/ge08_summary.parquet",
-        "link_csv": "https://storage.data.gov.my/elections/federal/ge08_summary.csv",
-        "link_preview": "https://storage.data.gov.my/elections/federal/ge08_summary.parquet",
-        "variables": [
-            {
-                "id": 0,
-                "name": "ge08_summary",
-                "title_en": "GE-08: Summary",
-                "title_bm": "PRU-08: Rumusan",
-                "desc_en": "Analytical summary of the pre-Independence general election held on 27 July 1955.",
-                "desc_bm": "Ringkasan analitik bagi pilihanraya umum pramerdeka yang diadakan pada 27 Julai 1955.",
-                "catalog_data": {
-                    "catalog_filters": {
-                        "frequency": "INFREQUENT",
-                        "geographic": [
-                            "PARLIMEN",
-                            "STATE",
-                            "NATIONAL"
-                        ],
-                        "demographic": [],
-                        "start": "1990",
-                        "end": "1990",
-                        "data_source": [
-                            "SPR"
-                        ]
-                    },
-                    "metadata_neutral": {
-                        "data_as_of": "1955-08-31 23:59",
-                        "last_updated": "2023-07-18 23:59",
-                        "next_update": "-"
-                    },
-                    "metadata_lang": {
-                        "en": {
-                            "methodology": "This data is a digital representation of the physical election results tabulated and gazetted per the Electoral Regulations (Conduct of Elections). The digitalisation process was rigorously cross-checked against physical records to ensure consistency and accuracy of information.",
-                            "caveat": "As of now, this data has not been verified by SPR, and is shown here on the staging site to provide easy access for exploring and checking the data.",
-                            "publication": "-"
-                        },
-                        "bm": {
-                            "methodology": "Data ini merupakan rekod digital keputusan pilihanraya yang dikira dan diwartakan selaras dengan Peraturan-Peraturan Pilihan Raya (Penjalanan Pilihan Raya). Proses pendigitalan disemak silang dengan rekod fizikal untuk memastikan ketepatan maklumat.",
-                            "caveat": "Setakat sekarang, data ini belum disemak dan diabsahkan oleh SPR, maka hanya dipaparkan di portal UAT ini bagi tujuan memudahkan proses semakan.",
-                            "publication": "-"
-                        }
-                    },
-                    "chart": {
-                        "chart_type": "TABLE",
-                        "chart_filters": {
-                            "SLICE_BY": [],
-                            "precision": 0
-                        },
-                        "chart_variables": {
-                            "parents": [],
-                            "exclude": [],
-                            "freeze": [
-                                "state",
-                                "parlimen"
-                            ]
-                        }
-                    }
-                }
-            },
-            {
-                "id": -1,
-                "name": "state",
-                "title_en": "State",
-                "title_bm": "Negeri",
-                "desc_en": "[String] 1 of 16 states",
-                "desc_bm": "[Rentetan] 1 antara 16 negeri"
-            },
-            {
-                "id": -1,
-                "name": "parlimen",
-                "title_en": "Parliament",
-                "title_bm": "Parlimen",
-                "desc_en": "[String] Name of seat as it appeared on the ballot on voting day",
-                "desc_bm": "[Rentetan] Nama kerusi seperti mana yang tertera di kertas undi pada hari mengundi"
-            },
-            {
-                "id": -1,
-                "name": "area_name",
-                "title_en": "Area Name",
-                "title_bm": "Nama Kawasan",
-                "desc_en": "[String] Name of the area, with seat code (P.xxx) stripped out, and area name historically harmonised. For example, Kota Baharu, Kota Bahru and Kota Bharu are all harmonised to the modern Kota Bharu.",
-                "desc_bm": "[Rentetan] Nama kawasan, tanpa kod kerusi (P.xxx) dan namanya diselaraskan mengambil kira perubahan dari zaman ke zaman. Contohnya, nama Kota Baharu, Kota Bahru, dan Kota Bharu semuanya diharmonikan kepada penggunaan moden iaitu Kota Bharu."
-            },
-            {
-                "id": -1,
-                "name": "voters_total",
-                "title_en": "Total Voters",
-                "title_bm": "Jumlah Pengundi",
-                "desc_en": "[Integer] Number of voters registered to vote in that seat at that election",
-                "desc_bm": "[Integer] Jumlah pengundi yang didaftarkan untuk mengundi di kerusi tersebut semasa PRU-00"
-            },
-            {
-                "id": -1,
-                "name": "ballots_issued",
-                "title_en": "Ballots Issued",
-                "title_bm": "Undi Dikeluarkan",
-                "desc_en": "[Integer] Number of ballots issued, including postal ballots, but not inclduing ballots accidentally damaged and immediately replace during the voting procedure",
-                "desc_bm": "[Integer] Jumlah kertas undi yang dikeluarkan, termasuk kertas undi pos, tetapi tidak termasuk kertas undi yang rosak dan terus digantikan semasa urusan mengundi dijalankan"
-            },
-            {
-                "id": -1,
-                "name": "ballots_not_returned",
-                "title_en": "Ballots Not Returned",
-                "title_bm": "Undi Tidak Dikembalikan",
-                "desc_en": "[Integer] Number of ballots issued but not returned for counting, including postal ballots not returned to the counting centre in time, but excluding spoilt ballots (e.g. torn or stained) which were replaced and therefore not counted as ballots issued",
-                "desc_bm": "[Integer] Jumlah kertas undi yang dikeluarkan tetapi tidak dikembalikan untuk pengiraan undi, termasuk kertas undi pos yang tidak dikembalikan ke pusat kiraan undi, tetapi tidak termasuk kertas undi rosak (contohnya terkoyak atau ternoda) yang telah digantikan maka tidak dikira sebagai kertas undi yang dikeluarkan"
-            },
-            {
-                "id": -1,
-                "name": "votes_rejected",
-                "title_en": "Votes Rejected",
-                "title_bm": "Undi Ditolak",
-                "desc_en": "[Integer] Number of ballots returned but declared invalid during counting because the candidate could not be determined",
-                "desc_bm": "[Integer] Jumlah kertas undi yang telah dikembalikan tetapi ditolak semasa proses kiraan undi kerana calon yang diundi tidak dapat ditentukan"
-            },
-            {
-                "id": -1,
-                "name": "voter_turnout",
-                "title_en": "Voter Turnout",
-                "title_bm": "Peratus Keluar",
-                "desc_en": "[Float] Derived as: (ballots_issued / voters_total) * 100",
-                "desc_bm": " [Apung] Diperolehi dengan formula: (ballots_issued / voters_total) * 100"
-            },
-            {
-                "id": -1,
-                "name": "votes_rejected_perc",
-                "title_en": "Percentage Rejected",
-                "title_bm": "Peratus Ditolak",
-                "desc_en": "[Float] Derived as: (votes_rejected / (ballots_issued - ballots_not_returned)) * 100",
-                "desc_bm": " [Apung] Diperolehi dengan formula: (votes_rejected / (ballots_issued - ballots_not_returned)) * 100"
-            }
-        ]
-    }
+	"file": {
+		"manual_trigger": 0,
+		"bucket": "elections_federal",
+		"file_name": "ge08_summary",
+		"category": "ELECTIONS",
+		"category_en": "Elections",
+		"category_bm": "Pilihanraya",
+		"subcategory": "FEDERAL",
+		"subcategory_en": "Federal",
+		"subcategory_bm": "Persekutuan",
+		"description": {
+			"en": "Analytical summary of the pre-Independence general election held in 1955.",
+			"bm": "Ringkasan analitik bagi pilihanraya umum pramerdeka yang diadakan pada tahun 1955."
+		},
+		"link_parquet": "https://storage.data.gov.my/elections/federal/ge08_summary.parquet",
+		"link_csv": "https://storage.data.gov.my/elections/federal/ge08_summary.csv",
+		"link_preview": "https://storage.data.gov.my/elections/federal/ge08_summary.parquet",
+		"variables": [
+			{
+				"id": 0,
+				"name": "ge08_summary",
+				"title_en": "GE-08: Summary",
+				"title_bm": "PRU-08: Rumusan",
+				"desc_en": "Analytical summary of the pre-Independence general election held on 27 July 1955.",
+				"desc_bm": "Ringkasan analitik bagi pilihanraya umum pramerdeka yang diadakan pada 27 Julai 1955.",
+				"catalog_data": {
+					"catalog_filters": {
+						"frequency": "INFREQUENT",
+						"geography": ["PARLIMEN", "STATE", "NATIONAL"],
+						"demographic": [],
+						"start": "1990",
+						"end": "1990",
+						"data_source": ["SPR"]
+					},
+					"metadata_neutral": {
+						"data_as_of": "1955-08-31 23:59",
+						"last_updated": "2023-07-18 23:59",
+						"next_update": "-"
+					},
+					"metadata_lang": {
+						"en": {
+							"methodology": "This data is a digital representation of the physical election results tabulated and gazetted per the Electoral Regulations (Conduct of Elections). The digitalisation process was rigorously cross-checked against physical records to ensure consistency and accuracy of information.",
+							"caveat": "As of now, this data has not been verified by SPR, and is shown here on the staging site to provide easy access for exploring and checking the data.",
+							"publication": "-"
+						},
+						"bm": {
+							"methodology": "Data ini merupakan rekod digital keputusan pilihanraya yang dikira dan diwartakan selaras dengan Peraturan-Peraturan Pilihan Raya (Penjalanan Pilihan Raya). Proses pendigitalan disemak silang dengan rekod fizikal untuk memastikan ketepatan maklumat.",
+							"caveat": "Setakat sekarang, data ini belum disemak dan diabsahkan oleh SPR, maka hanya dipaparkan di portal UAT ini bagi tujuan memudahkan proses semakan.",
+							"publication": "-"
+						}
+					},
+					"chart": {
+						"chart_type": "TABLE",
+						"chart_filters": {
+							"SLICE_BY": [],
+							"precision": 0
+						},
+						"chart_variables": {
+							"parents": [],
+							"exclude": [],
+							"freeze": ["state", "parlimen"]
+						}
+					}
+				}
+			},
+			{
+				"id": -1,
+				"name": "state",
+				"title_en": "State",
+				"title_bm": "Negeri",
+				"desc_en": "[String] 1 of 16 states",
+				"desc_bm": "[Rentetan] 1 antara 16 negeri"
+			},
+			{
+				"id": -1,
+				"name": "parlimen",
+				"title_en": "Parliament",
+				"title_bm": "Parlimen",
+				"desc_en": "[String] Name of seat as it appeared on the ballot on voting day",
+				"desc_bm": "[Rentetan] Nama kerusi seperti mana yang tertera di kertas undi pada hari mengundi"
+			},
+			{
+				"id": -1,
+				"name": "area_name",
+				"title_en": "Area Name",
+				"title_bm": "Nama Kawasan",
+				"desc_en": "[String] Name of the area, with seat code (P.xxx) stripped out, and area name historically harmonised. For example, Kota Baharu, Kota Bahru and Kota Bharu are all harmonised to the modern Kota Bharu.",
+				"desc_bm": "[Rentetan] Nama kawasan, tanpa kod kerusi (P.xxx) dan namanya diselaraskan mengambil kira perubahan dari zaman ke zaman. Contohnya, nama Kota Baharu, Kota Bahru, dan Kota Bharu semuanya diharmonikan kepada penggunaan moden iaitu Kota Bharu."
+			},
+			{
+				"id": -1,
+				"name": "voters_total",
+				"title_en": "Total Voters",
+				"title_bm": "Jumlah Pengundi",
+				"desc_en": "[Integer] Number of voters registered to vote in that seat at that election",
+				"desc_bm": "[Integer] Jumlah pengundi yang didaftarkan untuk mengundi di kerusi tersebut semasa PRU-00"
+			},
+			{
+				"id": -1,
+				"name": "ballots_issued",
+				"title_en": "Ballots Issued",
+				"title_bm": "Undi Dikeluarkan",
+				"desc_en": "[Integer] Number of ballots issued, including postal ballots, but not inclduing ballots accidentally damaged and immediately replace during the voting procedure",
+				"desc_bm": "[Integer] Jumlah kertas undi yang dikeluarkan, termasuk kertas undi pos, tetapi tidak termasuk kertas undi yang rosak dan terus digantikan semasa urusan mengundi dijalankan"
+			},
+			{
+				"id": -1,
+				"name": "ballots_not_returned",
+				"title_en": "Ballots Not Returned",
+				"title_bm": "Undi Tidak Dikembalikan",
+				"desc_en": "[Integer] Number of ballots issued but not returned for counting, including postal ballots not returned to the counting centre in time, but excluding spoilt ballots (e.g. torn or stained) which were replaced and therefore not counted as ballots issued",
+				"desc_bm": "[Integer] Jumlah kertas undi yang dikeluarkan tetapi tidak dikembalikan untuk pengiraan undi, termasuk kertas undi pos yang tidak dikembalikan ke pusat kiraan undi, tetapi tidak termasuk kertas undi rosak (contohnya terkoyak atau ternoda) yang telah digantikan maka tidak dikira sebagai kertas undi yang dikeluarkan"
+			},
+			{
+				"id": -1,
+				"name": "votes_rejected",
+				"title_en": "Votes Rejected",
+				"title_bm": "Undi Ditolak",
+				"desc_en": "[Integer] Number of ballots returned but declared invalid during counting because the candidate could not be determined",
+				"desc_bm": "[Integer] Jumlah kertas undi yang telah dikembalikan tetapi ditolak semasa proses kiraan undi kerana calon yang diundi tidak dapat ditentukan"
+			},
+			{
+				"id": -1,
+				"name": "voter_turnout",
+				"title_en": "Voter Turnout",
+				"title_bm": "Peratus Keluar",
+				"desc_en": "[Float] Derived as: (ballots_issued / voters_total) * 100",
+				"desc_bm": " [Apung] Diperolehi dengan formula: (ballots_issued / voters_total) * 100"
+			},
+			{
+				"id": -1,
+				"name": "votes_rejected_perc",
+				"title_en": "Percentage Rejected",
+				"title_bm": "Peratus Ditolak",
+				"desc_en": "[Float] Derived as: (votes_rejected / (ballots_issued - ballots_not_returned)) * 100",
+				"desc_bm": " [Apung] Diperolehi dengan formula: (votes_rejected / (ballots_issued - ballots_not_returned)) * 100"
+			}
+		]
+	}
 }

--- a/catalog/ge08_summary.json
+++ b/catalog/ge08_summary.json
@@ -28,7 +28,7 @@
 					"catalog_filters": {
 						"frequency": "INFREQUENT",
 						"geography": ["PARLIMEN", "STATE", "NATIONAL"],
-						"demographic": [],
+						"demography": [],
 						"start": "1990",
 						"end": "1990",
 						"data_source": ["SPR"]

--- a/catalog/ge09_ballots.json
+++ b/catalog/ge09_ballots.json
@@ -1,142 +1,133 @@
 {
-    "file": {
-        "manual_trigger": 0,
-        "bucket": "elections_federal",
-        "file_name": "ge09_ballots",
-        "category": "ELECTIONS",
-        "category_en": "Elections",
-        "category_bm": "Pilihanraya",
-        "subcategory": "FEDERAL",
-        "subcategory_en": "Federal",
-        "subcategory_bm": "Persekutuan",
-        "description": {
-            "en": "Ballots for every seat contested at the pre-Independence general election held in 1955.",
-            "bm": "Perincian undi bagi setiap kerusi yang dipertandingkan di pilihanraya umum pramerdeka yang diadakan pada tahun 1955."
-        },
-        "link_parquet": "https://storage.data.gov.my/elections/federal/ge09_ballots.parquet",
-        "link_csv": "https://storage.data.gov.my/elections/federal/ge09_ballots.csv",
-        "link_preview": "https://storage.data.gov.my/elections/federal/ge09_ballots.parquet",
-        "variables": [
-            {
-                "id": 0,
-                "name": "ge09_ballots",
-                "title_en": "GE-09: Ballots",
-                "title_bm": "PRU-09: Kertas Undi",
-                "desc_en": "Ballots for every seat contested at the pre-Independence general election held on 27 July 1955.",
-                "desc_bm": "Perincian undi bagi setiap kerusi yang dipertandingkan di pilihanraya umum pramerdeka yang diadakan pada 27 Julai 1955.",
-                "catalog_data": {
-                    "catalog_filters": {
-                        "frequency": "INFREQUENT",
-                        "geographic": [
-                            "PARLIMEN",
-                            "STATE",
-                            "NATIONAL"
-                        ],
-                        "demographic": [],
-                        "start": "1995",
-                        "end": "1995",
-                        "data_source": [
-                            "SPR"
-                        ]
-                    },
-                    "metadata_neutral": {
-                        "data_as_of": "1955-08-31 23:59",
-                        "last_updated": "2023-07-18 23:59",
-                        "next_update": "-"
-                    },
-                    "metadata_lang": {
-                        "en": {
-                            "methodology": "This data is a digital representation of the physical election results tabulated and gazetted per the Electoral Regulations (Conduct of Elections). The digitalisation process was rigorously cross-checked against physical records to ensure consistency and accuracy of information.",
-                            "caveat": "As of now, this data has not been verified by SPR, and is shown here on the staging site to provide easy access for exploring and checking the data.",
-                            "publication": "-"
-                        },
-                        "bm": {
-                            "methodology": "Data ini merupakan rekod digital keputusan pilihanraya yang dikira dan diwartakan selaras dengan Peraturan-Peraturan Pilihan Raya (Penjalanan Pilihan Raya). Proses pendigitalan disemak silang dengan rekod fizikal untuk memastikan ketepatan maklumat.",
-                            "caveat": "Setakat sekarang, data ini belum disemak dan diabsahkan oleh SPR, maka hanya dipaparkan di portal UAT ini bagi tujuan memudahkan proses semakan.",
-                            "publication": "-"
-                        }
-                    },
-                    "chart": {
-                        "chart_type": "TABLE",
-                        "chart_filters": {
-                            "SLICE_BY": [],
-                            "precision": 0
-                        },
-                        "chart_variables": {
-                            "parents": [],
-                            "exclude": [],
-                            "freeze": [
-                                "state",
-                                "parlimen"
-                            ]
-                        }
-                    }
-                }
-            },
-            {
-                "id": -1,
-                "name": "state",
-                "title_en": "State",
-                "title_bm": "Negeri",
-                "desc_en": "[String] 1 of 16 states",
-                "desc_bm": "[Rentetan] 1 antara 16 negeri"
-            },
-            {
-                "id": -1,
-                "name": "parlimen",
-                "title_en": "Parliament",
-                "title_bm": "Parlimen",
-                "desc_en": "[String] Name of seat as it appeared on the ballot on voting day",
-                "desc_bm": "[Rentetan] Nama kerusi seperti mana yang tertera di kertas undi pada hari mengundi"
-            },
-            {
-                "id": -1,
-                "name": "area_name",
-                "title_en": "Area Name",
-                "title_bm": "Nama Kawasan",
-                "desc_en": "[String] Name of the area, with seat code (P.xxx) stripped out, and area name historically harmonised. For example, Kota Baharu, Kota Bahru and Kota Bharu are all harmonised to the modern Kota Bharu.",
-                "desc_bm": "[Rentetan] Nama kawasan, tanpa kod kerusi (P.xxx) dan namanya diselaraskan mengambil kira perubahan dari zaman ke zaman. Contohnya, nama Kota Baharu, Kota Bahru, dan Kota Bharu semuanya diharmonikan kepada penggunaan moden iaitu Kota Bharu."
-            },
-            {
-                "id": -1,
-                "name": "ballot_order",
-                "title_en": "Ballot Order",
-                "title_bm": "Urutan Nama",
-                "desc_en": "[Integer] Order in which the candidate appears on the ballot",
-                "desc_bm": "[Integer] Urutan nama-nama yang tertera pada kertas undi"
-            },
-            {
-                "id": -1,
-                "name": "name",
-                "title_en": "Name",
-                "title_bm": "Nama",
-                "desc_en": "[String] Name of candidate as it appeared on the ballot on voting day; this may not be the same as their real name as candidates are free to choose the name they use for campaigning and voting",
-                "desc_bm": "[Rentetan] Nama calon seperti mana yang tertera di kertas undi pada hari mengundi; ini tidak semestinya sama dengan nama sebenar mereka kerana calon adalah bebas untuk memilih nama yang digunakan bagi tujuan kempen dan undi"
-            },
-            {
-                "id": -1,
-                "name": "candidate_uid",
-                "title_en": "Unique Candidate ID",
-                "title_bm": "ID Unik Calon",
-                "desc_en": "[Integer] Unique integer identifier to track candidates across elections",
-                "desc_bm": "[Integer] Integer unik untuk menjejaki keputusan seseorang calon merentasi pilihan raya"
-            },
-            {
-                "id": -1,
-                "name": "party",
-                "title_en": "Party",
-                "title_bm": "Parti",
-                "desc_en": "[String] Party of the candidate as it appeared on the ballot on voting day; this record is not amended to reflect unofficial information on parties and coalitions. For example, if a candidate competed under the flag of Party X despite being a member of Party Y, their party is recorded as Party X.",
-                "desc_bm": "[String] Parti calon seperti yang tertera pada kertas undi pada hari mengundi; rekod ini tidak dipinda untuk menggambarkan maklumat tidak rasmi mengenai parti dan gabungan. Sebagai contoh, jika calon bertanding bawah bendera Parti X walaupun menjadi ahli Parti Y, parti mereka direkodkan sebagai Parti X."
-            },
-            {
-                "id": -1,
-                "name": "votes",
-                "title_en": "Votes",
-                "title_bm": "Undi",
-                "desc_en": "Integer] Number of votes won by the candidate",
-                "desc_bm": "[Integer] Jumlah undi yang diperolehi oleh calon"
-            }
-        ]
-    }
+	"file": {
+		"manual_trigger": 0,
+		"bucket": "elections_federal",
+		"file_name": "ge09_ballots",
+		"category": "ELECTIONS",
+		"category_en": "Elections",
+		"category_bm": "Pilihanraya",
+		"subcategory": "FEDERAL",
+		"subcategory_en": "Federal",
+		"subcategory_bm": "Persekutuan",
+		"description": {
+			"en": "Ballots for every seat contested at the pre-Independence general election held in 1955.",
+			"bm": "Perincian undi bagi setiap kerusi yang dipertandingkan di pilihanraya umum pramerdeka yang diadakan pada tahun 1955."
+		},
+		"link_parquet": "https://storage.data.gov.my/elections/federal/ge09_ballots.parquet",
+		"link_csv": "https://storage.data.gov.my/elections/federal/ge09_ballots.csv",
+		"link_preview": "https://storage.data.gov.my/elections/federal/ge09_ballots.parquet",
+		"variables": [
+			{
+				"id": 0,
+				"name": "ge09_ballots",
+				"title_en": "GE-09: Ballots",
+				"title_bm": "PRU-09: Kertas Undi",
+				"desc_en": "Ballots for every seat contested at the pre-Independence general election held on 27 July 1955.",
+				"desc_bm": "Perincian undi bagi setiap kerusi yang dipertandingkan di pilihanraya umum pramerdeka yang diadakan pada 27 Julai 1955.",
+				"catalog_data": {
+					"catalog_filters": {
+						"frequency": "INFREQUENT",
+						"geography": ["PARLIMEN", "STATE", "NATIONAL"],
+						"demographic": [],
+						"start": "1995",
+						"end": "1995",
+						"data_source": ["SPR"]
+					},
+					"metadata_neutral": {
+						"data_as_of": "1955-08-31 23:59",
+						"last_updated": "2023-07-18 23:59",
+						"next_update": "-"
+					},
+					"metadata_lang": {
+						"en": {
+							"methodology": "This data is a digital representation of the physical election results tabulated and gazetted per the Electoral Regulations (Conduct of Elections). The digitalisation process was rigorously cross-checked against physical records to ensure consistency and accuracy of information.",
+							"caveat": "As of now, this data has not been verified by SPR, and is shown here on the staging site to provide easy access for exploring and checking the data.",
+							"publication": "-"
+						},
+						"bm": {
+							"methodology": "Data ini merupakan rekod digital keputusan pilihanraya yang dikira dan diwartakan selaras dengan Peraturan-Peraturan Pilihan Raya (Penjalanan Pilihan Raya). Proses pendigitalan disemak silang dengan rekod fizikal untuk memastikan ketepatan maklumat.",
+							"caveat": "Setakat sekarang, data ini belum disemak dan diabsahkan oleh SPR, maka hanya dipaparkan di portal UAT ini bagi tujuan memudahkan proses semakan.",
+							"publication": "-"
+						}
+					},
+					"chart": {
+						"chart_type": "TABLE",
+						"chart_filters": {
+							"SLICE_BY": [],
+							"precision": 0
+						},
+						"chart_variables": {
+							"parents": [],
+							"exclude": [],
+							"freeze": ["state", "parlimen"]
+						}
+					}
+				}
+			},
+			{
+				"id": -1,
+				"name": "state",
+				"title_en": "State",
+				"title_bm": "Negeri",
+				"desc_en": "[String] 1 of 16 states",
+				"desc_bm": "[Rentetan] 1 antara 16 negeri"
+			},
+			{
+				"id": -1,
+				"name": "parlimen",
+				"title_en": "Parliament",
+				"title_bm": "Parlimen",
+				"desc_en": "[String] Name of seat as it appeared on the ballot on voting day",
+				"desc_bm": "[Rentetan] Nama kerusi seperti mana yang tertera di kertas undi pada hari mengundi"
+			},
+			{
+				"id": -1,
+				"name": "area_name",
+				"title_en": "Area Name",
+				"title_bm": "Nama Kawasan",
+				"desc_en": "[String] Name of the area, with seat code (P.xxx) stripped out, and area name historically harmonised. For example, Kota Baharu, Kota Bahru and Kota Bharu are all harmonised to the modern Kota Bharu.",
+				"desc_bm": "[Rentetan] Nama kawasan, tanpa kod kerusi (P.xxx) dan namanya diselaraskan mengambil kira perubahan dari zaman ke zaman. Contohnya, nama Kota Baharu, Kota Bahru, dan Kota Bharu semuanya diharmonikan kepada penggunaan moden iaitu Kota Bharu."
+			},
+			{
+				"id": -1,
+				"name": "ballot_order",
+				"title_en": "Ballot Order",
+				"title_bm": "Urutan Nama",
+				"desc_en": "[Integer] Order in which the candidate appears on the ballot",
+				"desc_bm": "[Integer] Urutan nama-nama yang tertera pada kertas undi"
+			},
+			{
+				"id": -1,
+				"name": "name",
+				"title_en": "Name",
+				"title_bm": "Nama",
+				"desc_en": "[String] Name of candidate as it appeared on the ballot on voting day; this may not be the same as their real name as candidates are free to choose the name they use for campaigning and voting",
+				"desc_bm": "[Rentetan] Nama calon seperti mana yang tertera di kertas undi pada hari mengundi; ini tidak semestinya sama dengan nama sebenar mereka kerana calon adalah bebas untuk memilih nama yang digunakan bagi tujuan kempen dan undi"
+			},
+			{
+				"id": -1,
+				"name": "candidate_uid",
+				"title_en": "Unique Candidate ID",
+				"title_bm": "ID Unik Calon",
+				"desc_en": "[Integer] Unique integer identifier to track candidates across elections",
+				"desc_bm": "[Integer] Integer unik untuk menjejaki keputusan seseorang calon merentasi pilihan raya"
+			},
+			{
+				"id": -1,
+				"name": "party",
+				"title_en": "Party",
+				"title_bm": "Parti",
+				"desc_en": "[String] Party of the candidate as it appeared on the ballot on voting day; this record is not amended to reflect unofficial information on parties and coalitions. For example, if a candidate competed under the flag of Party X despite being a member of Party Y, their party is recorded as Party X.",
+				"desc_bm": "[String] Parti calon seperti yang tertera pada kertas undi pada hari mengundi; rekod ini tidak dipinda untuk menggambarkan maklumat tidak rasmi mengenai parti dan gabungan. Sebagai contoh, jika calon bertanding bawah bendera Parti X walaupun menjadi ahli Parti Y, parti mereka direkodkan sebagai Parti X."
+			},
+			{
+				"id": -1,
+				"name": "votes",
+				"title_en": "Votes",
+				"title_bm": "Undi",
+				"desc_en": "Integer] Number of votes won by the candidate",
+				"desc_bm": "[Integer] Jumlah undi yang diperolehi oleh calon"
+			}
+		]
+	}
 }

--- a/catalog/ge09_ballots.json
+++ b/catalog/ge09_ballots.json
@@ -28,7 +28,7 @@
 					"catalog_filters": {
 						"frequency": "INFREQUENT",
 						"geography": ["PARLIMEN", "STATE", "NATIONAL"],
-						"demographic": [],
+						"demography": [],
 						"start": "1995",
 						"end": "1995",
 						"data_source": ["SPR"]

--- a/catalog/ge09_summary.json
+++ b/catalog/ge09_summary.json
@@ -1,150 +1,141 @@
 {
-    "file": {
-        "manual_trigger": 0,
-        "bucket": "elections_federal",
-        "file_name": "ge09_summary",
-        "category": "ELECTIONS",
-        "category_en": "Elections",
-        "category_bm": "Pilihanraya",
-        "subcategory": "FEDERAL",
-        "subcategory_en": "Federal",
-        "subcategory_bm": "Persekutuan",
-        "description": {
-            "en": "Analytical summary of the pre-Independence general election held in 1955.",
-            "bm": "Ringkasan analitik bagi pilihanraya umum pramerdeka yang diadakan pada tahun 1955."
-        },
-        "link_parquet": "https://storage.data.gov.my/elections/federal/ge09_summary.parquet",
-        "link_csv": "https://storage.data.gov.my/elections/federal/ge09_summary.csv",
-        "link_preview": "https://storage.data.gov.my/elections/federal/ge09_summary.parquet",
-        "variables": [
-            {
-                "id": 0,
-                "name": "ge09_summary",
-                "title_en": "GE-09: Summary",
-                "title_bm": "PRU-09: Rumusan",
-                "desc_en": "Analytical summary of the pre-Independence general election held on 27 July 1955.",
-                "desc_bm": "Ringkasan analitik bagi pilihanraya umum pramerdeka yang diadakan pada 27 Julai 1955.",
-                "catalog_data": {
-                    "catalog_filters": {
-                        "frequency": "INFREQUENT",
-                        "geographic": [
-                            "PARLIMEN",
-                            "STATE",
-                            "NATIONAL"
-                        ],
-                        "demographic": [],
-                        "start": "1995",
-                        "end": "1995",
-                        "data_source": [
-                            "SPR"
-                        ]
-                    },
-                    "metadata_neutral": {
-                        "data_as_of": "1955-08-31 23:59",
-                        "last_updated": "2023-07-18 23:59",
-                        "next_update": "-"
-                    },
-                    "metadata_lang": {
-                        "en": {
-                            "methodology": "This data is a digital representation of the physical election results tabulated and gazetted per the Electoral Regulations (Conduct of Elections). The digitalisation process was rigorously cross-checked against physical records to ensure consistency and accuracy of information.",
-                            "caveat": "As of now, this data has not been verified by SPR, and is shown here on the staging site to provide easy access for exploring and checking the data.",
-                            "publication": "-"
-                        },
-                        "bm": {
-                            "methodology": "Data ini merupakan rekod digital keputusan pilihanraya yang dikira dan diwartakan selaras dengan Peraturan-Peraturan Pilihan Raya (Penjalanan Pilihan Raya). Proses pendigitalan disemak silang dengan rekod fizikal untuk memastikan ketepatan maklumat.",
-                            "caveat": "Setakat sekarang, data ini belum disemak dan diabsahkan oleh SPR, maka hanya dipaparkan di portal UAT ini bagi tujuan memudahkan proses semakan.",
-                            "publication": "-"
-                        }
-                    },
-                    "chart": {
-                        "chart_type": "TABLE",
-                        "chart_filters": {
-                            "SLICE_BY": [],
-                            "precision": 0
-                        },
-                        "chart_variables": {
-                            "parents": [],
-                            "exclude": [],
-                            "freeze": [
-                                "state",
-                                "parlimen"
-                            ]
-                        }
-                    }
-                }
-            },
-            {
-                "id": -1,
-                "name": "state",
-                "title_en": "State",
-                "title_bm": "Negeri",
-                "desc_en": "[String] 1 of 16 states",
-                "desc_bm": "[Rentetan] 1 antara 16 negeri"
-            },
-            {
-                "id": -1,
-                "name": "parlimen",
-                "title_en": "Parliament",
-                "title_bm": "Parlimen",
-                "desc_en": "[String] Name of seat as it appeared on the ballot on voting day",
-                "desc_bm": "[Rentetan] Nama kerusi seperti mana yang tertera di kertas undi pada hari mengundi"
-            },
-            {
-                "id": -1,
-                "name": "area_name",
-                "title_en": "Area Name",
-                "title_bm": "Nama Kawasan",
-                "desc_en": "[String] Name of the area, with seat code (P.xxx) stripped out, and area name historically harmonised. For example, Kota Baharu, Kota Bahru and Kota Bharu are all harmonised to the modern Kota Bharu.",
-                "desc_bm": "[Rentetan] Nama kawasan, tanpa kod kerusi (P.xxx) dan namanya diselaraskan mengambil kira perubahan dari zaman ke zaman. Contohnya, nama Kota Baharu, Kota Bahru, dan Kota Bharu semuanya diharmonikan kepada penggunaan moden iaitu Kota Bharu."
-            },
-            {
-                "id": -1,
-                "name": "voters_total",
-                "title_en": "Total Voters",
-                "title_bm": "Jumlah Pengundi",
-                "desc_en": "[Integer] Number of voters registered to vote in that seat at that election",
-                "desc_bm": "[Integer] Jumlah pengundi yang didaftarkan untuk mengundi di kerusi tersebut semasa PRU-00"
-            },
-            {
-                "id": -1,
-                "name": "ballots_issued",
-                "title_en": "Ballots Issued",
-                "title_bm": "Undi Dikeluarkan",
-                "desc_en": "[Integer] Number of ballots issued, including postal ballots, but not inclduing ballots accidentally damaged and immediately replace during the voting procedure",
-                "desc_bm": "[Integer] Jumlah kertas undi yang dikeluarkan, termasuk kertas undi pos, tetapi tidak termasuk kertas undi yang rosak dan terus digantikan semasa urusan mengundi dijalankan"
-            },
-            {
-                "id": -1,
-                "name": "ballots_not_returned",
-                "title_en": "Ballots Not Returned",
-                "title_bm": "Undi Tidak Dikembalikan",
-                "desc_en": "[Integer] Number of ballots issued but not returned for counting, including postal ballots not returned to the counting centre in time, but excluding spoilt ballots (e.g. torn or stained) which were replaced and therefore not counted as ballots issued",
-                "desc_bm": "[Integer] Jumlah kertas undi yang dikeluarkan tetapi tidak dikembalikan untuk pengiraan undi, termasuk kertas undi pos yang tidak dikembalikan ke pusat kiraan undi, tetapi tidak termasuk kertas undi rosak (contohnya terkoyak atau ternoda) yang telah digantikan maka tidak dikira sebagai kertas undi yang dikeluarkan"
-            },
-            {
-                "id": -1,
-                "name": "votes_rejected",
-                "title_en": "Votes Rejected",
-                "title_bm": "Undi Ditolak",
-                "desc_en": "[Integer] Number of ballots returned but declared invalid during counting because the candidate could not be determined",
-                "desc_bm": "[Integer] Jumlah kertas undi yang telah dikembalikan tetapi ditolak semasa proses kiraan undi kerana calon yang diundi tidak dapat ditentukan"
-            },
-            {
-                "id": -1,
-                "name": "voter_turnout",
-                "title_en": "Voter Turnout",
-                "title_bm": "Peratus Keluar",
-                "desc_en": "[Float] Derived as: (ballots_issued / voters_total) * 100",
-                "desc_bm": " [Apung] Diperolehi dengan formula: (ballots_issued / voters_total) * 100"
-            },
-            {
-                "id": -1,
-                "name": "votes_rejected_perc",
-                "title_en": "Percentage Rejected",
-                "title_bm": "Peratus Ditolak",
-                "desc_en": "[Float] Derived as: (votes_rejected / (ballots_issued - ballots_not_returned)) * 100",
-                "desc_bm": " [Apung] Diperolehi dengan formula: (votes_rejected / (ballots_issued - ballots_not_returned)) * 100"
-            }
-        ]
-    }
+	"file": {
+		"manual_trigger": 0,
+		"bucket": "elections_federal",
+		"file_name": "ge09_summary",
+		"category": "ELECTIONS",
+		"category_en": "Elections",
+		"category_bm": "Pilihanraya",
+		"subcategory": "FEDERAL",
+		"subcategory_en": "Federal",
+		"subcategory_bm": "Persekutuan",
+		"description": {
+			"en": "Analytical summary of the pre-Independence general election held in 1955.",
+			"bm": "Ringkasan analitik bagi pilihanraya umum pramerdeka yang diadakan pada tahun 1955."
+		},
+		"link_parquet": "https://storage.data.gov.my/elections/federal/ge09_summary.parquet",
+		"link_csv": "https://storage.data.gov.my/elections/federal/ge09_summary.csv",
+		"link_preview": "https://storage.data.gov.my/elections/federal/ge09_summary.parquet",
+		"variables": [
+			{
+				"id": 0,
+				"name": "ge09_summary",
+				"title_en": "GE-09: Summary",
+				"title_bm": "PRU-09: Rumusan",
+				"desc_en": "Analytical summary of the pre-Independence general election held on 27 July 1955.",
+				"desc_bm": "Ringkasan analitik bagi pilihanraya umum pramerdeka yang diadakan pada 27 Julai 1955.",
+				"catalog_data": {
+					"catalog_filters": {
+						"frequency": "INFREQUENT",
+						"geography": ["PARLIMEN", "STATE", "NATIONAL"],
+						"demographic": [],
+						"start": "1995",
+						"end": "1995",
+						"data_source": ["SPR"]
+					},
+					"metadata_neutral": {
+						"data_as_of": "1955-08-31 23:59",
+						"last_updated": "2023-07-18 23:59",
+						"next_update": "-"
+					},
+					"metadata_lang": {
+						"en": {
+							"methodology": "This data is a digital representation of the physical election results tabulated and gazetted per the Electoral Regulations (Conduct of Elections). The digitalisation process was rigorously cross-checked against physical records to ensure consistency and accuracy of information.",
+							"caveat": "As of now, this data has not been verified by SPR, and is shown here on the staging site to provide easy access for exploring and checking the data.",
+							"publication": "-"
+						},
+						"bm": {
+							"methodology": "Data ini merupakan rekod digital keputusan pilihanraya yang dikira dan diwartakan selaras dengan Peraturan-Peraturan Pilihan Raya (Penjalanan Pilihan Raya). Proses pendigitalan disemak silang dengan rekod fizikal untuk memastikan ketepatan maklumat.",
+							"caveat": "Setakat sekarang, data ini belum disemak dan diabsahkan oleh SPR, maka hanya dipaparkan di portal UAT ini bagi tujuan memudahkan proses semakan.",
+							"publication": "-"
+						}
+					},
+					"chart": {
+						"chart_type": "TABLE",
+						"chart_filters": {
+							"SLICE_BY": [],
+							"precision": 0
+						},
+						"chart_variables": {
+							"parents": [],
+							"exclude": [],
+							"freeze": ["state", "parlimen"]
+						}
+					}
+				}
+			},
+			{
+				"id": -1,
+				"name": "state",
+				"title_en": "State",
+				"title_bm": "Negeri",
+				"desc_en": "[String] 1 of 16 states",
+				"desc_bm": "[Rentetan] 1 antara 16 negeri"
+			},
+			{
+				"id": -1,
+				"name": "parlimen",
+				"title_en": "Parliament",
+				"title_bm": "Parlimen",
+				"desc_en": "[String] Name of seat as it appeared on the ballot on voting day",
+				"desc_bm": "[Rentetan] Nama kerusi seperti mana yang tertera di kertas undi pada hari mengundi"
+			},
+			{
+				"id": -1,
+				"name": "area_name",
+				"title_en": "Area Name",
+				"title_bm": "Nama Kawasan",
+				"desc_en": "[String] Name of the area, with seat code (P.xxx) stripped out, and area name historically harmonised. For example, Kota Baharu, Kota Bahru and Kota Bharu are all harmonised to the modern Kota Bharu.",
+				"desc_bm": "[Rentetan] Nama kawasan, tanpa kod kerusi (P.xxx) dan namanya diselaraskan mengambil kira perubahan dari zaman ke zaman. Contohnya, nama Kota Baharu, Kota Bahru, dan Kota Bharu semuanya diharmonikan kepada penggunaan moden iaitu Kota Bharu."
+			},
+			{
+				"id": -1,
+				"name": "voters_total",
+				"title_en": "Total Voters",
+				"title_bm": "Jumlah Pengundi",
+				"desc_en": "[Integer] Number of voters registered to vote in that seat at that election",
+				"desc_bm": "[Integer] Jumlah pengundi yang didaftarkan untuk mengundi di kerusi tersebut semasa PRU-00"
+			},
+			{
+				"id": -1,
+				"name": "ballots_issued",
+				"title_en": "Ballots Issued",
+				"title_bm": "Undi Dikeluarkan",
+				"desc_en": "[Integer] Number of ballots issued, including postal ballots, but not inclduing ballots accidentally damaged and immediately replace during the voting procedure",
+				"desc_bm": "[Integer] Jumlah kertas undi yang dikeluarkan, termasuk kertas undi pos, tetapi tidak termasuk kertas undi yang rosak dan terus digantikan semasa urusan mengundi dijalankan"
+			},
+			{
+				"id": -1,
+				"name": "ballots_not_returned",
+				"title_en": "Ballots Not Returned",
+				"title_bm": "Undi Tidak Dikembalikan",
+				"desc_en": "[Integer] Number of ballots issued but not returned for counting, including postal ballots not returned to the counting centre in time, but excluding spoilt ballots (e.g. torn or stained) which were replaced and therefore not counted as ballots issued",
+				"desc_bm": "[Integer] Jumlah kertas undi yang dikeluarkan tetapi tidak dikembalikan untuk pengiraan undi, termasuk kertas undi pos yang tidak dikembalikan ke pusat kiraan undi, tetapi tidak termasuk kertas undi rosak (contohnya terkoyak atau ternoda) yang telah digantikan maka tidak dikira sebagai kertas undi yang dikeluarkan"
+			},
+			{
+				"id": -1,
+				"name": "votes_rejected",
+				"title_en": "Votes Rejected",
+				"title_bm": "Undi Ditolak",
+				"desc_en": "[Integer] Number of ballots returned but declared invalid during counting because the candidate could not be determined",
+				"desc_bm": "[Integer] Jumlah kertas undi yang telah dikembalikan tetapi ditolak semasa proses kiraan undi kerana calon yang diundi tidak dapat ditentukan"
+			},
+			{
+				"id": -1,
+				"name": "voter_turnout",
+				"title_en": "Voter Turnout",
+				"title_bm": "Peratus Keluar",
+				"desc_en": "[Float] Derived as: (ballots_issued / voters_total) * 100",
+				"desc_bm": " [Apung] Diperolehi dengan formula: (ballots_issued / voters_total) * 100"
+			},
+			{
+				"id": -1,
+				"name": "votes_rejected_perc",
+				"title_en": "Percentage Rejected",
+				"title_bm": "Peratus Ditolak",
+				"desc_en": "[Float] Derived as: (votes_rejected / (ballots_issued - ballots_not_returned)) * 100",
+				"desc_bm": " [Apung] Diperolehi dengan formula: (votes_rejected / (ballots_issued - ballots_not_returned)) * 100"
+			}
+		]
+	}
 }

--- a/catalog/ge09_summary.json
+++ b/catalog/ge09_summary.json
@@ -28,7 +28,7 @@
 					"catalog_filters": {
 						"frequency": "INFREQUENT",
 						"geography": ["PARLIMEN", "STATE", "NATIONAL"],
-						"demographic": [],
+						"demography": [],
 						"start": "1995",
 						"end": "1995",
 						"data_source": ["SPR"]

--- a/catalog/ge10_ballots.json
+++ b/catalog/ge10_ballots.json
@@ -28,7 +28,7 @@
 					"catalog_filters": {
 						"frequency": "INFREQUENT",
 						"geography": ["PARLIMEN", "STATE", "NATIONAL"],
-						"demographic": [],
+						"demography": [],
 						"start": "1999",
 						"end": "1999",
 						"data_source": ["SPR"]

--- a/catalog/ge10_ballots.json
+++ b/catalog/ge10_ballots.json
@@ -1,142 +1,133 @@
 {
-    "file": {
-        "manual_trigger": 0,
-        "bucket": "elections_federal",
-        "file_name": "ge10_ballots",
-        "category": "ELECTIONS",
-        "category_en": "Elections",
-        "category_bm": "Pilihanraya",
-        "subcategory": "FEDERAL",
-        "subcategory_en": "Federal",
-        "subcategory_bm": "Persekutuan",
-        "description": {
-            "en": "Ballots for every seat contested at the pre-Independence general election held in 1955.",
-            "bm": "Perincian undi bagi setiap kerusi yang dipertandingkan di pilihanraya umum pramerdeka yang diadakan pada tahun 1955."
-        },
-        "link_parquet": "https://storage.data.gov.my/elections/federal/ge10_ballots.parquet",
-        "link_csv": "https://storage.data.gov.my/elections/federal/ge10_ballots.csv",
-        "link_preview": "https://storage.data.gov.my/elections/federal/ge10_ballots.parquet",
-        "variables": [
-            {
-                "id": 0,
-                "name": "ge10_ballots",
-                "title_en": "GE-10: Ballots",
-                "title_bm": "PRU-10: Kertas Undi",
-                "desc_en": "Ballots for every seat contested at the pre-Independence general election held on 27 July 1955.",
-                "desc_bm": "Perincian undi bagi setiap kerusi yang dipertandingkan di pilihanraya umum pramerdeka yang diadakan pada 27 Julai 1955.",
-                "catalog_data": {
-                    "catalog_filters": {
-                        "frequency": "INFREQUENT",
-                        "geographic": [
-                            "PARLIMEN",
-                            "STATE",
-                            "NATIONAL"
-                        ],
-                        "demographic": [],
-                        "start": "1999",
-                        "end": "1999",
-                        "data_source": [
-                            "SPR"
-                        ]
-                    },
-                    "metadata_neutral": {
-                        "data_as_of": "1955-08-31 23:59",
-                        "last_updated": "2023-07-18 23:59",
-                        "next_update": "-"
-                    },
-                    "metadata_lang": {
-                        "en": {
-                            "methodology": "This data is a digital representation of the physical election results tabulated and gazetted per the Electoral Regulations (Conduct of Elections). The digitalisation process was rigorously cross-checked against physical records to ensure consistency and accuracy of information.",
-                            "caveat": "As of now, this data has not been verified by SPR, and is shown here on the staging site to provide easy access for exploring and checking the data.",
-                            "publication": "-"
-                        },
-                        "bm": {
-                            "methodology": "Data ini merupakan rekod digital keputusan pilihanraya yang dikira dan diwartakan selaras dengan Peraturan-Peraturan Pilihan Raya (Penjalanan Pilihan Raya). Proses pendigitalan disemak silang dengan rekod fizikal untuk memastikan ketepatan maklumat.",
-                            "caveat": "Setakat sekarang, data ini belum disemak dan diabsahkan oleh SPR, maka hanya dipaparkan di portal UAT ini bagi tujuan memudahkan proses semakan.",
-                            "publication": "-"
-                        }
-                    },
-                    "chart": {
-                        "chart_type": "TABLE",
-                        "chart_filters": {
-                            "SLICE_BY": [],
-                            "precision": 0
-                        },
-                        "chart_variables": {
-                            "parents": [],
-                            "exclude": [],
-                            "freeze": [
-                                "state",
-                                "parlimen"
-                            ]
-                        }
-                    }
-                }
-            },
-            {
-                "id": -1,
-                "name": "state",
-                "title_en": "State",
-                "title_bm": "Negeri",
-                "desc_en": "[String] 1 of 16 states",
-                "desc_bm": "[Rentetan] 1 antara 16 negeri"
-            },
-            {
-                "id": -1,
-                "name": "parlimen",
-                "title_en": "Parliament",
-                "title_bm": "Parlimen",
-                "desc_en": "[String] Name of seat as it appeared on the ballot on voting day",
-                "desc_bm": "[Rentetan] Nama kerusi seperti mana yang tertera di kertas undi pada hari mengundi"
-            },
-            {
-                "id": -1,
-                "name": "area_name",
-                "title_en": "Area Name",
-                "title_bm": "Nama Kawasan",
-                "desc_en": "[String] Name of the area, with seat code (P.xxx) stripped out, and area name historically harmonised. For example, Kota Baharu, Kota Bahru and Kota Bharu are all harmonised to the modern Kota Bharu.",
-                "desc_bm": "[Rentetan] Nama kawasan, tanpa kod kerusi (P.xxx) dan namanya diselaraskan mengambil kira perubahan dari zaman ke zaman. Contohnya, nama Kota Baharu, Kota Bahru, dan Kota Bharu semuanya diharmonikan kepada penggunaan moden iaitu Kota Bharu."
-            },
-            {
-                "id": -1,
-                "name": "ballot_order",
-                "title_en": "Ballot Order",
-                "title_bm": "Urutan Nama",
-                "desc_en": "[Integer] Order in which the candidate appears on the ballot",
-                "desc_bm": "[Integer] Urutan nama-nama yang tertera pada kertas undi"
-            },
-            {
-                "id": -1,
-                "name": "name",
-                "title_en": "Name",
-                "title_bm": "Nama",
-                "desc_en": "[String] Name of candidate as it appeared on the ballot on voting day; this may not be the same as their real name as candidates are free to choose the name they use for campaigning and voting",
-                "desc_bm": "[Rentetan] Nama calon seperti mana yang tertera di kertas undi pada hari mengundi; ini tidak semestinya sama dengan nama sebenar mereka kerana calon adalah bebas untuk memilih nama yang digunakan bagi tujuan kempen dan undi"
-            },
-            {
-                "id": -1,
-                "name": "candidate_uid",
-                "title_en": "Unique Candidate ID",
-                "title_bm": "ID Unik Calon",
-                "desc_en": "[Integer] Unique integer identifier to track candidates across elections",
-                "desc_bm": "[Integer] Integer unik untuk menjejaki keputusan seseorang calon merentasi pilihan raya"
-            },
-            {
-                "id": -1,
-                "name": "party",
-                "title_en": "Party",
-                "title_bm": "Parti",
-                "desc_en": "[String] Party of the candidate as it appeared on the ballot on voting day; this record is not amended to reflect unofficial information on parties and coalitions. For example, if a candidate competed under the flag of Party X despite being a member of Party Y, their party is recorded as Party X.",
-                "desc_bm": "[String] Parti calon seperti yang tertera pada kertas undi pada hari mengundi; rekod ini tidak dipinda untuk menggambarkan maklumat tidak rasmi mengenai parti dan gabungan. Sebagai contoh, jika calon bertanding bawah bendera Parti X walaupun menjadi ahli Parti Y, parti mereka direkodkan sebagai Parti X."
-            },
-            {
-                "id": -1,
-                "name": "votes",
-                "title_en": "Votes",
-                "title_bm": "Undi",
-                "desc_en": "Integer] Number of votes won by the candidate",
-                "desc_bm": "[Integer] Jumlah undi yang diperolehi oleh calon"
-            }
-        ]
-    }
+	"file": {
+		"manual_trigger": 0,
+		"bucket": "elections_federal",
+		"file_name": "ge10_ballots",
+		"category": "ELECTIONS",
+		"category_en": "Elections",
+		"category_bm": "Pilihanraya",
+		"subcategory": "FEDERAL",
+		"subcategory_en": "Federal",
+		"subcategory_bm": "Persekutuan",
+		"description": {
+			"en": "Ballots for every seat contested at the pre-Independence general election held in 1955.",
+			"bm": "Perincian undi bagi setiap kerusi yang dipertandingkan di pilihanraya umum pramerdeka yang diadakan pada tahun 1955."
+		},
+		"link_parquet": "https://storage.data.gov.my/elections/federal/ge10_ballots.parquet",
+		"link_csv": "https://storage.data.gov.my/elections/federal/ge10_ballots.csv",
+		"link_preview": "https://storage.data.gov.my/elections/federal/ge10_ballots.parquet",
+		"variables": [
+			{
+				"id": 0,
+				"name": "ge10_ballots",
+				"title_en": "GE-10: Ballots",
+				"title_bm": "PRU-10: Kertas Undi",
+				"desc_en": "Ballots for every seat contested at the pre-Independence general election held on 27 July 1955.",
+				"desc_bm": "Perincian undi bagi setiap kerusi yang dipertandingkan di pilihanraya umum pramerdeka yang diadakan pada 27 Julai 1955.",
+				"catalog_data": {
+					"catalog_filters": {
+						"frequency": "INFREQUENT",
+						"geography": ["PARLIMEN", "STATE", "NATIONAL"],
+						"demographic": [],
+						"start": "1999",
+						"end": "1999",
+						"data_source": ["SPR"]
+					},
+					"metadata_neutral": {
+						"data_as_of": "1955-08-31 23:59",
+						"last_updated": "2023-07-18 23:59",
+						"next_update": "-"
+					},
+					"metadata_lang": {
+						"en": {
+							"methodology": "This data is a digital representation of the physical election results tabulated and gazetted per the Electoral Regulations (Conduct of Elections). The digitalisation process was rigorously cross-checked against physical records to ensure consistency and accuracy of information.",
+							"caveat": "As of now, this data has not been verified by SPR, and is shown here on the staging site to provide easy access for exploring and checking the data.",
+							"publication": "-"
+						},
+						"bm": {
+							"methodology": "Data ini merupakan rekod digital keputusan pilihanraya yang dikira dan diwartakan selaras dengan Peraturan-Peraturan Pilihan Raya (Penjalanan Pilihan Raya). Proses pendigitalan disemak silang dengan rekod fizikal untuk memastikan ketepatan maklumat.",
+							"caveat": "Setakat sekarang, data ini belum disemak dan diabsahkan oleh SPR, maka hanya dipaparkan di portal UAT ini bagi tujuan memudahkan proses semakan.",
+							"publication": "-"
+						}
+					},
+					"chart": {
+						"chart_type": "TABLE",
+						"chart_filters": {
+							"SLICE_BY": [],
+							"precision": 0
+						},
+						"chart_variables": {
+							"parents": [],
+							"exclude": [],
+							"freeze": ["state", "parlimen"]
+						}
+					}
+				}
+			},
+			{
+				"id": -1,
+				"name": "state",
+				"title_en": "State",
+				"title_bm": "Negeri",
+				"desc_en": "[String] 1 of 16 states",
+				"desc_bm": "[Rentetan] 1 antara 16 negeri"
+			},
+			{
+				"id": -1,
+				"name": "parlimen",
+				"title_en": "Parliament",
+				"title_bm": "Parlimen",
+				"desc_en": "[String] Name of seat as it appeared on the ballot on voting day",
+				"desc_bm": "[Rentetan] Nama kerusi seperti mana yang tertera di kertas undi pada hari mengundi"
+			},
+			{
+				"id": -1,
+				"name": "area_name",
+				"title_en": "Area Name",
+				"title_bm": "Nama Kawasan",
+				"desc_en": "[String] Name of the area, with seat code (P.xxx) stripped out, and area name historically harmonised. For example, Kota Baharu, Kota Bahru and Kota Bharu are all harmonised to the modern Kota Bharu.",
+				"desc_bm": "[Rentetan] Nama kawasan, tanpa kod kerusi (P.xxx) dan namanya diselaraskan mengambil kira perubahan dari zaman ke zaman. Contohnya, nama Kota Baharu, Kota Bahru, dan Kota Bharu semuanya diharmonikan kepada penggunaan moden iaitu Kota Bharu."
+			},
+			{
+				"id": -1,
+				"name": "ballot_order",
+				"title_en": "Ballot Order",
+				"title_bm": "Urutan Nama",
+				"desc_en": "[Integer] Order in which the candidate appears on the ballot",
+				"desc_bm": "[Integer] Urutan nama-nama yang tertera pada kertas undi"
+			},
+			{
+				"id": -1,
+				"name": "name",
+				"title_en": "Name",
+				"title_bm": "Nama",
+				"desc_en": "[String] Name of candidate as it appeared on the ballot on voting day; this may not be the same as their real name as candidates are free to choose the name they use for campaigning and voting",
+				"desc_bm": "[Rentetan] Nama calon seperti mana yang tertera di kertas undi pada hari mengundi; ini tidak semestinya sama dengan nama sebenar mereka kerana calon adalah bebas untuk memilih nama yang digunakan bagi tujuan kempen dan undi"
+			},
+			{
+				"id": -1,
+				"name": "candidate_uid",
+				"title_en": "Unique Candidate ID",
+				"title_bm": "ID Unik Calon",
+				"desc_en": "[Integer] Unique integer identifier to track candidates across elections",
+				"desc_bm": "[Integer] Integer unik untuk menjejaki keputusan seseorang calon merentasi pilihan raya"
+			},
+			{
+				"id": -1,
+				"name": "party",
+				"title_en": "Party",
+				"title_bm": "Parti",
+				"desc_en": "[String] Party of the candidate as it appeared on the ballot on voting day; this record is not amended to reflect unofficial information on parties and coalitions. For example, if a candidate competed under the flag of Party X despite being a member of Party Y, their party is recorded as Party X.",
+				"desc_bm": "[String] Parti calon seperti yang tertera pada kertas undi pada hari mengundi; rekod ini tidak dipinda untuk menggambarkan maklumat tidak rasmi mengenai parti dan gabungan. Sebagai contoh, jika calon bertanding bawah bendera Parti X walaupun menjadi ahli Parti Y, parti mereka direkodkan sebagai Parti X."
+			},
+			{
+				"id": -1,
+				"name": "votes",
+				"title_en": "Votes",
+				"title_bm": "Undi",
+				"desc_en": "Integer] Number of votes won by the candidate",
+				"desc_bm": "[Integer] Jumlah undi yang diperolehi oleh calon"
+			}
+		]
+	}
 }

--- a/catalog/ge10_summary.json
+++ b/catalog/ge10_summary.json
@@ -28,7 +28,7 @@
 					"catalog_filters": {
 						"frequency": "INFREQUENT",
 						"geography": ["PARLIMEN", "STATE", "NATIONAL"],
-						"demographic": [],
+						"demography": [],
 						"start": "1999",
 						"end": "1999",
 						"data_source": ["SPR"]

--- a/catalog/ge10_summary.json
+++ b/catalog/ge10_summary.json
@@ -1,150 +1,141 @@
 {
-    "file": {
-        "manual_trigger": 0,
-        "bucket": "elections_federal",
-        "file_name": "ge10_summary",
-        "category": "ELECTIONS",
-        "category_en": "Elections",
-        "category_bm": "Pilihanraya",
-        "subcategory": "FEDERAL",
-        "subcategory_en": "Federal",
-        "subcategory_bm": "Persekutuan",
-        "description": {
-            "en": "Analytical summary of the pre-Independence general election held in 1955.",
-            "bm": "Ringkasan analitik bagi pilihanraya umum pramerdeka yang diadakan pada tahun 1955."
-        },
-        "link_parquet": "https://storage.data.gov.my/elections/federal/ge10_summary.parquet",
-        "link_csv": "https://storage.data.gov.my/elections/federal/ge10_summary.csv",
-        "link_preview": "https://storage.data.gov.my/elections/federal/ge10_summary.parquet",
-        "variables": [
-            {
-                "id": 0,
-                "name": "ge10_summary",
-                "title_en": "GE-10: Summary",
-                "title_bm": "PRU-10: Rumusan",
-                "desc_en": "Analytical summary of the pre-Independence general election held on 27 July 1955.",
-                "desc_bm": "Ringkasan analitik bagi pilihanraya umum pramerdeka yang diadakan pada 27 Julai 1955.",
-                "catalog_data": {
-                    "catalog_filters": {
-                        "frequency": "INFREQUENT",
-                        "geographic": [
-                            "PARLIMEN",
-                            "STATE",
-                            "NATIONAL"
-                        ],
-                        "demographic": [],
-                        "start": "1999",
-                        "end": "1999",
-                        "data_source": [
-                            "SPR"
-                        ]
-                    },
-                    "metadata_neutral": {
-                        "data_as_of": "1955-08-31 23:59",
-                        "last_updated": "2023-07-18 23:59",
-                        "next_update": "-"
-                    },
-                    "metadata_lang": {
-                        "en": {
-                            "methodology": "This data is a digital representation of the physical election results tabulated and gazetted per the Electoral Regulations (Conduct of Elections). The digitalisation process was rigorously cross-checked against physical records to ensure consistency and accuracy of information.",
-                            "caveat": "As of now, this data has not been verified by SPR, and is shown here on the staging site to provide easy access for exploring and checking the data.",
-                            "publication": "-"
-                        },
-                        "bm": {
-                            "methodology": "Data ini merupakan rekod digital keputusan pilihanraya yang dikira dan diwartakan selaras dengan Peraturan-Peraturan Pilihan Raya (Penjalanan Pilihan Raya). Proses pendigitalan disemak silang dengan rekod fizikal untuk memastikan ketepatan maklumat.",
-                            "caveat": "Setakat sekarang, data ini belum disemak dan diabsahkan oleh SPR, maka hanya dipaparkan di portal UAT ini bagi tujuan memudahkan proses semakan.",
-                            "publication": "-"
-                        }
-                    },
-                    "chart": {
-                        "chart_type": "TABLE",
-                        "chart_filters": {
-                            "SLICE_BY": [],
-                            "precision": 0
-                        },
-                        "chart_variables": {
-                            "parents": [],
-                            "exclude": [],
-                            "freeze": [
-                                "state",
-                                "parlimen"
-                            ]
-                        }
-                    }
-                }
-            },
-            {
-                "id": -1,
-                "name": "state",
-                "title_en": "State",
-                "title_bm": "Negeri",
-                "desc_en": "[String] 1 of 16 states",
-                "desc_bm": "[Rentetan] 1 antara 16 negeri"
-            },
-            {
-                "id": -1,
-                "name": "parlimen",
-                "title_en": "Parliament",
-                "title_bm": "Parlimen",
-                "desc_en": "[String] Name of seat as it appeared on the ballot on voting day",
-                "desc_bm": "[Rentetan] Nama kerusi seperti mana yang tertera di kertas undi pada hari mengundi"
-            },
-            {
-                "id": -1,
-                "name": "area_name",
-                "title_en": "Area Name",
-                "title_bm": "Nama Kawasan",
-                "desc_en": "[String] Name of the area, with seat code (P.xxx) stripped out, and area name historically harmonised. For example, Kota Baharu, Kota Bahru and Kota Bharu are all harmonised to the modern Kota Bharu.",
-                "desc_bm": "[Rentetan] Nama kawasan, tanpa kod kerusi (P.xxx) dan namanya diselaraskan mengambil kira perubahan dari zaman ke zaman. Contohnya, nama Kota Baharu, Kota Bahru, dan Kota Bharu semuanya diharmonikan kepada penggunaan moden iaitu Kota Bharu."
-            },
-            {
-                "id": -1,
-                "name": "voters_total",
-                "title_en": "Total Voters",
-                "title_bm": "Jumlah Pengundi",
-                "desc_en": "[Integer] Number of voters registered to vote in that seat at that election",
-                "desc_bm": "[Integer] Jumlah pengundi yang didaftarkan untuk mengundi di kerusi tersebut semasa PRU-00"
-            },
-            {
-                "id": -1,
-                "name": "ballots_issued",
-                "title_en": "Ballots Issued",
-                "title_bm": "Undi Dikeluarkan",
-                "desc_en": "[Integer] Number of ballots issued, including postal ballots, but not inclduing ballots accidentally damaged and immediately replace during the voting procedure",
-                "desc_bm": "[Integer] Jumlah kertas undi yang dikeluarkan, termasuk kertas undi pos, tetapi tidak termasuk kertas undi yang rosak dan terus digantikan semasa urusan mengundi dijalankan"
-            },
-            {
-                "id": -1,
-                "name": "ballots_not_returned",
-                "title_en": "Ballots Not Returned",
-                "title_bm": "Undi Tidak Dikembalikan",
-                "desc_en": "[Integer] Number of ballots issued but not returned for counting, including postal ballots not returned to the counting centre in time, but excluding spoilt ballots (e.g. torn or stained) which were replaced and therefore not counted as ballots issued",
-                "desc_bm": "[Integer] Jumlah kertas undi yang dikeluarkan tetapi tidak dikembalikan untuk pengiraan undi, termasuk kertas undi pos yang tidak dikembalikan ke pusat kiraan undi, tetapi tidak termasuk kertas undi rosak (contohnya terkoyak atau ternoda) yang telah digantikan maka tidak dikira sebagai kertas undi yang dikeluarkan"
-            },
-            {
-                "id": -1,
-                "name": "votes_rejected",
-                "title_en": "Votes Rejected",
-                "title_bm": "Undi Ditolak",
-                "desc_en": "[Integer] Number of ballots returned but declared invalid during counting because the candidate could not be determined",
-                "desc_bm": "[Integer] Jumlah kertas undi yang telah dikembalikan tetapi ditolak semasa proses kiraan undi kerana calon yang diundi tidak dapat ditentukan"
-            },
-            {
-                "id": -1,
-                "name": "voter_turnout",
-                "title_en": "Voter Turnout",
-                "title_bm": "Peratus Keluar",
-                "desc_en": "[Float] Derived as: (ballots_issued / voters_total) * 100",
-                "desc_bm": " [Apung] Diperolehi dengan formula: (ballots_issued / voters_total) * 100"
-            },
-            {
-                "id": -1,
-                "name": "votes_rejected_perc",
-                "title_en": "Percentage Rejected",
-                "title_bm": "Peratus Ditolak",
-                "desc_en": "[Float] Derived as: (votes_rejected / (ballots_issued - ballots_not_returned)) * 100",
-                "desc_bm": " [Apung] Diperolehi dengan formula: (votes_rejected / (ballots_issued - ballots_not_returned)) * 100"
-            }
-        ]
-    }
+	"file": {
+		"manual_trigger": 0,
+		"bucket": "elections_federal",
+		"file_name": "ge10_summary",
+		"category": "ELECTIONS",
+		"category_en": "Elections",
+		"category_bm": "Pilihanraya",
+		"subcategory": "FEDERAL",
+		"subcategory_en": "Federal",
+		"subcategory_bm": "Persekutuan",
+		"description": {
+			"en": "Analytical summary of the pre-Independence general election held in 1955.",
+			"bm": "Ringkasan analitik bagi pilihanraya umum pramerdeka yang diadakan pada tahun 1955."
+		},
+		"link_parquet": "https://storage.data.gov.my/elections/federal/ge10_summary.parquet",
+		"link_csv": "https://storage.data.gov.my/elections/federal/ge10_summary.csv",
+		"link_preview": "https://storage.data.gov.my/elections/federal/ge10_summary.parquet",
+		"variables": [
+			{
+				"id": 0,
+				"name": "ge10_summary",
+				"title_en": "GE-10: Summary",
+				"title_bm": "PRU-10: Rumusan",
+				"desc_en": "Analytical summary of the pre-Independence general election held on 27 July 1955.",
+				"desc_bm": "Ringkasan analitik bagi pilihanraya umum pramerdeka yang diadakan pada 27 Julai 1955.",
+				"catalog_data": {
+					"catalog_filters": {
+						"frequency": "INFREQUENT",
+						"geography": ["PARLIMEN", "STATE", "NATIONAL"],
+						"demographic": [],
+						"start": "1999",
+						"end": "1999",
+						"data_source": ["SPR"]
+					},
+					"metadata_neutral": {
+						"data_as_of": "1955-08-31 23:59",
+						"last_updated": "2023-07-18 23:59",
+						"next_update": "-"
+					},
+					"metadata_lang": {
+						"en": {
+							"methodology": "This data is a digital representation of the physical election results tabulated and gazetted per the Electoral Regulations (Conduct of Elections). The digitalisation process was rigorously cross-checked against physical records to ensure consistency and accuracy of information.",
+							"caveat": "As of now, this data has not been verified by SPR, and is shown here on the staging site to provide easy access for exploring and checking the data.",
+							"publication": "-"
+						},
+						"bm": {
+							"methodology": "Data ini merupakan rekod digital keputusan pilihanraya yang dikira dan diwartakan selaras dengan Peraturan-Peraturan Pilihan Raya (Penjalanan Pilihan Raya). Proses pendigitalan disemak silang dengan rekod fizikal untuk memastikan ketepatan maklumat.",
+							"caveat": "Setakat sekarang, data ini belum disemak dan diabsahkan oleh SPR, maka hanya dipaparkan di portal UAT ini bagi tujuan memudahkan proses semakan.",
+							"publication": "-"
+						}
+					},
+					"chart": {
+						"chart_type": "TABLE",
+						"chart_filters": {
+							"SLICE_BY": [],
+							"precision": 0
+						},
+						"chart_variables": {
+							"parents": [],
+							"exclude": [],
+							"freeze": ["state", "parlimen"]
+						}
+					}
+				}
+			},
+			{
+				"id": -1,
+				"name": "state",
+				"title_en": "State",
+				"title_bm": "Negeri",
+				"desc_en": "[String] 1 of 16 states",
+				"desc_bm": "[Rentetan] 1 antara 16 negeri"
+			},
+			{
+				"id": -1,
+				"name": "parlimen",
+				"title_en": "Parliament",
+				"title_bm": "Parlimen",
+				"desc_en": "[String] Name of seat as it appeared on the ballot on voting day",
+				"desc_bm": "[Rentetan] Nama kerusi seperti mana yang tertera di kertas undi pada hari mengundi"
+			},
+			{
+				"id": -1,
+				"name": "area_name",
+				"title_en": "Area Name",
+				"title_bm": "Nama Kawasan",
+				"desc_en": "[String] Name of the area, with seat code (P.xxx) stripped out, and area name historically harmonised. For example, Kota Baharu, Kota Bahru and Kota Bharu are all harmonised to the modern Kota Bharu.",
+				"desc_bm": "[Rentetan] Nama kawasan, tanpa kod kerusi (P.xxx) dan namanya diselaraskan mengambil kira perubahan dari zaman ke zaman. Contohnya, nama Kota Baharu, Kota Bahru, dan Kota Bharu semuanya diharmonikan kepada penggunaan moden iaitu Kota Bharu."
+			},
+			{
+				"id": -1,
+				"name": "voters_total",
+				"title_en": "Total Voters",
+				"title_bm": "Jumlah Pengundi",
+				"desc_en": "[Integer] Number of voters registered to vote in that seat at that election",
+				"desc_bm": "[Integer] Jumlah pengundi yang didaftarkan untuk mengundi di kerusi tersebut semasa PRU-00"
+			},
+			{
+				"id": -1,
+				"name": "ballots_issued",
+				"title_en": "Ballots Issued",
+				"title_bm": "Undi Dikeluarkan",
+				"desc_en": "[Integer] Number of ballots issued, including postal ballots, but not inclduing ballots accidentally damaged and immediately replace during the voting procedure",
+				"desc_bm": "[Integer] Jumlah kertas undi yang dikeluarkan, termasuk kertas undi pos, tetapi tidak termasuk kertas undi yang rosak dan terus digantikan semasa urusan mengundi dijalankan"
+			},
+			{
+				"id": -1,
+				"name": "ballots_not_returned",
+				"title_en": "Ballots Not Returned",
+				"title_bm": "Undi Tidak Dikembalikan",
+				"desc_en": "[Integer] Number of ballots issued but not returned for counting, including postal ballots not returned to the counting centre in time, but excluding spoilt ballots (e.g. torn or stained) which were replaced and therefore not counted as ballots issued",
+				"desc_bm": "[Integer] Jumlah kertas undi yang dikeluarkan tetapi tidak dikembalikan untuk pengiraan undi, termasuk kertas undi pos yang tidak dikembalikan ke pusat kiraan undi, tetapi tidak termasuk kertas undi rosak (contohnya terkoyak atau ternoda) yang telah digantikan maka tidak dikira sebagai kertas undi yang dikeluarkan"
+			},
+			{
+				"id": -1,
+				"name": "votes_rejected",
+				"title_en": "Votes Rejected",
+				"title_bm": "Undi Ditolak",
+				"desc_en": "[Integer] Number of ballots returned but declared invalid during counting because the candidate could not be determined",
+				"desc_bm": "[Integer] Jumlah kertas undi yang telah dikembalikan tetapi ditolak semasa proses kiraan undi kerana calon yang diundi tidak dapat ditentukan"
+			},
+			{
+				"id": -1,
+				"name": "voter_turnout",
+				"title_en": "Voter Turnout",
+				"title_bm": "Peratus Keluar",
+				"desc_en": "[Float] Derived as: (ballots_issued / voters_total) * 100",
+				"desc_bm": " [Apung] Diperolehi dengan formula: (ballots_issued / voters_total) * 100"
+			},
+			{
+				"id": -1,
+				"name": "votes_rejected_perc",
+				"title_en": "Percentage Rejected",
+				"title_bm": "Peratus Ditolak",
+				"desc_en": "[Float] Derived as: (votes_rejected / (ballots_issued - ballots_not_returned)) * 100",
+				"desc_bm": " [Apung] Diperolehi dengan formula: (votes_rejected / (ballots_issued - ballots_not_returned)) * 100"
+			}
+		]
+	}
 }

--- a/catalog/ge11_ballots.json
+++ b/catalog/ge11_ballots.json
@@ -28,7 +28,7 @@
 					"catalog_filters": {
 						"frequency": "INFREQUENT",
 						"geography": ["PARLIMEN", "STATE", "NATIONAL"],
-						"demographic": [],
+						"demography": [],
 						"start": "2004",
 						"end": "2004",
 						"data_source": ["SPR"]

--- a/catalog/ge11_ballots.json
+++ b/catalog/ge11_ballots.json
@@ -1,142 +1,133 @@
 {
-    "file": {
-        "manual_trigger": 0,
-        "bucket": "elections_federal",
-        "file_name": "ge11_ballots",
-        "category": "ELECTIONS",
-        "category_en": "Elections",
-        "category_bm": "Pilihanraya",
-        "subcategory": "FEDERAL",
-        "subcategory_en": "Federal",
-        "subcategory_bm": "Persekutuan",
-        "description": {
-            "en": "Ballots for every seat contested at the pre-Independence general election held in 1955.",
-            "bm": "Perincian undi bagi setiap kerusi yang dipertandingkan di pilihanraya umum pramerdeka yang diadakan pada tahun 1955."
-        },
-        "link_parquet": "https://storage.data.gov.my/elections/federal/ge11_ballots.parquet",
-        "link_csv": "https://storage.data.gov.my/elections/federal/ge11_ballots.csv",
-        "link_preview": "https://storage.data.gov.my/elections/federal/ge11_ballots.parquet",
-        "variables": [
-            {
-                "id": 0,
-                "name": "ge11_ballots",
-                "title_en": "GE-11: Ballots",
-                "title_bm": "PRU-11: Kertas Undi",
-                "desc_en": "Ballots for every seat contested at the pre-Independence general election held on 27 July 1955.",
-                "desc_bm": "Perincian undi bagi setiap kerusi yang dipertandingkan di pilihanraya umum pramerdeka yang diadakan pada 27 Julai 1955.",
-                "catalog_data": {
-                    "catalog_filters": {
-                        "frequency": "INFREQUENT",
-                        "geographic": [
-                            "PARLIMEN",
-                            "STATE",
-                            "NATIONAL"
-                        ],
-                        "demographic": [],
-                        "start": "2004",
-                        "end": "2004",
-                        "data_source": [
-                            "SPR"
-                        ]
-                    },
-                    "metadata_neutral": {
-                        "data_as_of": "1955-08-31 23:59",
-                        "last_updated": "2023-07-18 23:59",
-                        "next_update": "-"
-                    },
-                    "metadata_lang": {
-                        "en": {
-                            "methodology": "This data is a digital representation of the physical election results tabulated and gazetted per the Electoral Regulations (Conduct of Elections). The digitalisation process was rigorously cross-checked against physical records to ensure consistency and accuracy of information.",
-                            "caveat": "As of now, this data has not been verified by SPR, and is shown here on the staging site to provide easy access for exploring and checking the data.",
-                            "publication": "-"
-                        },
-                        "bm": {
-                            "methodology": "Data ini merupakan rekod digital keputusan pilihanraya yang dikira dan diwartakan selaras dengan Peraturan-Peraturan Pilihan Raya (Penjalanan Pilihan Raya). Proses pendigitalan disemak silang dengan rekod fizikal untuk memastikan ketepatan maklumat.",
-                            "caveat": "Setakat sekarang, data ini belum disemak dan diabsahkan oleh SPR, maka hanya dipaparkan di portal UAT ini bagi tujuan memudahkan proses semakan.",
-                            "publication": "-"
-                        }
-                    },
-                    "chart": {
-                        "chart_type": "TABLE",
-                        "chart_filters": {
-                            "SLICE_BY": [],
-                            "precision": 0
-                        },
-                        "chart_variables": {
-                            "parents": [],
-                            "exclude": [],
-                            "freeze": [
-                                "state",
-                                "parlimen"
-                            ]
-                        }
-                    }
-                }
-            },
-            {
-                "id": -1,
-                "name": "state",
-                "title_en": "State",
-                "title_bm": "Negeri",
-                "desc_en": "[String] 1 of 16 states",
-                "desc_bm": "[Rentetan] 1 antara 16 negeri"
-            },
-            {
-                "id": -1,
-                "name": "parlimen",
-                "title_en": "Parliament",
-                "title_bm": "Parlimen",
-                "desc_en": "[String] Name of seat as it appeared on the ballot on voting day",
-                "desc_bm": "[Rentetan] Nama kerusi seperti mana yang tertera di kertas undi pada hari mengundi"
-            },
-            {
-                "id": -1,
-                "name": "area_name",
-                "title_en": "Area Name",
-                "title_bm": "Nama Kawasan",
-                "desc_en": "[String] Name of the area, with seat code (P.xxx) stripped out, and area name historically harmonised. For example, Kota Baharu, Kota Bahru and Kota Bharu are all harmonised to the modern Kota Bharu.",
-                "desc_bm": "[Rentetan] Nama kawasan, tanpa kod kerusi (P.xxx) dan namanya diselaraskan mengambil kira perubahan dari zaman ke zaman. Contohnya, nama Kota Baharu, Kota Bahru, dan Kota Bharu semuanya diharmonikan kepada penggunaan moden iaitu Kota Bharu."
-            },
-            {
-                "id": -1,
-                "name": "ballot_order",
-                "title_en": "Ballot Order",
-                "title_bm": "Urutan Nama",
-                "desc_en": "[Integer] Order in which the candidate appears on the ballot",
-                "desc_bm": "[Integer] Urutan nama-nama yang tertera pada kertas undi"
-            },
-            {
-                "id": -1,
-                "name": "name",
-                "title_en": "Name",
-                "title_bm": "Nama",
-                "desc_en": "[String] Name of candidate as it appeared on the ballot on voting day; this may not be the same as their real name as candidates are free to choose the name they use for campaigning and voting",
-                "desc_bm": "[Rentetan] Nama calon seperti mana yang tertera di kertas undi pada hari mengundi; ini tidak semestinya sama dengan nama sebenar mereka kerana calon adalah bebas untuk memilih nama yang digunakan bagi tujuan kempen dan undi"
-            },
-            {
-                "id": -1,
-                "name": "candidate_uid",
-                "title_en": "Unique Candidate ID",
-                "title_bm": "ID Unik Calon",
-                "desc_en": "[Integer] Unique integer identifier to track candidates across elections",
-                "desc_bm": "[Integer] Integer unik untuk menjejaki keputusan seseorang calon merentasi pilihan raya"
-            },
-            {
-                "id": -1,
-                "name": "party",
-                "title_en": "Party",
-                "title_bm": "Parti",
-                "desc_en": "[String] Party of the candidate as it appeared on the ballot on voting day; this record is not amended to reflect unofficial information on parties and coalitions. For example, if a candidate competed under the flag of Party X despite being a member of Party Y, their party is recorded as Party X.",
-                "desc_bm": "[String] Parti calon seperti yang tertera pada kertas undi pada hari mengundi; rekod ini tidak dipinda untuk menggambarkan maklumat tidak rasmi mengenai parti dan gabungan. Sebagai contoh, jika calon bertanding bawah bendera Parti X walaupun menjadi ahli Parti Y, parti mereka direkodkan sebagai Parti X."
-            },
-            {
-                "id": -1,
-                "name": "votes",
-                "title_en": "Votes",
-                "title_bm": "Undi",
-                "desc_en": "Integer] Number of votes won by the candidate",
-                "desc_bm": "[Integer] Jumlah undi yang diperolehi oleh calon"
-            }
-        ]
-    }
+	"file": {
+		"manual_trigger": 0,
+		"bucket": "elections_federal",
+		"file_name": "ge11_ballots",
+		"category": "ELECTIONS",
+		"category_en": "Elections",
+		"category_bm": "Pilihanraya",
+		"subcategory": "FEDERAL",
+		"subcategory_en": "Federal",
+		"subcategory_bm": "Persekutuan",
+		"description": {
+			"en": "Ballots for every seat contested at the pre-Independence general election held in 1955.",
+			"bm": "Perincian undi bagi setiap kerusi yang dipertandingkan di pilihanraya umum pramerdeka yang diadakan pada tahun 1955."
+		},
+		"link_parquet": "https://storage.data.gov.my/elections/federal/ge11_ballots.parquet",
+		"link_csv": "https://storage.data.gov.my/elections/federal/ge11_ballots.csv",
+		"link_preview": "https://storage.data.gov.my/elections/federal/ge11_ballots.parquet",
+		"variables": [
+			{
+				"id": 0,
+				"name": "ge11_ballots",
+				"title_en": "GE-11: Ballots",
+				"title_bm": "PRU-11: Kertas Undi",
+				"desc_en": "Ballots for every seat contested at the pre-Independence general election held on 27 July 1955.",
+				"desc_bm": "Perincian undi bagi setiap kerusi yang dipertandingkan di pilihanraya umum pramerdeka yang diadakan pada 27 Julai 1955.",
+				"catalog_data": {
+					"catalog_filters": {
+						"frequency": "INFREQUENT",
+						"geography": ["PARLIMEN", "STATE", "NATIONAL"],
+						"demographic": [],
+						"start": "2004",
+						"end": "2004",
+						"data_source": ["SPR"]
+					},
+					"metadata_neutral": {
+						"data_as_of": "1955-08-31 23:59",
+						"last_updated": "2023-07-18 23:59",
+						"next_update": "-"
+					},
+					"metadata_lang": {
+						"en": {
+							"methodology": "This data is a digital representation of the physical election results tabulated and gazetted per the Electoral Regulations (Conduct of Elections). The digitalisation process was rigorously cross-checked against physical records to ensure consistency and accuracy of information.",
+							"caveat": "As of now, this data has not been verified by SPR, and is shown here on the staging site to provide easy access for exploring and checking the data.",
+							"publication": "-"
+						},
+						"bm": {
+							"methodology": "Data ini merupakan rekod digital keputusan pilihanraya yang dikira dan diwartakan selaras dengan Peraturan-Peraturan Pilihan Raya (Penjalanan Pilihan Raya). Proses pendigitalan disemak silang dengan rekod fizikal untuk memastikan ketepatan maklumat.",
+							"caveat": "Setakat sekarang, data ini belum disemak dan diabsahkan oleh SPR, maka hanya dipaparkan di portal UAT ini bagi tujuan memudahkan proses semakan.",
+							"publication": "-"
+						}
+					},
+					"chart": {
+						"chart_type": "TABLE",
+						"chart_filters": {
+							"SLICE_BY": [],
+							"precision": 0
+						},
+						"chart_variables": {
+							"parents": [],
+							"exclude": [],
+							"freeze": ["state", "parlimen"]
+						}
+					}
+				}
+			},
+			{
+				"id": -1,
+				"name": "state",
+				"title_en": "State",
+				"title_bm": "Negeri",
+				"desc_en": "[String] 1 of 16 states",
+				"desc_bm": "[Rentetan] 1 antara 16 negeri"
+			},
+			{
+				"id": -1,
+				"name": "parlimen",
+				"title_en": "Parliament",
+				"title_bm": "Parlimen",
+				"desc_en": "[String] Name of seat as it appeared on the ballot on voting day",
+				"desc_bm": "[Rentetan] Nama kerusi seperti mana yang tertera di kertas undi pada hari mengundi"
+			},
+			{
+				"id": -1,
+				"name": "area_name",
+				"title_en": "Area Name",
+				"title_bm": "Nama Kawasan",
+				"desc_en": "[String] Name of the area, with seat code (P.xxx) stripped out, and area name historically harmonised. For example, Kota Baharu, Kota Bahru and Kota Bharu are all harmonised to the modern Kota Bharu.",
+				"desc_bm": "[Rentetan] Nama kawasan, tanpa kod kerusi (P.xxx) dan namanya diselaraskan mengambil kira perubahan dari zaman ke zaman. Contohnya, nama Kota Baharu, Kota Bahru, dan Kota Bharu semuanya diharmonikan kepada penggunaan moden iaitu Kota Bharu."
+			},
+			{
+				"id": -1,
+				"name": "ballot_order",
+				"title_en": "Ballot Order",
+				"title_bm": "Urutan Nama",
+				"desc_en": "[Integer] Order in which the candidate appears on the ballot",
+				"desc_bm": "[Integer] Urutan nama-nama yang tertera pada kertas undi"
+			},
+			{
+				"id": -1,
+				"name": "name",
+				"title_en": "Name",
+				"title_bm": "Nama",
+				"desc_en": "[String] Name of candidate as it appeared on the ballot on voting day; this may not be the same as their real name as candidates are free to choose the name they use for campaigning and voting",
+				"desc_bm": "[Rentetan] Nama calon seperti mana yang tertera di kertas undi pada hari mengundi; ini tidak semestinya sama dengan nama sebenar mereka kerana calon adalah bebas untuk memilih nama yang digunakan bagi tujuan kempen dan undi"
+			},
+			{
+				"id": -1,
+				"name": "candidate_uid",
+				"title_en": "Unique Candidate ID",
+				"title_bm": "ID Unik Calon",
+				"desc_en": "[Integer] Unique integer identifier to track candidates across elections",
+				"desc_bm": "[Integer] Integer unik untuk menjejaki keputusan seseorang calon merentasi pilihan raya"
+			},
+			{
+				"id": -1,
+				"name": "party",
+				"title_en": "Party",
+				"title_bm": "Parti",
+				"desc_en": "[String] Party of the candidate as it appeared on the ballot on voting day; this record is not amended to reflect unofficial information on parties and coalitions. For example, if a candidate competed under the flag of Party X despite being a member of Party Y, their party is recorded as Party X.",
+				"desc_bm": "[String] Parti calon seperti yang tertera pada kertas undi pada hari mengundi; rekod ini tidak dipinda untuk menggambarkan maklumat tidak rasmi mengenai parti dan gabungan. Sebagai contoh, jika calon bertanding bawah bendera Parti X walaupun menjadi ahli Parti Y, parti mereka direkodkan sebagai Parti X."
+			},
+			{
+				"id": -1,
+				"name": "votes",
+				"title_en": "Votes",
+				"title_bm": "Undi",
+				"desc_en": "Integer] Number of votes won by the candidate",
+				"desc_bm": "[Integer] Jumlah undi yang diperolehi oleh calon"
+			}
+		]
+	}
 }

--- a/catalog/ge11_summary.json
+++ b/catalog/ge11_summary.json
@@ -1,150 +1,141 @@
 {
-    "file": {
-        "manual_trigger": 0,
-        "bucket": "elections_federal",
-        "file_name": "ge11_summary",
-        "category": "ELECTIONS",
-        "category_en": "Elections",
-        "category_bm": "Pilihanraya",
-        "subcategory": "FEDERAL",
-        "subcategory_en": "Federal",
-        "subcategory_bm": "Persekutuan",
-        "description": {
-            "en": "Analytical summary of the pre-Independence general election held in 1955.",
-            "bm": "Ringkasan analitik bagi pilihanraya umum pramerdeka yang diadakan pada tahun 1955."
-        },
-        "link_parquet": "https://storage.data.gov.my/elections/federal/ge11_summary.parquet",
-        "link_csv": "https://storage.data.gov.my/elections/federal/ge11_summary.csv",
-        "link_preview": "https://storage.data.gov.my/elections/federal/ge11_summary.parquet",
-        "variables": [
-            {
-                "id": 0,
-                "name": "ge11_summary",
-                "title_en": "GE-11: Summary",
-                "title_bm": "PRU-11: Rumusan",
-                "desc_en": "Analytical summary of the pre-Independence general election held on 27 July 1955.",
-                "desc_bm": "Ringkasan analitik bagi pilihanraya umum pramerdeka yang diadakan pada 27 Julai 1955.",
-                "catalog_data": {
-                    "catalog_filters": {
-                        "frequency": "INFREQUENT",
-                        "geographic": [
-                            "PARLIMEN",
-                            "STATE",
-                            "NATIONAL"
-                        ],
-                        "demographic": [],
-                        "start": "2004",
-                        "end": "2004",
-                        "data_source": [
-                            "SPR"
-                        ]
-                    },
-                    "metadata_neutral": {
-                        "data_as_of": "1955-08-31 23:59",
-                        "last_updated": "2023-07-18 23:59",
-                        "next_update": "-"
-                    },
-                    "metadata_lang": {
-                        "en": {
-                            "methodology": "This data is a digital representation of the physical election results tabulated and gazetted per the Electoral Regulations (Conduct of Elections). The digitalisation process was rigorously cross-checked against physical records to ensure consistency and accuracy of information.",
-                            "caveat": "As of now, this data has not been verified by SPR, and is shown here on the staging site to provide easy access for exploring and checking the data.",
-                            "publication": "-"
-                        },
-                        "bm": {
-                            "methodology": "Data ini merupakan rekod digital keputusan pilihanraya yang dikira dan diwartakan selaras dengan Peraturan-Peraturan Pilihan Raya (Penjalanan Pilihan Raya). Proses pendigitalan disemak silang dengan rekod fizikal untuk memastikan ketepatan maklumat.",
-                            "caveat": "Setakat sekarang, data ini belum disemak dan diabsahkan oleh SPR, maka hanya dipaparkan di portal UAT ini bagi tujuan memudahkan proses semakan.",
-                            "publication": "-"
-                        }
-                    },
-                    "chart": {
-                        "chart_type": "TABLE",
-                        "chart_filters": {
-                            "SLICE_BY": [],
-                            "precision": 0
-                        },
-                        "chart_variables": {
-                            "parents": [],
-                            "exclude": [],
-                            "freeze": [
-                                "state",
-                                "parlimen"
-                            ]
-                        }
-                    }
-                }
-            },
-            {
-                "id": -1,
-                "name": "state",
-                "title_en": "State",
-                "title_bm": "Negeri",
-                "desc_en": "[String] 1 of 16 states",
-                "desc_bm": "[Rentetan] 1 antara 16 negeri"
-            },
-            {
-                "id": -1,
-                "name": "parlimen",
-                "title_en": "Parliament",
-                "title_bm": "Parlimen",
-                "desc_en": "[String] Name of seat as it appeared on the ballot on voting day",
-                "desc_bm": "[Rentetan] Nama kerusi seperti mana yang tertera di kertas undi pada hari mengundi"
-            },
-            {
-                "id": -1,
-                "name": "area_name",
-                "title_en": "Area Name",
-                "title_bm": "Nama Kawasan",
-                "desc_en": "[String] Name of the area, with seat code (P.xxx) stripped out, and area name historically harmonised. For example, Kota Baharu, Kota Bahru and Kota Bharu are all harmonised to the modern Kota Bharu.",
-                "desc_bm": "[Rentetan] Nama kawasan, tanpa kod kerusi (P.xxx) dan namanya diselaraskan mengambil kira perubahan dari zaman ke zaman. Contohnya, nama Kota Baharu, Kota Bahru, dan Kota Bharu semuanya diharmonikan kepada penggunaan moden iaitu Kota Bharu."
-            },
-            {
-                "id": -1,
-                "name": "voters_total",
-                "title_en": "Total Voters",
-                "title_bm": "Jumlah Pengundi",
-                "desc_en": "[Integer] Number of voters registered to vote in that seat at that election",
-                "desc_bm": "[Integer] Jumlah pengundi yang didaftarkan untuk mengundi di kerusi tersebut semasa PRU-00"
-            },
-            {
-                "id": -1,
-                "name": "ballots_issued",
-                "title_en": "Ballots Issued",
-                "title_bm": "Undi Dikeluarkan",
-                "desc_en": "[Integer] Number of ballots issued, including postal ballots, but not inclduing ballots accidentally damaged and immediately replace during the voting procedure",
-                "desc_bm": "[Integer] Jumlah kertas undi yang dikeluarkan, termasuk kertas undi pos, tetapi tidak termasuk kertas undi yang rosak dan terus digantikan semasa urusan mengundi dijalankan"
-            },
-            {
-                "id": -1,
-                "name": "ballots_not_returned",
-                "title_en": "Ballots Not Returned",
-                "title_bm": "Undi Tidak Dikembalikan",
-                "desc_en": "[Integer] Number of ballots issued but not returned for counting, including postal ballots not returned to the counting centre in time, but excluding spoilt ballots (e.g. torn or stained) which were replaced and therefore not counted as ballots issued",
-                "desc_bm": "[Integer] Jumlah kertas undi yang dikeluarkan tetapi tidak dikembalikan untuk pengiraan undi, termasuk kertas undi pos yang tidak dikembalikan ke pusat kiraan undi, tetapi tidak termasuk kertas undi rosak (contohnya terkoyak atau ternoda) yang telah digantikan maka tidak dikira sebagai kertas undi yang dikeluarkan"
-            },
-            {
-                "id": -1,
-                "name": "votes_rejected",
-                "title_en": "Votes Rejected",
-                "title_bm": "Undi Ditolak",
-                "desc_en": "[Integer] Number of ballots returned but declared invalid during counting because the candidate could not be determined",
-                "desc_bm": "[Integer] Jumlah kertas undi yang telah dikembalikan tetapi ditolak semasa proses kiraan undi kerana calon yang diundi tidak dapat ditentukan"
-            },
-            {
-                "id": -1,
-                "name": "voter_turnout",
-                "title_en": "Voter Turnout",
-                "title_bm": "Peratus Keluar",
-                "desc_en": "[Float] Derived as: (ballots_issued / voters_total) * 100",
-                "desc_bm": " [Apung] Diperolehi dengan formula: (ballots_issued / voters_total) * 100"
-            },
-            {
-                "id": -1,
-                "name": "votes_rejected_perc",
-                "title_en": "Percentage Rejected",
-                "title_bm": "Peratus Ditolak",
-                "desc_en": "[Float] Derived as: (votes_rejected / (ballots_issued - ballots_not_returned)) * 100",
-                "desc_bm": " [Apung] Diperolehi dengan formula: (votes_rejected / (ballots_issued - ballots_not_returned)) * 100"
-            }
-        ]
-    }
+	"file": {
+		"manual_trigger": 0,
+		"bucket": "elections_federal",
+		"file_name": "ge11_summary",
+		"category": "ELECTIONS",
+		"category_en": "Elections",
+		"category_bm": "Pilihanraya",
+		"subcategory": "FEDERAL",
+		"subcategory_en": "Federal",
+		"subcategory_bm": "Persekutuan",
+		"description": {
+			"en": "Analytical summary of the pre-Independence general election held in 1955.",
+			"bm": "Ringkasan analitik bagi pilihanraya umum pramerdeka yang diadakan pada tahun 1955."
+		},
+		"link_parquet": "https://storage.data.gov.my/elections/federal/ge11_summary.parquet",
+		"link_csv": "https://storage.data.gov.my/elections/federal/ge11_summary.csv",
+		"link_preview": "https://storage.data.gov.my/elections/federal/ge11_summary.parquet",
+		"variables": [
+			{
+				"id": 0,
+				"name": "ge11_summary",
+				"title_en": "GE-11: Summary",
+				"title_bm": "PRU-11: Rumusan",
+				"desc_en": "Analytical summary of the pre-Independence general election held on 27 July 1955.",
+				"desc_bm": "Ringkasan analitik bagi pilihanraya umum pramerdeka yang diadakan pada 27 Julai 1955.",
+				"catalog_data": {
+					"catalog_filters": {
+						"frequency": "INFREQUENT",
+						"geography": ["PARLIMEN", "STATE", "NATIONAL"],
+						"demographic": [],
+						"start": "2004",
+						"end": "2004",
+						"data_source": ["SPR"]
+					},
+					"metadata_neutral": {
+						"data_as_of": "1955-08-31 23:59",
+						"last_updated": "2023-07-18 23:59",
+						"next_update": "-"
+					},
+					"metadata_lang": {
+						"en": {
+							"methodology": "This data is a digital representation of the physical election results tabulated and gazetted per the Electoral Regulations (Conduct of Elections). The digitalisation process was rigorously cross-checked against physical records to ensure consistency and accuracy of information.",
+							"caveat": "As of now, this data has not been verified by SPR, and is shown here on the staging site to provide easy access for exploring and checking the data.",
+							"publication": "-"
+						},
+						"bm": {
+							"methodology": "Data ini merupakan rekod digital keputusan pilihanraya yang dikira dan diwartakan selaras dengan Peraturan-Peraturan Pilihan Raya (Penjalanan Pilihan Raya). Proses pendigitalan disemak silang dengan rekod fizikal untuk memastikan ketepatan maklumat.",
+							"caveat": "Setakat sekarang, data ini belum disemak dan diabsahkan oleh SPR, maka hanya dipaparkan di portal UAT ini bagi tujuan memudahkan proses semakan.",
+							"publication": "-"
+						}
+					},
+					"chart": {
+						"chart_type": "TABLE",
+						"chart_filters": {
+							"SLICE_BY": [],
+							"precision": 0
+						},
+						"chart_variables": {
+							"parents": [],
+							"exclude": [],
+							"freeze": ["state", "parlimen"]
+						}
+					}
+				}
+			},
+			{
+				"id": -1,
+				"name": "state",
+				"title_en": "State",
+				"title_bm": "Negeri",
+				"desc_en": "[String] 1 of 16 states",
+				"desc_bm": "[Rentetan] 1 antara 16 negeri"
+			},
+			{
+				"id": -1,
+				"name": "parlimen",
+				"title_en": "Parliament",
+				"title_bm": "Parlimen",
+				"desc_en": "[String] Name of seat as it appeared on the ballot on voting day",
+				"desc_bm": "[Rentetan] Nama kerusi seperti mana yang tertera di kertas undi pada hari mengundi"
+			},
+			{
+				"id": -1,
+				"name": "area_name",
+				"title_en": "Area Name",
+				"title_bm": "Nama Kawasan",
+				"desc_en": "[String] Name of the area, with seat code (P.xxx) stripped out, and area name historically harmonised. For example, Kota Baharu, Kota Bahru and Kota Bharu are all harmonised to the modern Kota Bharu.",
+				"desc_bm": "[Rentetan] Nama kawasan, tanpa kod kerusi (P.xxx) dan namanya diselaraskan mengambil kira perubahan dari zaman ke zaman. Contohnya, nama Kota Baharu, Kota Bahru, dan Kota Bharu semuanya diharmonikan kepada penggunaan moden iaitu Kota Bharu."
+			},
+			{
+				"id": -1,
+				"name": "voters_total",
+				"title_en": "Total Voters",
+				"title_bm": "Jumlah Pengundi",
+				"desc_en": "[Integer] Number of voters registered to vote in that seat at that election",
+				"desc_bm": "[Integer] Jumlah pengundi yang didaftarkan untuk mengundi di kerusi tersebut semasa PRU-00"
+			},
+			{
+				"id": -1,
+				"name": "ballots_issued",
+				"title_en": "Ballots Issued",
+				"title_bm": "Undi Dikeluarkan",
+				"desc_en": "[Integer] Number of ballots issued, including postal ballots, but not inclduing ballots accidentally damaged and immediately replace during the voting procedure",
+				"desc_bm": "[Integer] Jumlah kertas undi yang dikeluarkan, termasuk kertas undi pos, tetapi tidak termasuk kertas undi yang rosak dan terus digantikan semasa urusan mengundi dijalankan"
+			},
+			{
+				"id": -1,
+				"name": "ballots_not_returned",
+				"title_en": "Ballots Not Returned",
+				"title_bm": "Undi Tidak Dikembalikan",
+				"desc_en": "[Integer] Number of ballots issued but not returned for counting, including postal ballots not returned to the counting centre in time, but excluding spoilt ballots (e.g. torn or stained) which were replaced and therefore not counted as ballots issued",
+				"desc_bm": "[Integer] Jumlah kertas undi yang dikeluarkan tetapi tidak dikembalikan untuk pengiraan undi, termasuk kertas undi pos yang tidak dikembalikan ke pusat kiraan undi, tetapi tidak termasuk kertas undi rosak (contohnya terkoyak atau ternoda) yang telah digantikan maka tidak dikira sebagai kertas undi yang dikeluarkan"
+			},
+			{
+				"id": -1,
+				"name": "votes_rejected",
+				"title_en": "Votes Rejected",
+				"title_bm": "Undi Ditolak",
+				"desc_en": "[Integer] Number of ballots returned but declared invalid during counting because the candidate could not be determined",
+				"desc_bm": "[Integer] Jumlah kertas undi yang telah dikembalikan tetapi ditolak semasa proses kiraan undi kerana calon yang diundi tidak dapat ditentukan"
+			},
+			{
+				"id": -1,
+				"name": "voter_turnout",
+				"title_en": "Voter Turnout",
+				"title_bm": "Peratus Keluar",
+				"desc_en": "[Float] Derived as: (ballots_issued / voters_total) * 100",
+				"desc_bm": " [Apung] Diperolehi dengan formula: (ballots_issued / voters_total) * 100"
+			},
+			{
+				"id": -1,
+				"name": "votes_rejected_perc",
+				"title_en": "Percentage Rejected",
+				"title_bm": "Peratus Ditolak",
+				"desc_en": "[Float] Derived as: (votes_rejected / (ballots_issued - ballots_not_returned)) * 100",
+				"desc_bm": " [Apung] Diperolehi dengan formula: (votes_rejected / (ballots_issued - ballots_not_returned)) * 100"
+			}
+		]
+	}
 }

--- a/catalog/ge11_summary.json
+++ b/catalog/ge11_summary.json
@@ -28,7 +28,7 @@
 					"catalog_filters": {
 						"frequency": "INFREQUENT",
 						"geography": ["PARLIMEN", "STATE", "NATIONAL"],
-						"demographic": [],
+						"demography": [],
 						"start": "2004",
 						"end": "2004",
 						"data_source": ["SPR"]

--- a/catalog/ge12_ballots.json
+++ b/catalog/ge12_ballots.json
@@ -1,142 +1,133 @@
 {
-    "file": {
-        "manual_trigger": 0,
-        "bucket": "elections_federal",
-        "file_name": "ge12_ballots",
-        "category": "ELECTIONS",
-        "category_en": "Elections",
-        "category_bm": "Pilihanraya",
-        "subcategory": "FEDERAL",
-        "subcategory_en": "Federal",
-        "subcategory_bm": "Persekutuan",
-        "description": {
-            "en": "Ballots for every seat contested at the pre-Independence general election held in 1955.",
-            "bm": "Perincian undi bagi setiap kerusi yang dipertandingkan di pilihanraya umum pramerdeka yang diadakan pada tahun 1955."
-        },
-        "link_parquet": "https://storage.data.gov.my/elections/federal/ge12_ballots.parquet",
-        "link_csv": "https://storage.data.gov.my/elections/federal/ge12_ballots.csv",
-        "link_preview": "https://storage.data.gov.my/elections/federal/ge12_ballots.parquet",
-        "variables": [
-            {
-                "id": 0,
-                "name": "ge12_ballots",
-                "title_en": "GE-12: Ballots",
-                "title_bm": "PRU-12: Kertas Undi",
-                "desc_en": "Ballots for every seat contested at the pre-Independence general election held on 27 July 1955.",
-                "desc_bm": "Perincian undi bagi setiap kerusi yang dipertandingkan di pilihanraya umum pramerdeka yang diadakan pada 27 Julai 1955.",
-                "catalog_data": {
-                    "catalog_filters": {
-                        "frequency": "INFREQUENT",
-                        "geographic": [
-                            "PARLIMEN",
-                            "STATE",
-                            "NATIONAL"
-                        ],
-                        "demographic": [],
-                        "start": "2008",
-                        "end": "2008",
-                        "data_source": [
-                            "SPR"
-                        ]
-                    },
-                    "metadata_neutral": {
-                        "data_as_of": "1955-08-31 23:59",
-                        "last_updated": "2023-07-18 23:59",
-                        "next_update": "-"
-                    },
-                    "metadata_lang": {
-                        "en": {
-                            "methodology": "This data is a digital representation of the physical election results tabulated and gazetted per the Electoral Regulations (Conduct of Elections). The digitalisation process was rigorously cross-checked against physical records to ensure consistency and accuracy of information.",
-                            "caveat": "As of now, this data has not been verified by SPR, and is shown here on the staging site to provide easy access for exploring and checking the data.",
-                            "publication": "-"
-                        },
-                        "bm": {
-                            "methodology": "Data ini merupakan rekod digital keputusan pilihanraya yang dikira dan diwartakan selaras dengan Peraturan-Peraturan Pilihan Raya (Penjalanan Pilihan Raya). Proses pendigitalan disemak silang dengan rekod fizikal untuk memastikan ketepatan maklumat.",
-                            "caveat": "Setakat sekarang, data ini belum disemak dan diabsahkan oleh SPR, maka hanya dipaparkan di portal UAT ini bagi tujuan memudahkan proses semakan.",
-                            "publication": "-"
-                        }
-                    },
-                    "chart": {
-                        "chart_type": "TABLE",
-                        "chart_filters": {
-                            "SLICE_BY": [],
-                            "precision": 0
-                        },
-                        "chart_variables": {
-                            "parents": [],
-                            "exclude": [],
-                            "freeze": [
-                                "state",
-                                "parlimen"
-                            ]
-                        }
-                    }
-                }
-            },
-            {
-                "id": -1,
-                "name": "state",
-                "title_en": "State",
-                "title_bm": "Negeri",
-                "desc_en": "[String] 1 of 16 states",
-                "desc_bm": "[Rentetan] 1 antara 16 negeri"
-            },
-            {
-                "id": -1,
-                "name": "parlimen",
-                "title_en": "Parliament",
-                "title_bm": "Parlimen",
-                "desc_en": "[String] Name of seat as it appeared on the ballot on voting day",
-                "desc_bm": "[Rentetan] Nama kerusi seperti mana yang tertera di kertas undi pada hari mengundi"
-            },
-            {
-                "id": -1,
-                "name": "area_name",
-                "title_en": "Area Name",
-                "title_bm": "Nama Kawasan",
-                "desc_en": "[String] Name of the area, with seat code (P.xxx) stripped out, and area name historically harmonised. For example, Kota Baharu, Kota Bahru and Kota Bharu are all harmonised to the modern Kota Bharu.",
-                "desc_bm": "[Rentetan] Nama kawasan, tanpa kod kerusi (P.xxx) dan namanya diselaraskan mengambil kira perubahan dari zaman ke zaman. Contohnya, nama Kota Baharu, Kota Bahru, dan Kota Bharu semuanya diharmonikan kepada penggunaan moden iaitu Kota Bharu."
-            },
-            {
-                "id": -1,
-                "name": "ballot_order",
-                "title_en": "Ballot Order",
-                "title_bm": "Urutan Nama",
-                "desc_en": "[Integer] Order in which the candidate appears on the ballot",
-                "desc_bm": "[Integer] Urutan nama-nama yang tertera pada kertas undi"
-            },
-            {
-                "id": -1,
-                "name": "name",
-                "title_en": "Name",
-                "title_bm": "Nama",
-                "desc_en": "[String] Name of candidate as it appeared on the ballot on voting day; this may not be the same as their real name as candidates are free to choose the name they use for campaigning and voting",
-                "desc_bm": "[Rentetan] Nama calon seperti mana yang tertera di kertas undi pada hari mengundi; ini tidak semestinya sama dengan nama sebenar mereka kerana calon adalah bebas untuk memilih nama yang digunakan bagi tujuan kempen dan undi"
-            },
-            {
-                "id": -1,
-                "name": "candidate_uid",
-                "title_en": "Unique Candidate ID",
-                "title_bm": "ID Unik Calon",
-                "desc_en": "[Integer] Unique integer identifier to track candidates across elections",
-                "desc_bm": "[Integer] Integer unik untuk menjejaki keputusan seseorang calon merentasi pilihan raya"
-            },
-            {
-                "id": -1,
-                "name": "party",
-                "title_en": "Party",
-                "title_bm": "Parti",
-                "desc_en": "[String] Party of the candidate as it appeared on the ballot on voting day; this record is not amended to reflect unofficial information on parties and coalitions. For example, if a candidate competed under the flag of Party X despite being a member of Party Y, their party is recorded as Party X.",
-                "desc_bm": "[String] Parti calon seperti yang tertera pada kertas undi pada hari mengundi; rekod ini tidak dipinda untuk menggambarkan maklumat tidak rasmi mengenai parti dan gabungan. Sebagai contoh, jika calon bertanding bawah bendera Parti X walaupun menjadi ahli Parti Y, parti mereka direkodkan sebagai Parti X."
-            },
-            {
-                "id": -1,
-                "name": "votes",
-                "title_en": "Votes",
-                "title_bm": "Undi",
-                "desc_en": "Integer] Number of votes won by the candidate",
-                "desc_bm": "[Integer] Jumlah undi yang diperolehi oleh calon"
-            }
-        ]
-    }
+	"file": {
+		"manual_trigger": 0,
+		"bucket": "elections_federal",
+		"file_name": "ge12_ballots",
+		"category": "ELECTIONS",
+		"category_en": "Elections",
+		"category_bm": "Pilihanraya",
+		"subcategory": "FEDERAL",
+		"subcategory_en": "Federal",
+		"subcategory_bm": "Persekutuan",
+		"description": {
+			"en": "Ballots for every seat contested at the pre-Independence general election held in 1955.",
+			"bm": "Perincian undi bagi setiap kerusi yang dipertandingkan di pilihanraya umum pramerdeka yang diadakan pada tahun 1955."
+		},
+		"link_parquet": "https://storage.data.gov.my/elections/federal/ge12_ballots.parquet",
+		"link_csv": "https://storage.data.gov.my/elections/federal/ge12_ballots.csv",
+		"link_preview": "https://storage.data.gov.my/elections/federal/ge12_ballots.parquet",
+		"variables": [
+			{
+				"id": 0,
+				"name": "ge12_ballots",
+				"title_en": "GE-12: Ballots",
+				"title_bm": "PRU-12: Kertas Undi",
+				"desc_en": "Ballots for every seat contested at the pre-Independence general election held on 27 July 1955.",
+				"desc_bm": "Perincian undi bagi setiap kerusi yang dipertandingkan di pilihanraya umum pramerdeka yang diadakan pada 27 Julai 1955.",
+				"catalog_data": {
+					"catalog_filters": {
+						"frequency": "INFREQUENT",
+						"geography": ["PARLIMEN", "STATE", "NATIONAL"],
+						"demographic": [],
+						"start": "2008",
+						"end": "2008",
+						"data_source": ["SPR"]
+					},
+					"metadata_neutral": {
+						"data_as_of": "1955-08-31 23:59",
+						"last_updated": "2023-07-18 23:59",
+						"next_update": "-"
+					},
+					"metadata_lang": {
+						"en": {
+							"methodology": "This data is a digital representation of the physical election results tabulated and gazetted per the Electoral Regulations (Conduct of Elections). The digitalisation process was rigorously cross-checked against physical records to ensure consistency and accuracy of information.",
+							"caveat": "As of now, this data has not been verified by SPR, and is shown here on the staging site to provide easy access for exploring and checking the data.",
+							"publication": "-"
+						},
+						"bm": {
+							"methodology": "Data ini merupakan rekod digital keputusan pilihanraya yang dikira dan diwartakan selaras dengan Peraturan-Peraturan Pilihan Raya (Penjalanan Pilihan Raya). Proses pendigitalan disemak silang dengan rekod fizikal untuk memastikan ketepatan maklumat.",
+							"caveat": "Setakat sekarang, data ini belum disemak dan diabsahkan oleh SPR, maka hanya dipaparkan di portal UAT ini bagi tujuan memudahkan proses semakan.",
+							"publication": "-"
+						}
+					},
+					"chart": {
+						"chart_type": "TABLE",
+						"chart_filters": {
+							"SLICE_BY": [],
+							"precision": 0
+						},
+						"chart_variables": {
+							"parents": [],
+							"exclude": [],
+							"freeze": ["state", "parlimen"]
+						}
+					}
+				}
+			},
+			{
+				"id": -1,
+				"name": "state",
+				"title_en": "State",
+				"title_bm": "Negeri",
+				"desc_en": "[String] 1 of 16 states",
+				"desc_bm": "[Rentetan] 1 antara 16 negeri"
+			},
+			{
+				"id": -1,
+				"name": "parlimen",
+				"title_en": "Parliament",
+				"title_bm": "Parlimen",
+				"desc_en": "[String] Name of seat as it appeared on the ballot on voting day",
+				"desc_bm": "[Rentetan] Nama kerusi seperti mana yang tertera di kertas undi pada hari mengundi"
+			},
+			{
+				"id": -1,
+				"name": "area_name",
+				"title_en": "Area Name",
+				"title_bm": "Nama Kawasan",
+				"desc_en": "[String] Name of the area, with seat code (P.xxx) stripped out, and area name historically harmonised. For example, Kota Baharu, Kota Bahru and Kota Bharu are all harmonised to the modern Kota Bharu.",
+				"desc_bm": "[Rentetan] Nama kawasan, tanpa kod kerusi (P.xxx) dan namanya diselaraskan mengambil kira perubahan dari zaman ke zaman. Contohnya, nama Kota Baharu, Kota Bahru, dan Kota Bharu semuanya diharmonikan kepada penggunaan moden iaitu Kota Bharu."
+			},
+			{
+				"id": -1,
+				"name": "ballot_order",
+				"title_en": "Ballot Order",
+				"title_bm": "Urutan Nama",
+				"desc_en": "[Integer] Order in which the candidate appears on the ballot",
+				"desc_bm": "[Integer] Urutan nama-nama yang tertera pada kertas undi"
+			},
+			{
+				"id": -1,
+				"name": "name",
+				"title_en": "Name",
+				"title_bm": "Nama",
+				"desc_en": "[String] Name of candidate as it appeared on the ballot on voting day; this may not be the same as their real name as candidates are free to choose the name they use for campaigning and voting",
+				"desc_bm": "[Rentetan] Nama calon seperti mana yang tertera di kertas undi pada hari mengundi; ini tidak semestinya sama dengan nama sebenar mereka kerana calon adalah bebas untuk memilih nama yang digunakan bagi tujuan kempen dan undi"
+			},
+			{
+				"id": -1,
+				"name": "candidate_uid",
+				"title_en": "Unique Candidate ID",
+				"title_bm": "ID Unik Calon",
+				"desc_en": "[Integer] Unique integer identifier to track candidates across elections",
+				"desc_bm": "[Integer] Integer unik untuk menjejaki keputusan seseorang calon merentasi pilihan raya"
+			},
+			{
+				"id": -1,
+				"name": "party",
+				"title_en": "Party",
+				"title_bm": "Parti",
+				"desc_en": "[String] Party of the candidate as it appeared on the ballot on voting day; this record is not amended to reflect unofficial information on parties and coalitions. For example, if a candidate competed under the flag of Party X despite being a member of Party Y, their party is recorded as Party X.",
+				"desc_bm": "[String] Parti calon seperti yang tertera pada kertas undi pada hari mengundi; rekod ini tidak dipinda untuk menggambarkan maklumat tidak rasmi mengenai parti dan gabungan. Sebagai contoh, jika calon bertanding bawah bendera Parti X walaupun menjadi ahli Parti Y, parti mereka direkodkan sebagai Parti X."
+			},
+			{
+				"id": -1,
+				"name": "votes",
+				"title_en": "Votes",
+				"title_bm": "Undi",
+				"desc_en": "Integer] Number of votes won by the candidate",
+				"desc_bm": "[Integer] Jumlah undi yang diperolehi oleh calon"
+			}
+		]
+	}
 }

--- a/catalog/ge12_ballots.json
+++ b/catalog/ge12_ballots.json
@@ -28,7 +28,7 @@
 					"catalog_filters": {
 						"frequency": "INFREQUENT",
 						"geography": ["PARLIMEN", "STATE", "NATIONAL"],
-						"demographic": [],
+						"demography": [],
 						"start": "2008",
 						"end": "2008",
 						"data_source": ["SPR"]

--- a/catalog/ge12_summary.json
+++ b/catalog/ge12_summary.json
@@ -1,150 +1,141 @@
 {
-    "file": {
-        "manual_trigger": 0,
-        "bucket": "elections_federal",
-        "file_name": "ge12_summary",
-        "category": "ELECTIONS",
-        "category_en": "Elections",
-        "category_bm": "Pilihanraya",
-        "subcategory": "FEDERAL",
-        "subcategory_en": "Federal",
-        "subcategory_bm": "Persekutuan",
-        "description": {
-            "en": "Analytical summary of the pre-Independence general election held in 1955.",
-            "bm": "Ringkasan analitik bagi pilihanraya umum pramerdeka yang diadakan pada tahun 1955."
-        },
-        "link_parquet": "https://storage.data.gov.my/elections/federal/ge12_summary.parquet",
-        "link_csv": "https://storage.data.gov.my/elections/federal/ge12_summary.csv",
-        "link_preview": "https://storage.data.gov.my/elections/federal/ge12_summary.parquet",
-        "variables": [
-            {
-                "id": 0,
-                "name": "ge12_summary",
-                "title_en": "GE-12: Summary",
-                "title_bm": "PRU-12: Rumusan",
-                "desc_en": "Analytical summary of the pre-Independence general election held on 27 July 1955.",
-                "desc_bm": "Ringkasan analitik bagi pilihanraya umum pramerdeka yang diadakan pada 27 Julai 1955.",
-                "catalog_data": {
-                    "catalog_filters": {
-                        "frequency": "INFREQUENT",
-                        "geographic": [
-                            "PARLIMEN",
-                            "STATE",
-                            "NATIONAL"
-                        ],
-                        "demographic": [],
-                        "start": "2008",
-                        "end": "2008",
-                        "data_source": [
-                            "SPR"
-                        ]
-                    },
-                    "metadata_neutral": {
-                        "data_as_of": "1955-08-31 23:59",
-                        "last_updated": "2023-07-18 23:59",
-                        "next_update": "-"
-                    },
-                    "metadata_lang": {
-                        "en": {
-                            "methodology": "This data is a digital representation of the physical election results tabulated and gazetted per the Electoral Regulations (Conduct of Elections). The digitalisation process was rigorously cross-checked against physical records to ensure consistency and accuracy of information.",
-                            "caveat": "As of now, this data has not been verified by SPR, and is shown here on the staging site to provide easy access for exploring and checking the data.",
-                            "publication": "-"
-                        },
-                        "bm": {
-                            "methodology": "Data ini merupakan rekod digital keputusan pilihanraya yang dikira dan diwartakan selaras dengan Peraturan-Peraturan Pilihan Raya (Penjalanan Pilihan Raya). Proses pendigitalan disemak silang dengan rekod fizikal untuk memastikan ketepatan maklumat.",
-                            "caveat": "Setakat sekarang, data ini belum disemak dan diabsahkan oleh SPR, maka hanya dipaparkan di portal UAT ini bagi tujuan memudahkan proses semakan.",
-                            "publication": "-"
-                        }
-                    },
-                    "chart": {
-                        "chart_type": "TABLE",
-                        "chart_filters": {
-                            "SLICE_BY": [],
-                            "precision": 0
-                        },
-                        "chart_variables": {
-                            "parents": [],
-                            "exclude": [],
-                            "freeze": [
-                                "state",
-                                "parlimen"
-                            ]
-                        }
-                    }
-                }
-            },
-            {
-                "id": -1,
-                "name": "state",
-                "title_en": "State",
-                "title_bm": "Negeri",
-                "desc_en": "[String] 1 of 16 states",
-                "desc_bm": "[Rentetan] 1 antara 16 negeri"
-            },
-            {
-                "id": -1,
-                "name": "parlimen",
-                "title_en": "Parliament",
-                "title_bm": "Parlimen",
-                "desc_en": "[String] Name of seat as it appeared on the ballot on voting day",
-                "desc_bm": "[Rentetan] Nama kerusi seperti mana yang tertera di kertas undi pada hari mengundi"
-            },
-            {
-                "id": -1,
-                "name": "area_name",
-                "title_en": "Area Name",
-                "title_bm": "Nama Kawasan",
-                "desc_en": "[String] Name of the area, with seat code (P.xxx) stripped out, and area name historically harmonised. For example, Kota Baharu, Kota Bahru and Kota Bharu are all harmonised to the modern Kota Bharu.",
-                "desc_bm": "[Rentetan] Nama kawasan, tanpa kod kerusi (P.xxx) dan namanya diselaraskan mengambil kira perubahan dari zaman ke zaman. Contohnya, nama Kota Baharu, Kota Bahru, dan Kota Bharu semuanya diharmonikan kepada penggunaan moden iaitu Kota Bharu."
-            },
-            {
-                "id": -1,
-                "name": "voters_total",
-                "title_en": "Total Voters",
-                "title_bm": "Jumlah Pengundi",
-                "desc_en": "[Integer] Number of voters registered to vote in that seat at that election",
-                "desc_bm": "[Integer] Jumlah pengundi yang didaftarkan untuk mengundi di kerusi tersebut semasa PRU-00"
-            },
-            {
-                "id": -1,
-                "name": "ballots_issued",
-                "title_en": "Ballots Issued",
-                "title_bm": "Undi Dikeluarkan",
-                "desc_en": "[Integer] Number of ballots issued, including postal ballots, but not inclduing ballots accidentally damaged and immediately replace during the voting procedure",
-                "desc_bm": "[Integer] Jumlah kertas undi yang dikeluarkan, termasuk kertas undi pos, tetapi tidak termasuk kertas undi yang rosak dan terus digantikan semasa urusan mengundi dijalankan"
-            },
-            {
-                "id": -1,
-                "name": "ballots_not_returned",
-                "title_en": "Ballots Not Returned",
-                "title_bm": "Undi Tidak Dikembalikan",
-                "desc_en": "[Integer] Number of ballots issued but not returned for counting, including postal ballots not returned to the counting centre in time, but excluding spoilt ballots (e.g. torn or stained) which were replaced and therefore not counted as ballots issued",
-                "desc_bm": "[Integer] Jumlah kertas undi yang dikeluarkan tetapi tidak dikembalikan untuk pengiraan undi, termasuk kertas undi pos yang tidak dikembalikan ke pusat kiraan undi, tetapi tidak termasuk kertas undi rosak (contohnya terkoyak atau ternoda) yang telah digantikan maka tidak dikira sebagai kertas undi yang dikeluarkan"
-            },
-            {
-                "id": -1,
-                "name": "votes_rejected",
-                "title_en": "Votes Rejected",
-                "title_bm": "Undi Ditolak",
-                "desc_en": "[Integer] Number of ballots returned but declared invalid during counting because the candidate could not be determined",
-                "desc_bm": "[Integer] Jumlah kertas undi yang telah dikembalikan tetapi ditolak semasa proses kiraan undi kerana calon yang diundi tidak dapat ditentukan"
-            },
-            {
-                "id": -1,
-                "name": "voter_turnout",
-                "title_en": "Voter Turnout",
-                "title_bm": "Peratus Keluar",
-                "desc_en": "[Float] Derived as: (ballots_issued / voters_total) * 100",
-                "desc_bm": " [Apung] Diperolehi dengan formula: (ballots_issued / voters_total) * 100"
-            },
-            {
-                "id": -1,
-                "name": "votes_rejected_perc",
-                "title_en": "Percentage Rejected",
-                "title_bm": "Peratus Ditolak",
-                "desc_en": "[Float] Derived as: (votes_rejected / (ballots_issued - ballots_not_returned)) * 100",
-                "desc_bm": " [Apung] Diperolehi dengan formula: (votes_rejected / (ballots_issued - ballots_not_returned)) * 100"
-            }
-        ]
-    }
+	"file": {
+		"manual_trigger": 0,
+		"bucket": "elections_federal",
+		"file_name": "ge12_summary",
+		"category": "ELECTIONS",
+		"category_en": "Elections",
+		"category_bm": "Pilihanraya",
+		"subcategory": "FEDERAL",
+		"subcategory_en": "Federal",
+		"subcategory_bm": "Persekutuan",
+		"description": {
+			"en": "Analytical summary of the pre-Independence general election held in 1955.",
+			"bm": "Ringkasan analitik bagi pilihanraya umum pramerdeka yang diadakan pada tahun 1955."
+		},
+		"link_parquet": "https://storage.data.gov.my/elections/federal/ge12_summary.parquet",
+		"link_csv": "https://storage.data.gov.my/elections/federal/ge12_summary.csv",
+		"link_preview": "https://storage.data.gov.my/elections/federal/ge12_summary.parquet",
+		"variables": [
+			{
+				"id": 0,
+				"name": "ge12_summary",
+				"title_en": "GE-12: Summary",
+				"title_bm": "PRU-12: Rumusan",
+				"desc_en": "Analytical summary of the pre-Independence general election held on 27 July 1955.",
+				"desc_bm": "Ringkasan analitik bagi pilihanraya umum pramerdeka yang diadakan pada 27 Julai 1955.",
+				"catalog_data": {
+					"catalog_filters": {
+						"frequency": "INFREQUENT",
+						"geography": ["PARLIMEN", "STATE", "NATIONAL"],
+						"demographic": [],
+						"start": "2008",
+						"end": "2008",
+						"data_source": ["SPR"]
+					},
+					"metadata_neutral": {
+						"data_as_of": "1955-08-31 23:59",
+						"last_updated": "2023-07-18 23:59",
+						"next_update": "-"
+					},
+					"metadata_lang": {
+						"en": {
+							"methodology": "This data is a digital representation of the physical election results tabulated and gazetted per the Electoral Regulations (Conduct of Elections). The digitalisation process was rigorously cross-checked against physical records to ensure consistency and accuracy of information.",
+							"caveat": "As of now, this data has not been verified by SPR, and is shown here on the staging site to provide easy access for exploring and checking the data.",
+							"publication": "-"
+						},
+						"bm": {
+							"methodology": "Data ini merupakan rekod digital keputusan pilihanraya yang dikira dan diwartakan selaras dengan Peraturan-Peraturan Pilihan Raya (Penjalanan Pilihan Raya). Proses pendigitalan disemak silang dengan rekod fizikal untuk memastikan ketepatan maklumat.",
+							"caveat": "Setakat sekarang, data ini belum disemak dan diabsahkan oleh SPR, maka hanya dipaparkan di portal UAT ini bagi tujuan memudahkan proses semakan.",
+							"publication": "-"
+						}
+					},
+					"chart": {
+						"chart_type": "TABLE",
+						"chart_filters": {
+							"SLICE_BY": [],
+							"precision": 0
+						},
+						"chart_variables": {
+							"parents": [],
+							"exclude": [],
+							"freeze": ["state", "parlimen"]
+						}
+					}
+				}
+			},
+			{
+				"id": -1,
+				"name": "state",
+				"title_en": "State",
+				"title_bm": "Negeri",
+				"desc_en": "[String] 1 of 16 states",
+				"desc_bm": "[Rentetan] 1 antara 16 negeri"
+			},
+			{
+				"id": -1,
+				"name": "parlimen",
+				"title_en": "Parliament",
+				"title_bm": "Parlimen",
+				"desc_en": "[String] Name of seat as it appeared on the ballot on voting day",
+				"desc_bm": "[Rentetan] Nama kerusi seperti mana yang tertera di kertas undi pada hari mengundi"
+			},
+			{
+				"id": -1,
+				"name": "area_name",
+				"title_en": "Area Name",
+				"title_bm": "Nama Kawasan",
+				"desc_en": "[String] Name of the area, with seat code (P.xxx) stripped out, and area name historically harmonised. For example, Kota Baharu, Kota Bahru and Kota Bharu are all harmonised to the modern Kota Bharu.",
+				"desc_bm": "[Rentetan] Nama kawasan, tanpa kod kerusi (P.xxx) dan namanya diselaraskan mengambil kira perubahan dari zaman ke zaman. Contohnya, nama Kota Baharu, Kota Bahru, dan Kota Bharu semuanya diharmonikan kepada penggunaan moden iaitu Kota Bharu."
+			},
+			{
+				"id": -1,
+				"name": "voters_total",
+				"title_en": "Total Voters",
+				"title_bm": "Jumlah Pengundi",
+				"desc_en": "[Integer] Number of voters registered to vote in that seat at that election",
+				"desc_bm": "[Integer] Jumlah pengundi yang didaftarkan untuk mengundi di kerusi tersebut semasa PRU-00"
+			},
+			{
+				"id": -1,
+				"name": "ballots_issued",
+				"title_en": "Ballots Issued",
+				"title_bm": "Undi Dikeluarkan",
+				"desc_en": "[Integer] Number of ballots issued, including postal ballots, but not inclduing ballots accidentally damaged and immediately replace during the voting procedure",
+				"desc_bm": "[Integer] Jumlah kertas undi yang dikeluarkan, termasuk kertas undi pos, tetapi tidak termasuk kertas undi yang rosak dan terus digantikan semasa urusan mengundi dijalankan"
+			},
+			{
+				"id": -1,
+				"name": "ballots_not_returned",
+				"title_en": "Ballots Not Returned",
+				"title_bm": "Undi Tidak Dikembalikan",
+				"desc_en": "[Integer] Number of ballots issued but not returned for counting, including postal ballots not returned to the counting centre in time, but excluding spoilt ballots (e.g. torn or stained) which were replaced and therefore not counted as ballots issued",
+				"desc_bm": "[Integer] Jumlah kertas undi yang dikeluarkan tetapi tidak dikembalikan untuk pengiraan undi, termasuk kertas undi pos yang tidak dikembalikan ke pusat kiraan undi, tetapi tidak termasuk kertas undi rosak (contohnya terkoyak atau ternoda) yang telah digantikan maka tidak dikira sebagai kertas undi yang dikeluarkan"
+			},
+			{
+				"id": -1,
+				"name": "votes_rejected",
+				"title_en": "Votes Rejected",
+				"title_bm": "Undi Ditolak",
+				"desc_en": "[Integer] Number of ballots returned but declared invalid during counting because the candidate could not be determined",
+				"desc_bm": "[Integer] Jumlah kertas undi yang telah dikembalikan tetapi ditolak semasa proses kiraan undi kerana calon yang diundi tidak dapat ditentukan"
+			},
+			{
+				"id": -1,
+				"name": "voter_turnout",
+				"title_en": "Voter Turnout",
+				"title_bm": "Peratus Keluar",
+				"desc_en": "[Float] Derived as: (ballots_issued / voters_total) * 100",
+				"desc_bm": " [Apung] Diperolehi dengan formula: (ballots_issued / voters_total) * 100"
+			},
+			{
+				"id": -1,
+				"name": "votes_rejected_perc",
+				"title_en": "Percentage Rejected",
+				"title_bm": "Peratus Ditolak",
+				"desc_en": "[Float] Derived as: (votes_rejected / (ballots_issued - ballots_not_returned)) * 100",
+				"desc_bm": " [Apung] Diperolehi dengan formula: (votes_rejected / (ballots_issued - ballots_not_returned)) * 100"
+			}
+		]
+	}
 }

--- a/catalog/ge12_summary.json
+++ b/catalog/ge12_summary.json
@@ -28,7 +28,7 @@
 					"catalog_filters": {
 						"frequency": "INFREQUENT",
 						"geography": ["PARLIMEN", "STATE", "NATIONAL"],
-						"demographic": [],
+						"demography": [],
 						"start": "2008",
 						"end": "2008",
 						"data_source": ["SPR"]

--- a/catalog/ge13_ballots.json
+++ b/catalog/ge13_ballots.json
@@ -1,142 +1,133 @@
 {
-    "file": {
-        "manual_trigger": 0,
-        "bucket": "elections_federal",
-        "file_name": "ge13_ballots",
-        "category": "ELECTIONS",
-        "category_en": "Elections",
-        "category_bm": "Pilihanraya",
-        "subcategory": "FEDERAL",
-        "subcategory_en": "Federal",
-        "subcategory_bm": "Persekutuan",
-        "description": {
-            "en": "Ballots for every seat contested at the pre-Independence general election held in 1955.",
-            "bm": "Perincian undi bagi setiap kerusi yang dipertandingkan di pilihanraya umum pramerdeka yang diadakan pada tahun 1955."
-        },
-        "link_parquet": "https://storage.data.gov.my/elections/federal/ge13_ballots.parquet",
-        "link_csv": "https://storage.data.gov.my/elections/federal/ge13_ballots.csv",
-        "link_preview": "https://storage.data.gov.my/elections/federal/ge13_ballots.parquet",
-        "variables": [
-            {
-                "id": 0,
-                "name": "ge13_ballots",
-                "title_en": "GE-13: Ballots",
-                "title_bm": "PRU-13: Kertas Undi",
-                "desc_en": "Ballots for every seat contested at the pre-Independence general election held on 27 July 1955.",
-                "desc_bm": "Perincian undi bagi setiap kerusi yang dipertandingkan di pilihanraya umum pramerdeka yang diadakan pada 27 Julai 1955.",
-                "catalog_data": {
-                    "catalog_filters": {
-                        "frequency": "INFREQUENT",
-                        "geography": [
-                            "PARLIMEN",
-                            "STATE",
-                            "NATIONAL"
-                        ],
-                        "demographic": [],
-                        "start": "2013",
-                        "end": "2013",
-                        "data_source": [
-                            "SPR"
-                        ]
-                    },
-                    "metadata_neutral": {
-                        "data_as_of": "1955-08-31 23:59",
-                        "last_updated": "2023-07-18 23:59",
-                        "next_update": "-"
-                    },
-                    "metadata_lang": {
-                        "en": {
-                            "methodology": "This data is a digital representation of the physical election results tabulated and gazetted per the Electoral Regulations (Conduct of Elections). The digitalisation process was rigorously cross-checked against physical records to ensure consistency and accuracy of information.",
-                            "caveat": "As of now, this data has not been verified by SPR, and is shown here on the staging site to provide easy access for exploring and checking the data.",
-                            "publication": "-"
-                        },
-                        "bm": {
-                            "methodology": "Data ini merupakan rekod digital keputusan pilihanraya yang dikira dan diwartakan selaras dengan Peraturan-Peraturan Pilihan Raya (Penjalanan Pilihan Raya). Proses pendigitalan disemak silang dengan rekod fizikal untuk memastikan ketepatan maklumat.",
-                            "caveat": "Setakat sekarang, data ini belum disemak dan diabsahkan oleh SPR, maka hanya dipaparkan di portal UAT ini bagi tujuan memudahkan proses semakan.",
-                            "publication": "-"
-                        }
-                    },
-                    "chart": {
-                        "chart_type": "TABLE",
-                        "chart_filters": {
-                            "SLICE_BY": [],
-                            "precision": 0
-                        },
-                        "chart_variables": {
-                            "parents": [],
-                            "exclude": [],
-                            "freeze": [
-                                "state",
-                                "parlimen"
-                            ]
-                        }
-                    }
-                }
-            },
-            {
-                "id": -1,
-                "name": "state",
-                "title_en": "State",
-                "title_bm": "Negeri",
-                "desc_en": "[String] 1 of 16 states",
-                "desc_bm": "[Rentetan] 1 antara 16 negeri"
-            },
-            {
-                "id": -1,
-                "name": "parlimen",
-                "title_en": "Parliament",
-                "title_bm": "Parlimen",
-                "desc_en": "[String] Name of seat as it appeared on the ballot on voting day",
-                "desc_bm": "[Rentetan] Nama kerusi seperti mana yang tertera di kertas undi pada hari mengundi"
-            },
-            {
-                "id": -1,
-                "name": "area_name",
-                "title_en": "Area Name",
-                "title_bm": "Nama Kawasan",
-                "desc_en": "[String] Name of the area, with seat code (P.xxx) stripped out, and area name historically harmonised. For example, Kota Baharu, Kota Bahru and Kota Bharu are all harmonised to the modern Kota Bharu.",
-                "desc_bm": "[Rentetan] Nama kawasan, tanpa kod kerusi (P.xxx) dan namanya diselaraskan mengambil kira perubahan dari zaman ke zaman. Contohnya, nama Kota Baharu, Kota Bahru, dan Kota Bharu semuanya diharmonikan kepada penggunaan moden iaitu Kota Bharu."
-            },
-            {
-                "id": -1,
-                "name": "ballot_order",
-                "title_en": "Ballot Order",
-                "title_bm": "Urutan Nama",
-                "desc_en": "[Integer] Order in which the candidate appears on the ballot",
-                "desc_bm": "[Integer] Urutan nama-nama yang tertera pada kertas undi"
-            },
-            {
-                "id": -1,
-                "name": "name",
-                "title_en": "Name",
-                "title_bm": "Nama",
-                "desc_en": "[String] Name of candidate as it appeared on the ballot on voting day; this may not be the same as their real name as candidates are free to choose the name they use for campaigning and voting",
-                "desc_bm": "[Rentetan] Nama calon seperti mana yang tertera di kertas undi pada hari mengundi; ini tidak semestinya sama dengan nama sebenar mereka kerana calon adalah bebas untuk memilih nama yang digunakan bagi tujuan kempen dan undi"
-            },
-            {
-                "id": -1,
-                "name": "candidate_uid",
-                "title_en": "Unique Candidate ID",
-                "title_bm": "ID Unik Calon",
-                "desc_en": "[Integer] Unique integer identifier to track candidates across elections",
-                "desc_bm": "[Integer] Integer unik untuk menjejaki keputusan seseorang calon merentasi pilihan raya"
-            },
-            {
-                "id": -1,
-                "name": "party",
-                "title_en": "Party",
-                "title_bm": "Parti",
-                "desc_en": "[String] Party of the candidate as it appeared on the ballot on voting day; this record is not amended to reflect unofficial information on parties and coalitions. For example, if a candidate competed under the flag of Party X despite being a member of Party Y, their party is recorded as Party X.",
-                "desc_bm": "[String] Parti calon seperti yang tertera pada kertas undi pada hari mengundi; rekod ini tidak dipinda untuk menggambarkan maklumat tidak rasmi mengenai parti dan gabungan. Sebagai contoh, jika calon bertanding bawah bendera Parti X walaupun menjadi ahli Parti Y, parti mereka direkodkan sebagai Parti X."
-            },
-            {
-                "id": -1,
-                "name": "votes",
-                "title_en": "Votes",
-                "title_bm": "Undi",
-                "desc_en": "Integer] Number of votes won by the candidate",
-                "desc_bm": "[Integer] Jumlah undi yang diperolehi oleh calon"
-            }
-        ]
-    }
+	"file": {
+		"manual_trigger": 0,
+		"bucket": "elections_federal",
+		"file_name": "ge13_ballots",
+		"category": "ELECTIONS",
+		"category_en": "Elections",
+		"category_bm": "Pilihanraya",
+		"subcategory": "FEDERAL",
+		"subcategory_en": "Federal",
+		"subcategory_bm": "Persekutuan",
+		"description": {
+			"en": "Ballots for every seat contested at the pre-Independence general election held in 1955.",
+			"bm": "Perincian undi bagi setiap kerusi yang dipertandingkan di pilihanraya umum pramerdeka yang diadakan pada tahun 1955."
+		},
+		"link_parquet": "https://storage.data.gov.my/elections/federal/ge13_ballots.parquet",
+		"link_csv": "https://storage.data.gov.my/elections/federal/ge13_ballots.csv",
+		"link_preview": "https://storage.data.gov.my/elections/federal/ge13_ballots.parquet",
+		"variables": [
+			{
+				"id": 0,
+				"name": "ge13_ballots",
+				"title_en": "GE-13: Ballots",
+				"title_bm": "PRU-13: Kertas Undi",
+				"desc_en": "Ballots for every seat contested at the pre-Independence general election held on 27 July 1955.",
+				"desc_bm": "Perincian undi bagi setiap kerusi yang dipertandingkan di pilihanraya umum pramerdeka yang diadakan pada 27 Julai 1955.",
+				"catalog_data": {
+					"catalog_filters": {
+						"frequency": "INFREQUENT",
+						"geography": ["PARLIMEN", "STATE", "NATIONAL"],
+						"demography": [],
+						"start": "2013",
+						"end": "2013",
+						"data_source": ["SPR"]
+					},
+					"metadata_neutral": {
+						"data_as_of": "1955-08-31 23:59",
+						"last_updated": "2023-07-18 23:59",
+						"next_update": "-"
+					},
+					"metadata_lang": {
+						"en": {
+							"methodology": "This data is a digital representation of the physical election results tabulated and gazetted per the Electoral Regulations (Conduct of Elections). The digitalisation process was rigorously cross-checked against physical records to ensure consistency and accuracy of information.",
+							"caveat": "As of now, this data has not been verified by SPR, and is shown here on the staging site to provide easy access for exploring and checking the data.",
+							"publication": "-"
+						},
+						"bm": {
+							"methodology": "Data ini merupakan rekod digital keputusan pilihanraya yang dikira dan diwartakan selaras dengan Peraturan-Peraturan Pilihan Raya (Penjalanan Pilihan Raya). Proses pendigitalan disemak silang dengan rekod fizikal untuk memastikan ketepatan maklumat.",
+							"caveat": "Setakat sekarang, data ini belum disemak dan diabsahkan oleh SPR, maka hanya dipaparkan di portal UAT ini bagi tujuan memudahkan proses semakan.",
+							"publication": "-"
+						}
+					},
+					"chart": {
+						"chart_type": "TABLE",
+						"chart_filters": {
+							"SLICE_BY": [],
+							"precision": 0
+						},
+						"chart_variables": {
+							"parents": [],
+							"exclude": [],
+							"freeze": ["state", "parlimen"]
+						}
+					}
+				}
+			},
+			{
+				"id": -1,
+				"name": "state",
+				"title_en": "State",
+				"title_bm": "Negeri",
+				"desc_en": "[String] 1 of 16 states",
+				"desc_bm": "[Rentetan] 1 antara 16 negeri"
+			},
+			{
+				"id": -1,
+				"name": "parlimen",
+				"title_en": "Parliament",
+				"title_bm": "Parlimen",
+				"desc_en": "[String] Name of seat as it appeared on the ballot on voting day",
+				"desc_bm": "[Rentetan] Nama kerusi seperti mana yang tertera di kertas undi pada hari mengundi"
+			},
+			{
+				"id": -1,
+				"name": "area_name",
+				"title_en": "Area Name",
+				"title_bm": "Nama Kawasan",
+				"desc_en": "[String] Name of the area, with seat code (P.xxx) stripped out, and area name historically harmonised. For example, Kota Baharu, Kota Bahru and Kota Bharu are all harmonised to the modern Kota Bharu.",
+				"desc_bm": "[Rentetan] Nama kawasan, tanpa kod kerusi (P.xxx) dan namanya diselaraskan mengambil kira perubahan dari zaman ke zaman. Contohnya, nama Kota Baharu, Kota Bahru, dan Kota Bharu semuanya diharmonikan kepada penggunaan moden iaitu Kota Bharu."
+			},
+			{
+				"id": -1,
+				"name": "ballot_order",
+				"title_en": "Ballot Order",
+				"title_bm": "Urutan Nama",
+				"desc_en": "[Integer] Order in which the candidate appears on the ballot",
+				"desc_bm": "[Integer] Urutan nama-nama yang tertera pada kertas undi"
+			},
+			{
+				"id": -1,
+				"name": "name",
+				"title_en": "Name",
+				"title_bm": "Nama",
+				"desc_en": "[String] Name of candidate as it appeared on the ballot on voting day; this may not be the same as their real name as candidates are free to choose the name they use for campaigning and voting",
+				"desc_bm": "[Rentetan] Nama calon seperti mana yang tertera di kertas undi pada hari mengundi; ini tidak semestinya sama dengan nama sebenar mereka kerana calon adalah bebas untuk memilih nama yang digunakan bagi tujuan kempen dan undi"
+			},
+			{
+				"id": -1,
+				"name": "candidate_uid",
+				"title_en": "Unique Candidate ID",
+				"title_bm": "ID Unik Calon",
+				"desc_en": "[Integer] Unique integer identifier to track candidates across elections",
+				"desc_bm": "[Integer] Integer unik untuk menjejaki keputusan seseorang calon merentasi pilihan raya"
+			},
+			{
+				"id": -1,
+				"name": "party",
+				"title_en": "Party",
+				"title_bm": "Parti",
+				"desc_en": "[String] Party of the candidate as it appeared on the ballot on voting day; this record is not amended to reflect unofficial information on parties and coalitions. For example, if a candidate competed under the flag of Party X despite being a member of Party Y, their party is recorded as Party X.",
+				"desc_bm": "[String] Parti calon seperti yang tertera pada kertas undi pada hari mengundi; rekod ini tidak dipinda untuk menggambarkan maklumat tidak rasmi mengenai parti dan gabungan. Sebagai contoh, jika calon bertanding bawah bendera Parti X walaupun menjadi ahli Parti Y, parti mereka direkodkan sebagai Parti X."
+			},
+			{
+				"id": -1,
+				"name": "votes",
+				"title_en": "Votes",
+				"title_bm": "Undi",
+				"desc_en": "Integer] Number of votes won by the candidate",
+				"desc_bm": "[Integer] Jumlah undi yang diperolehi oleh calon"
+			}
+		]
+	}
 }

--- a/catalog/ge13_ballots.json
+++ b/catalog/ge13_ballots.json
@@ -27,7 +27,7 @@
                 "catalog_data": {
                     "catalog_filters": {
                         "frequency": "INFREQUENT",
-                        "geographic": [
+                        "geography": [
                             "PARLIMEN",
                             "STATE",
                             "NATIONAL"

--- a/catalog/ge13_summary.json
+++ b/catalog/ge13_summary.json
@@ -28,7 +28,7 @@
 					"catalog_filters": {
 						"frequency": "INFREQUENT",
 						"geography": ["PARLIMEN", "STATE", "NATIONAL"],
-						"demographic": [],
+						"demography": [],
 						"start": "2013",
 						"end": "2013",
 						"data_source": ["SPR"]

--- a/catalog/ge13_summary.json
+++ b/catalog/ge13_summary.json
@@ -1,150 +1,141 @@
 {
-    "file": {
-        "manual_trigger": 0,
-        "bucket": "elections_federal",
-        "file_name": "ge13_summary",
-        "category": "ELECTIONS",
-        "category_en": "Elections",
-        "category_bm": "Pilihanraya",
-        "subcategory": "FEDERAL",
-        "subcategory_en": "Federal",
-        "subcategory_bm": "Persekutuan",
-        "description": {
-            "en": "Analytical summary of the pre-Independence general election held in 1955.",
-            "bm": "Ringkasan analitik bagi pilihanraya umum pramerdeka yang diadakan pada tahun 1955."
-        },
-        "link_parquet": "https://storage.data.gov.my/elections/federal/ge13_summary.parquet",
-        "link_csv": "https://storage.data.gov.my/elections/federal/ge13_summary.csv",
-        "link_preview": "https://storage.data.gov.my/elections/federal/ge13_summary.parquet",
-        "variables": [
-            {
-                "id": 0,
-                "name": "ge13_summary",
-                "title_en": "GE-13: Summary",
-                "title_bm": "PRU-13: Rumusan",
-                "desc_en": "Analytical summary of the pre-Independence general election held on 27 July 1955.",
-                "desc_bm": "Ringkasan analitik bagi pilihanraya umum pramerdeka yang diadakan pada 27 Julai 1955.",
-                "catalog_data": {
-                    "catalog_filters": {
-                        "frequency": "INFREQUENT",
-                        "geographic": [
-                            "PARLIMEN",
-                            "STATE",
-                            "NATIONAL"
-                        ],
-                        "demographic": [],
-                        "start": "2013",
-                        "end": "2013",
-                        "data_source": [
-                            "SPR"
-                        ]
-                    },
-                    "metadata_neutral": {
-                        "data_as_of": "1955-08-31 23:59",
-                        "last_updated": "2023-07-18 23:59",
-                        "next_update": "-"
-                    },
-                    "metadata_lang": {
-                        "en": {
-                            "methodology": "This data is a digital representation of the physical election results tabulated and gazetted per the Electoral Regulations (Conduct of Elections). The digitalisation process was rigorously cross-checked against physical records to ensure consistency and accuracy of information.",
-                            "caveat": "As of now, this data has not been verified by SPR, and is shown here on the staging site to provide easy access for exploring and checking the data.",
-                            "publication": "-"
-                        },
-                        "bm": {
-                            "methodology": "Data ini merupakan rekod digital keputusan pilihanraya yang dikira dan diwartakan selaras dengan Peraturan-Peraturan Pilihan Raya (Penjalanan Pilihan Raya). Proses pendigitalan disemak silang dengan rekod fizikal untuk memastikan ketepatan maklumat.",
-                            "caveat": "Setakat sekarang, data ini belum disemak dan diabsahkan oleh SPR, maka hanya dipaparkan di portal UAT ini bagi tujuan memudahkan proses semakan.",
-                            "publication": "-"
-                        }
-                    },
-                    "chart": {
-                        "chart_type": "TABLE",
-                        "chart_filters": {
-                            "SLICE_BY": [],
-                            "precision": 0
-                        },
-                        "chart_variables": {
-                            "parents": [],
-                            "exclude": [],
-                            "freeze": [
-                                "state",
-                                "parlimen"
-                            ]
-                        }
-                    }
-                }
-            },
-            {
-                "id": -1,
-                "name": "state",
-                "title_en": "State",
-                "title_bm": "Negeri",
-                "desc_en": "[String] 1 of 16 states",
-                "desc_bm": "[Rentetan] 1 antara 16 negeri"
-            },
-            {
-                "id": -1,
-                "name": "parlimen",
-                "title_en": "Parliament",
-                "title_bm": "Parlimen",
-                "desc_en": "[String] Name of seat as it appeared on the ballot on voting day",
-                "desc_bm": "[Rentetan] Nama kerusi seperti mana yang tertera di kertas undi pada hari mengundi"
-            },
-            {
-                "id": -1,
-                "name": "area_name",
-                "title_en": "Area Name",
-                "title_bm": "Nama Kawasan",
-                "desc_en": "[String] Name of the area, with seat code (P.xxx) stripped out, and area name historically harmonised. For example, Kota Baharu, Kota Bahru and Kota Bharu are all harmonised to the modern Kota Bharu.",
-                "desc_bm": "[Rentetan] Nama kawasan, tanpa kod kerusi (P.xxx) dan namanya diselaraskan mengambil kira perubahan dari zaman ke zaman. Contohnya, nama Kota Baharu, Kota Bahru, dan Kota Bharu semuanya diharmonikan kepada penggunaan moden iaitu Kota Bharu."
-            },
-            {
-                "id": -1,
-                "name": "voters_total",
-                "title_en": "Total Voters",
-                "title_bm": "Jumlah Pengundi",
-                "desc_en": "[Integer] Number of voters registered to vote in that seat at that election",
-                "desc_bm": "[Integer] Jumlah pengundi yang didaftarkan untuk mengundi di kerusi tersebut semasa PRU-00"
-            },
-            {
-                "id": -1,
-                "name": "ballots_issued",
-                "title_en": "Ballots Issued",
-                "title_bm": "Undi Dikeluarkan",
-                "desc_en": "[Integer] Number of ballots issued, including postal ballots, but not inclduing ballots accidentally damaged and immediately replace during the voting procedure",
-                "desc_bm": "[Integer] Jumlah kertas undi yang dikeluarkan, termasuk kertas undi pos, tetapi tidak termasuk kertas undi yang rosak dan terus digantikan semasa urusan mengundi dijalankan"
-            },
-            {
-                "id": -1,
-                "name": "ballots_not_returned",
-                "title_en": "Ballots Not Returned",
-                "title_bm": "Undi Tidak Dikembalikan",
-                "desc_en": "[Integer] Number of ballots issued but not returned for counting, including postal ballots not returned to the counting centre in time, but excluding spoilt ballots (e.g. torn or stained) which were replaced and therefore not counted as ballots issued",
-                "desc_bm": "[Integer] Jumlah kertas undi yang dikeluarkan tetapi tidak dikembalikan untuk pengiraan undi, termasuk kertas undi pos yang tidak dikembalikan ke pusat kiraan undi, tetapi tidak termasuk kertas undi rosak (contohnya terkoyak atau ternoda) yang telah digantikan maka tidak dikira sebagai kertas undi yang dikeluarkan"
-            },
-            {
-                "id": -1,
-                "name": "votes_rejected",
-                "title_en": "Votes Rejected",
-                "title_bm": "Undi Ditolak",
-                "desc_en": "[Integer] Number of ballots returned but declared invalid during counting because the candidate could not be determined",
-                "desc_bm": "[Integer] Jumlah kertas undi yang telah dikembalikan tetapi ditolak semasa proses kiraan undi kerana calon yang diundi tidak dapat ditentukan"
-            },
-            {
-                "id": -1,
-                "name": "voter_turnout",
-                "title_en": "Voter Turnout",
-                "title_bm": "Peratus Keluar",
-                "desc_en": "[Float] Derived as: (ballots_issued / voters_total) * 100",
-                "desc_bm": " [Apung] Diperolehi dengan formula: (ballots_issued / voters_total) * 100"
-            },
-            {
-                "id": -1,
-                "name": "votes_rejected_perc",
-                "title_en": "Percentage Rejected",
-                "title_bm": "Peratus Ditolak",
-                "desc_en": "[Float] Derived as: (votes_rejected / (ballots_issued - ballots_not_returned)) * 100",
-                "desc_bm": " [Apung] Diperolehi dengan formula: (votes_rejected / (ballots_issued - ballots_not_returned)) * 100"
-            }
-        ]
-    }
+	"file": {
+		"manual_trigger": 0,
+		"bucket": "elections_federal",
+		"file_name": "ge13_summary",
+		"category": "ELECTIONS",
+		"category_en": "Elections",
+		"category_bm": "Pilihanraya",
+		"subcategory": "FEDERAL",
+		"subcategory_en": "Federal",
+		"subcategory_bm": "Persekutuan",
+		"description": {
+			"en": "Analytical summary of the pre-Independence general election held in 1955.",
+			"bm": "Ringkasan analitik bagi pilihanraya umum pramerdeka yang diadakan pada tahun 1955."
+		},
+		"link_parquet": "https://storage.data.gov.my/elections/federal/ge13_summary.parquet",
+		"link_csv": "https://storage.data.gov.my/elections/federal/ge13_summary.csv",
+		"link_preview": "https://storage.data.gov.my/elections/federal/ge13_summary.parquet",
+		"variables": [
+			{
+				"id": 0,
+				"name": "ge13_summary",
+				"title_en": "GE-13: Summary",
+				"title_bm": "PRU-13: Rumusan",
+				"desc_en": "Analytical summary of the pre-Independence general election held on 27 July 1955.",
+				"desc_bm": "Ringkasan analitik bagi pilihanraya umum pramerdeka yang diadakan pada 27 Julai 1955.",
+				"catalog_data": {
+					"catalog_filters": {
+						"frequency": "INFREQUENT",
+						"geography": ["PARLIMEN", "STATE", "NATIONAL"],
+						"demographic": [],
+						"start": "2013",
+						"end": "2013",
+						"data_source": ["SPR"]
+					},
+					"metadata_neutral": {
+						"data_as_of": "1955-08-31 23:59",
+						"last_updated": "2023-07-18 23:59",
+						"next_update": "-"
+					},
+					"metadata_lang": {
+						"en": {
+							"methodology": "This data is a digital representation of the physical election results tabulated and gazetted per the Electoral Regulations (Conduct of Elections). The digitalisation process was rigorously cross-checked against physical records to ensure consistency and accuracy of information.",
+							"caveat": "As of now, this data has not been verified by SPR, and is shown here on the staging site to provide easy access for exploring and checking the data.",
+							"publication": "-"
+						},
+						"bm": {
+							"methodology": "Data ini merupakan rekod digital keputusan pilihanraya yang dikira dan diwartakan selaras dengan Peraturan-Peraturan Pilihan Raya (Penjalanan Pilihan Raya). Proses pendigitalan disemak silang dengan rekod fizikal untuk memastikan ketepatan maklumat.",
+							"caveat": "Setakat sekarang, data ini belum disemak dan diabsahkan oleh SPR, maka hanya dipaparkan di portal UAT ini bagi tujuan memudahkan proses semakan.",
+							"publication": "-"
+						}
+					},
+					"chart": {
+						"chart_type": "TABLE",
+						"chart_filters": {
+							"SLICE_BY": [],
+							"precision": 0
+						},
+						"chart_variables": {
+							"parents": [],
+							"exclude": [],
+							"freeze": ["state", "parlimen"]
+						}
+					}
+				}
+			},
+			{
+				"id": -1,
+				"name": "state",
+				"title_en": "State",
+				"title_bm": "Negeri",
+				"desc_en": "[String] 1 of 16 states",
+				"desc_bm": "[Rentetan] 1 antara 16 negeri"
+			},
+			{
+				"id": -1,
+				"name": "parlimen",
+				"title_en": "Parliament",
+				"title_bm": "Parlimen",
+				"desc_en": "[String] Name of seat as it appeared on the ballot on voting day",
+				"desc_bm": "[Rentetan] Nama kerusi seperti mana yang tertera di kertas undi pada hari mengundi"
+			},
+			{
+				"id": -1,
+				"name": "area_name",
+				"title_en": "Area Name",
+				"title_bm": "Nama Kawasan",
+				"desc_en": "[String] Name of the area, with seat code (P.xxx) stripped out, and area name historically harmonised. For example, Kota Baharu, Kota Bahru and Kota Bharu are all harmonised to the modern Kota Bharu.",
+				"desc_bm": "[Rentetan] Nama kawasan, tanpa kod kerusi (P.xxx) dan namanya diselaraskan mengambil kira perubahan dari zaman ke zaman. Contohnya, nama Kota Baharu, Kota Bahru, dan Kota Bharu semuanya diharmonikan kepada penggunaan moden iaitu Kota Bharu."
+			},
+			{
+				"id": -1,
+				"name": "voters_total",
+				"title_en": "Total Voters",
+				"title_bm": "Jumlah Pengundi",
+				"desc_en": "[Integer] Number of voters registered to vote in that seat at that election",
+				"desc_bm": "[Integer] Jumlah pengundi yang didaftarkan untuk mengundi di kerusi tersebut semasa PRU-00"
+			},
+			{
+				"id": -1,
+				"name": "ballots_issued",
+				"title_en": "Ballots Issued",
+				"title_bm": "Undi Dikeluarkan",
+				"desc_en": "[Integer] Number of ballots issued, including postal ballots, but not inclduing ballots accidentally damaged and immediately replace during the voting procedure",
+				"desc_bm": "[Integer] Jumlah kertas undi yang dikeluarkan, termasuk kertas undi pos, tetapi tidak termasuk kertas undi yang rosak dan terus digantikan semasa urusan mengundi dijalankan"
+			},
+			{
+				"id": -1,
+				"name": "ballots_not_returned",
+				"title_en": "Ballots Not Returned",
+				"title_bm": "Undi Tidak Dikembalikan",
+				"desc_en": "[Integer] Number of ballots issued but not returned for counting, including postal ballots not returned to the counting centre in time, but excluding spoilt ballots (e.g. torn or stained) which were replaced and therefore not counted as ballots issued",
+				"desc_bm": "[Integer] Jumlah kertas undi yang dikeluarkan tetapi tidak dikembalikan untuk pengiraan undi, termasuk kertas undi pos yang tidak dikembalikan ke pusat kiraan undi, tetapi tidak termasuk kertas undi rosak (contohnya terkoyak atau ternoda) yang telah digantikan maka tidak dikira sebagai kertas undi yang dikeluarkan"
+			},
+			{
+				"id": -1,
+				"name": "votes_rejected",
+				"title_en": "Votes Rejected",
+				"title_bm": "Undi Ditolak",
+				"desc_en": "[Integer] Number of ballots returned but declared invalid during counting because the candidate could not be determined",
+				"desc_bm": "[Integer] Jumlah kertas undi yang telah dikembalikan tetapi ditolak semasa proses kiraan undi kerana calon yang diundi tidak dapat ditentukan"
+			},
+			{
+				"id": -1,
+				"name": "voter_turnout",
+				"title_en": "Voter Turnout",
+				"title_bm": "Peratus Keluar",
+				"desc_en": "[Float] Derived as: (ballots_issued / voters_total) * 100",
+				"desc_bm": " [Apung] Diperolehi dengan formula: (ballots_issued / voters_total) * 100"
+			},
+			{
+				"id": -1,
+				"name": "votes_rejected_perc",
+				"title_en": "Percentage Rejected",
+				"title_bm": "Peratus Ditolak",
+				"desc_en": "[Float] Derived as: (votes_rejected / (ballots_issued - ballots_not_returned)) * 100",
+				"desc_bm": " [Apung] Diperolehi dengan formula: (votes_rejected / (ballots_issued - ballots_not_returned)) * 100"
+			}
+		]
+	}
 }

--- a/catalog/ge14_ballots.json
+++ b/catalog/ge14_ballots.json
@@ -28,7 +28,7 @@
 					"catalog_filters": {
 						"frequency": "INFREQUENT",
 						"geography": ["PARLIMEN", "STATE", "NATIONAL"],
-						"demographic": [],
+						"demography": [],
 						"start": "2018",
 						"end": "2018",
 						"data_source": ["SPR"]

--- a/catalog/ge14_ballots.json
+++ b/catalog/ge14_ballots.json
@@ -1,142 +1,133 @@
 {
-    "file": {
-        "manual_trigger": 0,
-        "bucket": "elections_federal",
-        "file_name": "ge14_ballots",
-        "category": "ELECTIONS",
-        "category_en": "Elections",
-        "category_bm": "Pilihanraya",
-        "subcategory": "FEDERAL",
-        "subcategory_en": "Federal",
-        "subcategory_bm": "Persekutuan",
-        "description": {
-            "en": "Ballots for every seat contested at the pre-Independence general election held in 1955.",
-            "bm": "Perincian undi bagi setiap kerusi yang dipertandingkan di pilihanraya umum pramerdeka yang diadakan pada tahun 1955."
-        },
-        "link_parquet": "https://storage.data.gov.my/elections/federal/ge14_ballots.parquet",
-        "link_csv": "https://storage.data.gov.my/elections/federal/ge14_ballots.csv",
-        "link_preview": "https://storage.data.gov.my/elections/federal/ge14_ballots.parquet",
-        "variables": [
-            {
-                "id": 0,
-                "name": "ge14_ballots",
-                "title_en": "GE-14: Ballots",
-                "title_bm": "PRU-14: Kertas Undi",
-                "desc_en": "Ballots for every seat contested at the pre-Independence general election held on 27 July 1955.",
-                "desc_bm": "Perincian undi bagi setiap kerusi yang dipertandingkan di pilihanraya umum pramerdeka yang diadakan pada 27 Julai 1955.",
-                "catalog_data": {
-                    "catalog_filters": {
-                        "frequency": "INFREQUENT",
-                        "geographic": [
-                            "PARLIMEN",
-                            "STATE",
-                            "NATIONAL"
-                        ],
-                        "demographic": [],
-                        "start": "2018",
-                        "end": "2018",
-                        "data_source": [
-                            "SPR"
-                        ]
-                    },
-                    "metadata_neutral": {
-                        "data_as_of": "1955-08-31 23:59",
-                        "last_updated": "2023-07-18 23:59",
-                        "next_update": "-"
-                    },
-                    "metadata_lang": {
-                        "en": {
-                            "methodology": "This data is a digital representation of the physical election results tabulated and gazetted per the Electoral Regulations (Conduct of Elections). The digitalisation process was rigorously cross-checked against physical records to ensure consistency and accuracy of information.",
-                            "caveat": "As of now, this data has not been verified by SPR, and is shown here on the staging site to provide easy access for exploring and checking the data.",
-                            "publication": "-"
-                        },
-                        "bm": {
-                            "methodology": "Data ini merupakan rekod digital keputusan pilihanraya yang dikira dan diwartakan selaras dengan Peraturan-Peraturan Pilihan Raya (Penjalanan Pilihan Raya). Proses pendigitalan disemak silang dengan rekod fizikal untuk memastikan ketepatan maklumat.",
-                            "caveat": "Setakat sekarang, data ini belum disemak dan diabsahkan oleh SPR, maka hanya dipaparkan di portal UAT ini bagi tujuan memudahkan proses semakan.",
-                            "publication": "-"
-                        }
-                    },
-                    "chart": {
-                        "chart_type": "TABLE",
-                        "chart_filters": {
-                            "SLICE_BY": [],
-                            "precision": 0
-                        },
-                        "chart_variables": {
-                            "parents": [],
-                            "exclude": [],
-                            "freeze": [
-                                "state",
-                                "parlimen"
-                            ]
-                        }
-                    }
-                }
-            },
-            {
-                "id": -1,
-                "name": "state",
-                "title_en": "State",
-                "title_bm": "Negeri",
-                "desc_en": "[String] 1 of 16 states",
-                "desc_bm": "[Rentetan] 1 antara 16 negeri"
-            },
-            {
-                "id": -1,
-                "name": "parlimen",
-                "title_en": "Parliament",
-                "title_bm": "Parlimen",
-                "desc_en": "[String] Name of seat as it appeared on the ballot on voting day",
-                "desc_bm": "[Rentetan] Nama kerusi seperti mana yang tertera di kertas undi pada hari mengundi"
-            },
-            {
-                "id": -1,
-                "name": "area_name",
-                "title_en": "Area Name",
-                "title_bm": "Nama Kawasan",
-                "desc_en": "[String] Name of the area, with seat code (P.xxx) stripped out, and area name historically harmonised. For example, Kota Baharu, Kota Bahru and Kota Bharu are all harmonised to the modern Kota Bharu.",
-                "desc_bm": "[Rentetan] Nama kawasan, tanpa kod kerusi (P.xxx) dan namanya diselaraskan mengambil kira perubahan dari zaman ke zaman. Contohnya, nama Kota Baharu, Kota Bahru, dan Kota Bharu semuanya diharmonikan kepada penggunaan moden iaitu Kota Bharu."
-            },
-            {
-                "id": -1,
-                "name": "ballot_order",
-                "title_en": "Ballot Order",
-                "title_bm": "Urutan Nama",
-                "desc_en": "[Integer] Order in which the candidate appears on the ballot",
-                "desc_bm": "[Integer] Urutan nama-nama yang tertera pada kertas undi"
-            },
-            {
-                "id": -1,
-                "name": "name",
-                "title_en": "Name",
-                "title_bm": "Nama",
-                "desc_en": "[String] Name of candidate as it appeared on the ballot on voting day; this may not be the same as their real name as candidates are free to choose the name they use for campaigning and voting",
-                "desc_bm": "[Rentetan] Nama calon seperti mana yang tertera di kertas undi pada hari mengundi; ini tidak semestinya sama dengan nama sebenar mereka kerana calon adalah bebas untuk memilih nama yang digunakan bagi tujuan kempen dan undi"
-            },
-            {
-                "id": -1,
-                "name": "candidate_uid",
-                "title_en": "Unique Candidate ID",
-                "title_bm": "ID Unik Calon",
-                "desc_en": "[Integer] Unique integer identifier to track candidates across elections",
-                "desc_bm": "[Integer] Integer unik untuk menjejaki keputusan seseorang calon merentasi pilihan raya"
-            },
-            {
-                "id": -1,
-                "name": "party",
-                "title_en": "Party",
-                "title_bm": "Parti",
-                "desc_en": "[String] Party of the candidate as it appeared on the ballot on voting day; this record is not amended to reflect unofficial information on parties and coalitions. For example, if a candidate competed under the flag of Party X despite being a member of Party Y, their party is recorded as Party X.",
-                "desc_bm": "[String] Parti calon seperti yang tertera pada kertas undi pada hari mengundi; rekod ini tidak dipinda untuk menggambarkan maklumat tidak rasmi mengenai parti dan gabungan. Sebagai contoh, jika calon bertanding bawah bendera Parti X walaupun menjadi ahli Parti Y, parti mereka direkodkan sebagai Parti X."
-            },
-            {
-                "id": -1,
-                "name": "votes",
-                "title_en": "Votes",
-                "title_bm": "Undi",
-                "desc_en": "Integer] Number of votes won by the candidate",
-                "desc_bm": "[Integer] Jumlah undi yang diperolehi oleh calon"
-            }
-        ]
-    }
+	"file": {
+		"manual_trigger": 0,
+		"bucket": "elections_federal",
+		"file_name": "ge14_ballots",
+		"category": "ELECTIONS",
+		"category_en": "Elections",
+		"category_bm": "Pilihanraya",
+		"subcategory": "FEDERAL",
+		"subcategory_en": "Federal",
+		"subcategory_bm": "Persekutuan",
+		"description": {
+			"en": "Ballots for every seat contested at the pre-Independence general election held in 1955.",
+			"bm": "Perincian undi bagi setiap kerusi yang dipertandingkan di pilihanraya umum pramerdeka yang diadakan pada tahun 1955."
+		},
+		"link_parquet": "https://storage.data.gov.my/elections/federal/ge14_ballots.parquet",
+		"link_csv": "https://storage.data.gov.my/elections/federal/ge14_ballots.csv",
+		"link_preview": "https://storage.data.gov.my/elections/federal/ge14_ballots.parquet",
+		"variables": [
+			{
+				"id": 0,
+				"name": "ge14_ballots",
+				"title_en": "GE-14: Ballots",
+				"title_bm": "PRU-14: Kertas Undi",
+				"desc_en": "Ballots for every seat contested at the pre-Independence general election held on 27 July 1955.",
+				"desc_bm": "Perincian undi bagi setiap kerusi yang dipertandingkan di pilihanraya umum pramerdeka yang diadakan pada 27 Julai 1955.",
+				"catalog_data": {
+					"catalog_filters": {
+						"frequency": "INFREQUENT",
+						"geography": ["PARLIMEN", "STATE", "NATIONAL"],
+						"demographic": [],
+						"start": "2018",
+						"end": "2018",
+						"data_source": ["SPR"]
+					},
+					"metadata_neutral": {
+						"data_as_of": "1955-08-31 23:59",
+						"last_updated": "2023-07-18 23:59",
+						"next_update": "-"
+					},
+					"metadata_lang": {
+						"en": {
+							"methodology": "This data is a digital representation of the physical election results tabulated and gazetted per the Electoral Regulations (Conduct of Elections). The digitalisation process was rigorously cross-checked against physical records to ensure consistency and accuracy of information.",
+							"caveat": "As of now, this data has not been verified by SPR, and is shown here on the staging site to provide easy access for exploring and checking the data.",
+							"publication": "-"
+						},
+						"bm": {
+							"methodology": "Data ini merupakan rekod digital keputusan pilihanraya yang dikira dan diwartakan selaras dengan Peraturan-Peraturan Pilihan Raya (Penjalanan Pilihan Raya). Proses pendigitalan disemak silang dengan rekod fizikal untuk memastikan ketepatan maklumat.",
+							"caveat": "Setakat sekarang, data ini belum disemak dan diabsahkan oleh SPR, maka hanya dipaparkan di portal UAT ini bagi tujuan memudahkan proses semakan.",
+							"publication": "-"
+						}
+					},
+					"chart": {
+						"chart_type": "TABLE",
+						"chart_filters": {
+							"SLICE_BY": [],
+							"precision": 0
+						},
+						"chart_variables": {
+							"parents": [],
+							"exclude": [],
+							"freeze": ["state", "parlimen"]
+						}
+					}
+				}
+			},
+			{
+				"id": -1,
+				"name": "state",
+				"title_en": "State",
+				"title_bm": "Negeri",
+				"desc_en": "[String] 1 of 16 states",
+				"desc_bm": "[Rentetan] 1 antara 16 negeri"
+			},
+			{
+				"id": -1,
+				"name": "parlimen",
+				"title_en": "Parliament",
+				"title_bm": "Parlimen",
+				"desc_en": "[String] Name of seat as it appeared on the ballot on voting day",
+				"desc_bm": "[Rentetan] Nama kerusi seperti mana yang tertera di kertas undi pada hari mengundi"
+			},
+			{
+				"id": -1,
+				"name": "area_name",
+				"title_en": "Area Name",
+				"title_bm": "Nama Kawasan",
+				"desc_en": "[String] Name of the area, with seat code (P.xxx) stripped out, and area name historically harmonised. For example, Kota Baharu, Kota Bahru and Kota Bharu are all harmonised to the modern Kota Bharu.",
+				"desc_bm": "[Rentetan] Nama kawasan, tanpa kod kerusi (P.xxx) dan namanya diselaraskan mengambil kira perubahan dari zaman ke zaman. Contohnya, nama Kota Baharu, Kota Bahru, dan Kota Bharu semuanya diharmonikan kepada penggunaan moden iaitu Kota Bharu."
+			},
+			{
+				"id": -1,
+				"name": "ballot_order",
+				"title_en": "Ballot Order",
+				"title_bm": "Urutan Nama",
+				"desc_en": "[Integer] Order in which the candidate appears on the ballot",
+				"desc_bm": "[Integer] Urutan nama-nama yang tertera pada kertas undi"
+			},
+			{
+				"id": -1,
+				"name": "name",
+				"title_en": "Name",
+				"title_bm": "Nama",
+				"desc_en": "[String] Name of candidate as it appeared on the ballot on voting day; this may not be the same as their real name as candidates are free to choose the name they use for campaigning and voting",
+				"desc_bm": "[Rentetan] Nama calon seperti mana yang tertera di kertas undi pada hari mengundi; ini tidak semestinya sama dengan nama sebenar mereka kerana calon adalah bebas untuk memilih nama yang digunakan bagi tujuan kempen dan undi"
+			},
+			{
+				"id": -1,
+				"name": "candidate_uid",
+				"title_en": "Unique Candidate ID",
+				"title_bm": "ID Unik Calon",
+				"desc_en": "[Integer] Unique integer identifier to track candidates across elections",
+				"desc_bm": "[Integer] Integer unik untuk menjejaki keputusan seseorang calon merentasi pilihan raya"
+			},
+			{
+				"id": -1,
+				"name": "party",
+				"title_en": "Party",
+				"title_bm": "Parti",
+				"desc_en": "[String] Party of the candidate as it appeared on the ballot on voting day; this record is not amended to reflect unofficial information on parties and coalitions. For example, if a candidate competed under the flag of Party X despite being a member of Party Y, their party is recorded as Party X.",
+				"desc_bm": "[String] Parti calon seperti yang tertera pada kertas undi pada hari mengundi; rekod ini tidak dipinda untuk menggambarkan maklumat tidak rasmi mengenai parti dan gabungan. Sebagai contoh, jika calon bertanding bawah bendera Parti X walaupun menjadi ahli Parti Y, parti mereka direkodkan sebagai Parti X."
+			},
+			{
+				"id": -1,
+				"name": "votes",
+				"title_en": "Votes",
+				"title_bm": "Undi",
+				"desc_en": "Integer] Number of votes won by the candidate",
+				"desc_bm": "[Integer] Jumlah undi yang diperolehi oleh calon"
+			}
+		]
+	}
 }

--- a/catalog/ge14_summary.json
+++ b/catalog/ge14_summary.json
@@ -28,7 +28,7 @@
 					"catalog_filters": {
 						"frequency": "INFREQUENT",
 						"geography": ["PARLIMEN", "STATE", "NATIONAL"],
-						"demographic": [],
+						"demography": [],
 						"start": "2018",
 						"end": "2018",
 						"data_source": ["SPR"]

--- a/catalog/ge14_summary.json
+++ b/catalog/ge14_summary.json
@@ -1,150 +1,141 @@
 {
-    "file": {
-        "manual_trigger": 0,
-        "bucket": "elections_federal",
-        "file_name": "ge14_summary",
-        "category": "ELECTIONS",
-        "category_en": "Elections",
-        "category_bm": "Pilihanraya",
-        "subcategory": "FEDERAL",
-        "subcategory_en": "Federal",
-        "subcategory_bm": "Persekutuan",
-        "description": {
-            "en": "Analytical summary of the pre-Independence general election held in 1955.",
-            "bm": "Ringkasan analitik bagi pilihanraya umum pramerdeka yang diadakan pada tahun 1955."
-        },
-        "link_parquet": "https://storage.data.gov.my/elections/federal/ge14_summary.parquet",
-        "link_csv": "https://storage.data.gov.my/elections/federal/ge14_summary.csv",
-        "link_preview": "https://storage.data.gov.my/elections/federal/ge14_summary.parquet",
-        "variables": [
-            {
-                "id": 0,
-                "name": "ge14_summary",
-                "title_en": "GE-14: Summary",
-                "title_bm": "PRU-14: Rumusan",
-                "desc_en": "Analytical summary of the pre-Independence general election held on 27 July 1955.",
-                "desc_bm": "Ringkasan analitik bagi pilihanraya umum pramerdeka yang diadakan pada 27 Julai 1955.",
-                "catalog_data": {
-                    "catalog_filters": {
-                        "frequency": "INFREQUENT",
-                        "geographic": [
-                            "PARLIMEN",
-                            "STATE",
-                            "NATIONAL"
-                        ],
-                        "demographic": [],
-                        "start": "2018",
-                        "end": "2018",
-                        "data_source": [
-                            "SPR"
-                        ]
-                    },
-                    "metadata_neutral": {
-                        "data_as_of": "1955-08-31 23:59",
-                        "last_updated": "2023-07-18 23:59",
-                        "next_update": "-"
-                    },
-                    "metadata_lang": {
-                        "en": {
-                            "methodology": "This data is a digital representation of the physical election results tabulated and gazetted per the Electoral Regulations (Conduct of Elections). The digitalisation process was rigorously cross-checked against physical records to ensure consistency and accuracy of information.",
-                            "caveat": "As of now, this data has not been verified by SPR, and is shown here on the staging site to provide easy access for exploring and checking the data.",
-                            "publication": "-"
-                        },
-                        "bm": {
-                            "methodology": "Data ini merupakan rekod digital keputusan pilihanraya yang dikira dan diwartakan selaras dengan Peraturan-Peraturan Pilihan Raya (Penjalanan Pilihan Raya). Proses pendigitalan disemak silang dengan rekod fizikal untuk memastikan ketepatan maklumat.",
-                            "caveat": "Setakat sekarang, data ini belum disemak dan diabsahkan oleh SPR, maka hanya dipaparkan di portal UAT ini bagi tujuan memudahkan proses semakan.",
-                            "publication": "-"
-                        }
-                    },
-                    "chart": {
-                        "chart_type": "TABLE",
-                        "chart_filters": {
-                            "SLICE_BY": [],
-                            "precision": 0
-                        },
-                        "chart_variables": {
-                            "parents": [],
-                            "exclude": [],
-                            "freeze": [
-                                "state",
-                                "parlimen"
-                            ]
-                        }
-                    }
-                }
-            },
-            {
-                "id": -1,
-                "name": "state",
-                "title_en": "State",
-                "title_bm": "Negeri",
-                "desc_en": "[String] 1 of 16 states",
-                "desc_bm": "[Rentetan] 1 antara 16 negeri"
-            },
-            {
-                "id": -1,
-                "name": "parlimen",
-                "title_en": "Parliament",
-                "title_bm": "Parlimen",
-                "desc_en": "[String] Name of seat as it appeared on the ballot on voting day",
-                "desc_bm": "[Rentetan] Nama kerusi seperti mana yang tertera di kertas undi pada hari mengundi"
-            },
-            {
-                "id": -1,
-                "name": "area_name",
-                "title_en": "Area Name",
-                "title_bm": "Nama Kawasan",
-                "desc_en": "[String] Name of the area, with seat code (P.xxx) stripped out, and area name historically harmonised. For example, Kota Baharu, Kota Bahru and Kota Bharu are all harmonised to the modern Kota Bharu.",
-                "desc_bm": "[Rentetan] Nama kawasan, tanpa kod kerusi (P.xxx) dan namanya diselaraskan mengambil kira perubahan dari zaman ke zaman. Contohnya, nama Kota Baharu, Kota Bahru, dan Kota Bharu semuanya diharmonikan kepada penggunaan moden iaitu Kota Bharu."
-            },
-            {
-                "id": -1,
-                "name": "voters_total",
-                "title_en": "Total Voters",
-                "title_bm": "Jumlah Pengundi",
-                "desc_en": "[Integer] Number of voters registered to vote in that seat at that election",
-                "desc_bm": "[Integer] Jumlah pengundi yang didaftarkan untuk mengundi di kerusi tersebut semasa PRU-00"
-            },
-            {
-                "id": -1,
-                "name": "ballots_issued",
-                "title_en": "Ballots Issued",
-                "title_bm": "Undi Dikeluarkan",
-                "desc_en": "[Integer] Number of ballots issued, including postal ballots, but not inclduing ballots accidentally damaged and immediately replace during the voting procedure",
-                "desc_bm": "[Integer] Jumlah kertas undi yang dikeluarkan, termasuk kertas undi pos, tetapi tidak termasuk kertas undi yang rosak dan terus digantikan semasa urusan mengundi dijalankan"
-            },
-            {
-                "id": -1,
-                "name": "ballots_not_returned",
-                "title_en": "Ballots Not Returned",
-                "title_bm": "Undi Tidak Dikembalikan",
-                "desc_en": "[Integer] Number of ballots issued but not returned for counting, including postal ballots not returned to the counting centre in time, but excluding spoilt ballots (e.g. torn or stained) which were replaced and therefore not counted as ballots issued",
-                "desc_bm": "[Integer] Jumlah kertas undi yang dikeluarkan tetapi tidak dikembalikan untuk pengiraan undi, termasuk kertas undi pos yang tidak dikembalikan ke pusat kiraan undi, tetapi tidak termasuk kertas undi rosak (contohnya terkoyak atau ternoda) yang telah digantikan maka tidak dikira sebagai kertas undi yang dikeluarkan"
-            },
-            {
-                "id": -1,
-                "name": "votes_rejected",
-                "title_en": "Votes Rejected",
-                "title_bm": "Undi Ditolak",
-                "desc_en": "[Integer] Number of ballots returned but declared invalid during counting because the candidate could not be determined",
-                "desc_bm": "[Integer] Jumlah kertas undi yang telah dikembalikan tetapi ditolak semasa proses kiraan undi kerana calon yang diundi tidak dapat ditentukan"
-            },
-            {
-                "id": -1,
-                "name": "voter_turnout",
-                "title_en": "Voter Turnout",
-                "title_bm": "Peratus Keluar",
-                "desc_en": "[Float] Derived as: (ballots_issued / voters_total) * 100",
-                "desc_bm": " [Apung] Diperolehi dengan formula: (ballots_issued / voters_total) * 100"
-            },
-            {
-                "id": -1,
-                "name": "votes_rejected_perc",
-                "title_en": "Percentage Rejected",
-                "title_bm": "Peratus Ditolak",
-                "desc_en": "[Float] Derived as: (votes_rejected / (ballots_issued - ballots_not_returned)) * 100",
-                "desc_bm": " [Apung] Diperolehi dengan formula: (votes_rejected / (ballots_issued - ballots_not_returned)) * 100"
-            }
-        ]
-    }
+	"file": {
+		"manual_trigger": 0,
+		"bucket": "elections_federal",
+		"file_name": "ge14_summary",
+		"category": "ELECTIONS",
+		"category_en": "Elections",
+		"category_bm": "Pilihanraya",
+		"subcategory": "FEDERAL",
+		"subcategory_en": "Federal",
+		"subcategory_bm": "Persekutuan",
+		"description": {
+			"en": "Analytical summary of the pre-Independence general election held in 1955.",
+			"bm": "Ringkasan analitik bagi pilihanraya umum pramerdeka yang diadakan pada tahun 1955."
+		},
+		"link_parquet": "https://storage.data.gov.my/elections/federal/ge14_summary.parquet",
+		"link_csv": "https://storage.data.gov.my/elections/federal/ge14_summary.csv",
+		"link_preview": "https://storage.data.gov.my/elections/federal/ge14_summary.parquet",
+		"variables": [
+			{
+				"id": 0,
+				"name": "ge14_summary",
+				"title_en": "GE-14: Summary",
+				"title_bm": "PRU-14: Rumusan",
+				"desc_en": "Analytical summary of the pre-Independence general election held on 27 July 1955.",
+				"desc_bm": "Ringkasan analitik bagi pilihanraya umum pramerdeka yang diadakan pada 27 Julai 1955.",
+				"catalog_data": {
+					"catalog_filters": {
+						"frequency": "INFREQUENT",
+						"geography": ["PARLIMEN", "STATE", "NATIONAL"],
+						"demographic": [],
+						"start": "2018",
+						"end": "2018",
+						"data_source": ["SPR"]
+					},
+					"metadata_neutral": {
+						"data_as_of": "1955-08-31 23:59",
+						"last_updated": "2023-07-18 23:59",
+						"next_update": "-"
+					},
+					"metadata_lang": {
+						"en": {
+							"methodology": "This data is a digital representation of the physical election results tabulated and gazetted per the Electoral Regulations (Conduct of Elections). The digitalisation process was rigorously cross-checked against physical records to ensure consistency and accuracy of information.",
+							"caveat": "As of now, this data has not been verified by SPR, and is shown here on the staging site to provide easy access for exploring and checking the data.",
+							"publication": "-"
+						},
+						"bm": {
+							"methodology": "Data ini merupakan rekod digital keputusan pilihanraya yang dikira dan diwartakan selaras dengan Peraturan-Peraturan Pilihan Raya (Penjalanan Pilihan Raya). Proses pendigitalan disemak silang dengan rekod fizikal untuk memastikan ketepatan maklumat.",
+							"caveat": "Setakat sekarang, data ini belum disemak dan diabsahkan oleh SPR, maka hanya dipaparkan di portal UAT ini bagi tujuan memudahkan proses semakan.",
+							"publication": "-"
+						}
+					},
+					"chart": {
+						"chart_type": "TABLE",
+						"chart_filters": {
+							"SLICE_BY": [],
+							"precision": 0
+						},
+						"chart_variables": {
+							"parents": [],
+							"exclude": [],
+							"freeze": ["state", "parlimen"]
+						}
+					}
+				}
+			},
+			{
+				"id": -1,
+				"name": "state",
+				"title_en": "State",
+				"title_bm": "Negeri",
+				"desc_en": "[String] 1 of 16 states",
+				"desc_bm": "[Rentetan] 1 antara 16 negeri"
+			},
+			{
+				"id": -1,
+				"name": "parlimen",
+				"title_en": "Parliament",
+				"title_bm": "Parlimen",
+				"desc_en": "[String] Name of seat as it appeared on the ballot on voting day",
+				"desc_bm": "[Rentetan] Nama kerusi seperti mana yang tertera di kertas undi pada hari mengundi"
+			},
+			{
+				"id": -1,
+				"name": "area_name",
+				"title_en": "Area Name",
+				"title_bm": "Nama Kawasan",
+				"desc_en": "[String] Name of the area, with seat code (P.xxx) stripped out, and area name historically harmonised. For example, Kota Baharu, Kota Bahru and Kota Bharu are all harmonised to the modern Kota Bharu.",
+				"desc_bm": "[Rentetan] Nama kawasan, tanpa kod kerusi (P.xxx) dan namanya diselaraskan mengambil kira perubahan dari zaman ke zaman. Contohnya, nama Kota Baharu, Kota Bahru, dan Kota Bharu semuanya diharmonikan kepada penggunaan moden iaitu Kota Bharu."
+			},
+			{
+				"id": -1,
+				"name": "voters_total",
+				"title_en": "Total Voters",
+				"title_bm": "Jumlah Pengundi",
+				"desc_en": "[Integer] Number of voters registered to vote in that seat at that election",
+				"desc_bm": "[Integer] Jumlah pengundi yang didaftarkan untuk mengundi di kerusi tersebut semasa PRU-00"
+			},
+			{
+				"id": -1,
+				"name": "ballots_issued",
+				"title_en": "Ballots Issued",
+				"title_bm": "Undi Dikeluarkan",
+				"desc_en": "[Integer] Number of ballots issued, including postal ballots, but not inclduing ballots accidentally damaged and immediately replace during the voting procedure",
+				"desc_bm": "[Integer] Jumlah kertas undi yang dikeluarkan, termasuk kertas undi pos, tetapi tidak termasuk kertas undi yang rosak dan terus digantikan semasa urusan mengundi dijalankan"
+			},
+			{
+				"id": -1,
+				"name": "ballots_not_returned",
+				"title_en": "Ballots Not Returned",
+				"title_bm": "Undi Tidak Dikembalikan",
+				"desc_en": "[Integer] Number of ballots issued but not returned for counting, including postal ballots not returned to the counting centre in time, but excluding spoilt ballots (e.g. torn or stained) which were replaced and therefore not counted as ballots issued",
+				"desc_bm": "[Integer] Jumlah kertas undi yang dikeluarkan tetapi tidak dikembalikan untuk pengiraan undi, termasuk kertas undi pos yang tidak dikembalikan ke pusat kiraan undi, tetapi tidak termasuk kertas undi rosak (contohnya terkoyak atau ternoda) yang telah digantikan maka tidak dikira sebagai kertas undi yang dikeluarkan"
+			},
+			{
+				"id": -1,
+				"name": "votes_rejected",
+				"title_en": "Votes Rejected",
+				"title_bm": "Undi Ditolak",
+				"desc_en": "[Integer] Number of ballots returned but declared invalid during counting because the candidate could not be determined",
+				"desc_bm": "[Integer] Jumlah kertas undi yang telah dikembalikan tetapi ditolak semasa proses kiraan undi kerana calon yang diundi tidak dapat ditentukan"
+			},
+			{
+				"id": -1,
+				"name": "voter_turnout",
+				"title_en": "Voter Turnout",
+				"title_bm": "Peratus Keluar",
+				"desc_en": "[Float] Derived as: (ballots_issued / voters_total) * 100",
+				"desc_bm": " [Apung] Diperolehi dengan formula: (ballots_issued / voters_total) * 100"
+			},
+			{
+				"id": -1,
+				"name": "votes_rejected_perc",
+				"title_en": "Percentage Rejected",
+				"title_bm": "Peratus Ditolak",
+				"desc_en": "[Float] Derived as: (votes_rejected / (ballots_issued - ballots_not_returned)) * 100",
+				"desc_bm": " [Apung] Diperolehi dengan formula: (votes_rejected / (ballots_issued - ballots_not_returned)) * 100"
+			}
+		]
+	}
 }

--- a/catalog/ge15_ballots.json
+++ b/catalog/ge15_ballots.json
@@ -28,7 +28,7 @@
 					"catalog_filters": {
 						"frequency": "INFREQUENT",
 						"geography": ["PARLIMEN", "STATE", "NATIONAL"],
-						"demographic": [],
+						"demography": [],
 						"start": "2022",
 						"end": "2022",
 						"data_source": ["SPR"]

--- a/catalog/ge15_ballots.json
+++ b/catalog/ge15_ballots.json
@@ -1,142 +1,133 @@
 {
-    "file": {
-        "manual_trigger": 0,
-        "bucket": "elections_federal",
-        "file_name": "ge15_ballots",
-        "category": "ELECTIONS",
-        "category_en": "Elections",
-        "category_bm": "Pilihanraya",
-        "subcategory": "FEDERAL",
-        "subcategory_en": "Federal",
-        "subcategory_bm": "Persekutuan",
-        "description": {
-            "en": "Ballots for every seat contested at the pre-Independence general election held in 1955.",
-            "bm": "Perincian undi bagi setiap kerusi yang dipertandingkan di pilihanraya umum pramerdeka yang diadakan pada tahun 1955."
-        },
-        "link_parquet": "https://storage.data.gov.my/elections/federal/ge15_ballots.parquet",
-        "link_csv": "https://storage.data.gov.my/elections/federal/ge15_ballots.csv",
-        "link_preview": "https://storage.data.gov.my/elections/federal/ge15_ballots.parquet",
-        "variables": [
-            {
-                "id": 0,
-                "name": "ge15_ballots",
-                "title_en": "GE-15: Ballots",
-                "title_bm": "PRU-15: Kertas Undi",
-                "desc_en": "Ballots for every seat contested at the pre-Independence general election held on 27 July 1955.",
-                "desc_bm": "Perincian undi bagi setiap kerusi yang dipertandingkan di pilihanraya umum pramerdeka yang diadakan pada 27 Julai 1955.",
-                "catalog_data": {
-                    "catalog_filters": {
-                        "frequency": "INFREQUENT",
-                        "geographic": [
-                            "PARLIMEN",
-                            "STATE",
-                            "NATIONAL"
-                        ],
-                        "demographic": [],
-                        "start": "2022",
-                        "end": "2022",
-                        "data_source": [
-                            "SPR"
-                        ]
-                    },
-                    "metadata_neutral": {
-                        "data_as_of": "1955-08-31 23:59",
-                        "last_updated": "2023-07-18 23:59",
-                        "next_update": "-"
-                    },
-                    "metadata_lang": {
-                        "en": {
-                            "methodology": "This data is a digital representation of the physical election results tabulated and gazetted per the Electoral Regulations (Conduct of Elections). The digitalisation process was rigorously cross-checked against physical records to ensure consistency and accuracy of information.",
-                            "caveat": "As of now, this data has not been verified by SPR, and is shown here on the staging site to provide easy access for exploring and checking the data.",
-                            "publication": "-"
-                        },
-                        "bm": {
-                            "methodology": "Data ini merupakan rekod digital keputusan pilihanraya yang dikira dan diwartakan selaras dengan Peraturan-Peraturan Pilihan Raya (Penjalanan Pilihan Raya). Proses pendigitalan disemak silang dengan rekod fizikal untuk memastikan ketepatan maklumat.",
-                            "caveat": "Setakat sekarang, data ini belum disemak dan diabsahkan oleh SPR, maka hanya dipaparkan di portal UAT ini bagi tujuan memudahkan proses semakan.",
-                            "publication": "-"
-                        }
-                    },
-                    "chart": {
-                        "chart_type": "TABLE",
-                        "chart_filters": {
-                            "SLICE_BY": [],
-                            "precision": 0
-                        },
-                        "chart_variables": {
-                            "parents": [],
-                            "exclude": [],
-                            "freeze": [
-                                "state",
-                                "parlimen"
-                            ]
-                        }
-                    }
-                }
-            },
-            {
-                "id": -1,
-                "name": "state",
-                "title_en": "State",
-                "title_bm": "Negeri",
-                "desc_en": "[String] 1 of 16 states",
-                "desc_bm": "[Rentetan] 1 antara 16 negeri"
-            },
-            {
-                "id": -1,
-                "name": "parlimen",
-                "title_en": "Parliament",
-                "title_bm": "Parlimen",
-                "desc_en": "[String] Name of seat as it appeared on the ballot on voting day",
-                "desc_bm": "[Rentetan] Nama kerusi seperti mana yang tertera di kertas undi pada hari mengundi"
-            },
-            {
-                "id": -1,
-                "name": "area_name",
-                "title_en": "Area Name",
-                "title_bm": "Nama Kawasan",
-                "desc_en": "[String] Name of the area, with seat code (P.xxx) stripped out, and area name historically harmonised. For example, Kota Baharu, Kota Bahru and Kota Bharu are all harmonised to the modern Kota Bharu.",
-                "desc_bm": "[Rentetan] Nama kawasan, tanpa kod kerusi (P.xxx) dan namanya diselaraskan mengambil kira perubahan dari zaman ke zaman. Contohnya, nama Kota Baharu, Kota Bahru, dan Kota Bharu semuanya diharmonikan kepada penggunaan moden iaitu Kota Bharu."
-            },
-            {
-                "id": -1,
-                "name": "ballot_order",
-                "title_en": "Ballot Order",
-                "title_bm": "Urutan Nama",
-                "desc_en": "[Integer] Order in which the candidate appears on the ballot",
-                "desc_bm": "[Integer] Urutan nama-nama yang tertera pada kertas undi"
-            },
-            {
-                "id": -1,
-                "name": "name",
-                "title_en": "Name",
-                "title_bm": "Nama",
-                "desc_en": "[String] Name of candidate as it appeared on the ballot on voting day; this may not be the same as their real name as candidates are free to choose the name they use for campaigning and voting",
-                "desc_bm": "[Rentetan] Nama calon seperti mana yang tertera di kertas undi pada hari mengundi; ini tidak semestinya sama dengan nama sebenar mereka kerana calon adalah bebas untuk memilih nama yang digunakan bagi tujuan kempen dan undi"
-            },
-            {
-                "id": -1,
-                "name": "candidate_uid",
-                "title_en": "Unique Candidate ID",
-                "title_bm": "ID Unik Calon",
-                "desc_en": "[Integer] Unique integer identifier to track candidates across elections",
-                "desc_bm": "[Integer] Integer unik untuk menjejaki keputusan seseorang calon merentasi pilihan raya"
-            },
-            {
-                "id": -1,
-                "name": "party",
-                "title_en": "Party",
-                "title_bm": "Parti",
-                "desc_en": "[String] Party of the candidate as it appeared on the ballot on voting day; this record is not amended to reflect unofficial information on parties and coalitions. For example, if a candidate competed under the flag of Party X despite being a member of Party Y, their party is recorded as Party X.",
-                "desc_bm": "[String] Parti calon seperti yang tertera pada kertas undi pada hari mengundi; rekod ini tidak dipinda untuk menggambarkan maklumat tidak rasmi mengenai parti dan gabungan. Sebagai contoh, jika calon bertanding bawah bendera Parti X walaupun menjadi ahli Parti Y, parti mereka direkodkan sebagai Parti X."
-            },
-            {
-                "id": -1,
-                "name": "votes",
-                "title_en": "Votes",
-                "title_bm": "Undi",
-                "desc_en": "Integer] Number of votes won by the candidate",
-                "desc_bm": "[Integer] Jumlah undi yang diperolehi oleh calon"
-            }
-        ]
-    }
+	"file": {
+		"manual_trigger": 0,
+		"bucket": "elections_federal",
+		"file_name": "ge15_ballots",
+		"category": "ELECTIONS",
+		"category_en": "Elections",
+		"category_bm": "Pilihanraya",
+		"subcategory": "FEDERAL",
+		"subcategory_en": "Federal",
+		"subcategory_bm": "Persekutuan",
+		"description": {
+			"en": "Ballots for every seat contested at the pre-Independence general election held in 1955.",
+			"bm": "Perincian undi bagi setiap kerusi yang dipertandingkan di pilihanraya umum pramerdeka yang diadakan pada tahun 1955."
+		},
+		"link_parquet": "https://storage.data.gov.my/elections/federal/ge15_ballots.parquet",
+		"link_csv": "https://storage.data.gov.my/elections/federal/ge15_ballots.csv",
+		"link_preview": "https://storage.data.gov.my/elections/federal/ge15_ballots.parquet",
+		"variables": [
+			{
+				"id": 0,
+				"name": "ge15_ballots",
+				"title_en": "GE-15: Ballots",
+				"title_bm": "PRU-15: Kertas Undi",
+				"desc_en": "Ballots for every seat contested at the pre-Independence general election held on 27 July 1955.",
+				"desc_bm": "Perincian undi bagi setiap kerusi yang dipertandingkan di pilihanraya umum pramerdeka yang diadakan pada 27 Julai 1955.",
+				"catalog_data": {
+					"catalog_filters": {
+						"frequency": "INFREQUENT",
+						"geography": ["PARLIMEN", "STATE", "NATIONAL"],
+						"demographic": [],
+						"start": "2022",
+						"end": "2022",
+						"data_source": ["SPR"]
+					},
+					"metadata_neutral": {
+						"data_as_of": "1955-08-31 23:59",
+						"last_updated": "2023-07-18 23:59",
+						"next_update": "-"
+					},
+					"metadata_lang": {
+						"en": {
+							"methodology": "This data is a digital representation of the physical election results tabulated and gazetted per the Electoral Regulations (Conduct of Elections). The digitalisation process was rigorously cross-checked against physical records to ensure consistency and accuracy of information.",
+							"caveat": "As of now, this data has not been verified by SPR, and is shown here on the staging site to provide easy access for exploring and checking the data.",
+							"publication": "-"
+						},
+						"bm": {
+							"methodology": "Data ini merupakan rekod digital keputusan pilihanraya yang dikira dan diwartakan selaras dengan Peraturan-Peraturan Pilihan Raya (Penjalanan Pilihan Raya). Proses pendigitalan disemak silang dengan rekod fizikal untuk memastikan ketepatan maklumat.",
+							"caveat": "Setakat sekarang, data ini belum disemak dan diabsahkan oleh SPR, maka hanya dipaparkan di portal UAT ini bagi tujuan memudahkan proses semakan.",
+							"publication": "-"
+						}
+					},
+					"chart": {
+						"chart_type": "TABLE",
+						"chart_filters": {
+							"SLICE_BY": [],
+							"precision": 0
+						},
+						"chart_variables": {
+							"parents": [],
+							"exclude": [],
+							"freeze": ["state", "parlimen"]
+						}
+					}
+				}
+			},
+			{
+				"id": -1,
+				"name": "state",
+				"title_en": "State",
+				"title_bm": "Negeri",
+				"desc_en": "[String] 1 of 16 states",
+				"desc_bm": "[Rentetan] 1 antara 16 negeri"
+			},
+			{
+				"id": -1,
+				"name": "parlimen",
+				"title_en": "Parliament",
+				"title_bm": "Parlimen",
+				"desc_en": "[String] Name of seat as it appeared on the ballot on voting day",
+				"desc_bm": "[Rentetan] Nama kerusi seperti mana yang tertera di kertas undi pada hari mengundi"
+			},
+			{
+				"id": -1,
+				"name": "area_name",
+				"title_en": "Area Name",
+				"title_bm": "Nama Kawasan",
+				"desc_en": "[String] Name of the area, with seat code (P.xxx) stripped out, and area name historically harmonised. For example, Kota Baharu, Kota Bahru and Kota Bharu are all harmonised to the modern Kota Bharu.",
+				"desc_bm": "[Rentetan] Nama kawasan, tanpa kod kerusi (P.xxx) dan namanya diselaraskan mengambil kira perubahan dari zaman ke zaman. Contohnya, nama Kota Baharu, Kota Bahru, dan Kota Bharu semuanya diharmonikan kepada penggunaan moden iaitu Kota Bharu."
+			},
+			{
+				"id": -1,
+				"name": "ballot_order",
+				"title_en": "Ballot Order",
+				"title_bm": "Urutan Nama",
+				"desc_en": "[Integer] Order in which the candidate appears on the ballot",
+				"desc_bm": "[Integer] Urutan nama-nama yang tertera pada kertas undi"
+			},
+			{
+				"id": -1,
+				"name": "name",
+				"title_en": "Name",
+				"title_bm": "Nama",
+				"desc_en": "[String] Name of candidate as it appeared on the ballot on voting day; this may not be the same as their real name as candidates are free to choose the name they use for campaigning and voting",
+				"desc_bm": "[Rentetan] Nama calon seperti mana yang tertera di kertas undi pada hari mengundi; ini tidak semestinya sama dengan nama sebenar mereka kerana calon adalah bebas untuk memilih nama yang digunakan bagi tujuan kempen dan undi"
+			},
+			{
+				"id": -1,
+				"name": "candidate_uid",
+				"title_en": "Unique Candidate ID",
+				"title_bm": "ID Unik Calon",
+				"desc_en": "[Integer] Unique integer identifier to track candidates across elections",
+				"desc_bm": "[Integer] Integer unik untuk menjejaki keputusan seseorang calon merentasi pilihan raya"
+			},
+			{
+				"id": -1,
+				"name": "party",
+				"title_en": "Party",
+				"title_bm": "Parti",
+				"desc_en": "[String] Party of the candidate as it appeared on the ballot on voting day; this record is not amended to reflect unofficial information on parties and coalitions. For example, if a candidate competed under the flag of Party X despite being a member of Party Y, their party is recorded as Party X.",
+				"desc_bm": "[String] Parti calon seperti yang tertera pada kertas undi pada hari mengundi; rekod ini tidak dipinda untuk menggambarkan maklumat tidak rasmi mengenai parti dan gabungan. Sebagai contoh, jika calon bertanding bawah bendera Parti X walaupun menjadi ahli Parti Y, parti mereka direkodkan sebagai Parti X."
+			},
+			{
+				"id": -1,
+				"name": "votes",
+				"title_en": "Votes",
+				"title_bm": "Undi",
+				"desc_en": "Integer] Number of votes won by the candidate",
+				"desc_bm": "[Integer] Jumlah undi yang diperolehi oleh calon"
+			}
+		]
+	}
 }

--- a/catalog/ge15_summary.json
+++ b/catalog/ge15_summary.json
@@ -28,7 +28,7 @@
 					"catalog_filters": {
 						"frequency": "INFREQUENT",
 						"geography": ["PARLIMEN", "STATE", "NATIONAL"],
-						"demographic": [],
+						"demography": [],
 						"start": "2022",
 						"end": "2022",
 						"data_source": ["SPR"]

--- a/catalog/ge15_summary.json
+++ b/catalog/ge15_summary.json
@@ -1,150 +1,141 @@
 {
-    "file": {
-        "manual_trigger": 0,
-        "bucket": "elections_federal",
-        "file_name": "ge15_summary",
-        "category": "ELECTIONS",
-        "category_en": "Elections",
-        "category_bm": "Pilihanraya",
-        "subcategory": "FEDERAL",
-        "subcategory_en": "Federal",
-        "subcategory_bm": "Persekutuan",
-        "description": {
-            "en": "Analytical summary of the pre-Independence general election held in 1955.",
-            "bm": "Ringkasan analitik bagi pilihanraya umum pramerdeka yang diadakan pada tahun 1955."
-        },
-        "link_parquet": "https://storage.data.gov.my/elections/federal/ge15_summary.parquet",
-        "link_csv": "https://storage.data.gov.my/elections/federal/ge15_summary.csv",
-        "link_preview": "https://storage.data.gov.my/elections/federal/ge15_summary.parquet",
-        "variables": [
-            {
-                "id": 0,
-                "name": "ge15_summary",
-                "title_en": "GE-15: Summary",
-                "title_bm": "PRU-15: Rumusan",
-                "desc_en": "Analytical summary of the pre-Independence general election held on 27 July 1955.",
-                "desc_bm": "Ringkasan analitik bagi pilihanraya umum pramerdeka yang diadakan pada 27 Julai 1955.",
-                "catalog_data": {
-                    "catalog_filters": {
-                        "frequency": "INFREQUENT",
-                        "geographic": [
-                            "PARLIMEN",
-                            "STATE",
-                            "NATIONAL"
-                        ],
-                        "demographic": [],
-                        "start": "2022",
-                        "end": "2022",
-                        "data_source": [
-                            "SPR"
-                        ]
-                    },
-                    "metadata_neutral": {
-                        "data_as_of": "1955-08-31 23:59",
-                        "last_updated": "2023-07-18 23:59",
-                        "next_update": "-"
-                    },
-                    "metadata_lang": {
-                        "en": {
-                            "methodology": "This data is a digital representation of the physical election results tabulated and gazetted per the Electoral Regulations (Conduct of Elections). The digitalisation process was rigorously cross-checked against physical records to ensure consistency and accuracy of information.",
-                            "caveat": "As of now, this data has not been verified by SPR, and is shown here on the staging site to provide easy access for exploring and checking the data.",
-                            "publication": "-"
-                        },
-                        "bm": {
-                            "methodology": "Data ini merupakan rekod digital keputusan pilihanraya yang dikira dan diwartakan selaras dengan Peraturan-Peraturan Pilihan Raya (Penjalanan Pilihan Raya). Proses pendigitalan disemak silang dengan rekod fizikal untuk memastikan ketepatan maklumat.",
-                            "caveat": "Setakat sekarang, data ini belum disemak dan diabsahkan oleh SPR, maka hanya dipaparkan di portal UAT ini bagi tujuan memudahkan proses semakan.",
-                            "publication": "-"
-                        }
-                    },
-                    "chart": {
-                        "chart_type": "TABLE",
-                        "chart_filters": {
-                            "SLICE_BY": [],
-                            "precision": 0
-                        },
-                        "chart_variables": {
-                            "parents": [],
-                            "exclude": [],
-                            "freeze": [
-                                "state",
-                                "parlimen"
-                            ]
-                        }
-                    }
-                }
-            },
-            {
-                "id": -1,
-                "name": "state",
-                "title_en": "State",
-                "title_bm": "Negeri",
-                "desc_en": "[String] 1 of 16 states",
-                "desc_bm": "[Rentetan] 1 antara 16 negeri"
-            },
-            {
-                "id": -1,
-                "name": "parlimen",
-                "title_en": "Parliament",
-                "title_bm": "Parlimen",
-                "desc_en": "[String] Name of seat as it appeared on the ballot on voting day",
-                "desc_bm": "[Rentetan] Nama kerusi seperti mana yang tertera di kertas undi pada hari mengundi"
-            },
-            {
-                "id": -1,
-                "name": "area_name",
-                "title_en": "Area Name",
-                "title_bm": "Nama Kawasan",
-                "desc_en": "[String] Name of the area, with seat code (P.xxx) stripped out, and area name historically harmonised. For example, Kota Baharu, Kota Bahru and Kota Bharu are all harmonised to the modern Kota Bharu.",
-                "desc_bm": "[Rentetan] Nama kawasan, tanpa kod kerusi (P.xxx) dan namanya diselaraskan mengambil kira perubahan dari zaman ke zaman. Contohnya, nama Kota Baharu, Kota Bahru, dan Kota Bharu semuanya diharmonikan kepada penggunaan moden iaitu Kota Bharu."
-            },
-            {
-                "id": -1,
-                "name": "voters_total",
-                "title_en": "Total Voters",
-                "title_bm": "Jumlah Pengundi",
-                "desc_en": "[Integer] Number of voters registered to vote in that seat at that election",
-                "desc_bm": "[Integer] Jumlah pengundi yang didaftarkan untuk mengundi di kerusi tersebut semasa PRU-00"
-            },
-            {
-                "id": -1,
-                "name": "ballots_issued",
-                "title_en": "Ballots Issued",
-                "title_bm": "Undi Dikeluarkan",
-                "desc_en": "[Integer] Number of ballots issued, including postal ballots, but not inclduing ballots accidentally damaged and immediately replace during the voting procedure",
-                "desc_bm": "[Integer] Jumlah kertas undi yang dikeluarkan, termasuk kertas undi pos, tetapi tidak termasuk kertas undi yang rosak dan terus digantikan semasa urusan mengundi dijalankan"
-            },
-            {
-                "id": -1,
-                "name": "ballots_not_returned",
-                "title_en": "Ballots Not Returned",
-                "title_bm": "Undi Tidak Dikembalikan",
-                "desc_en": "[Integer] Number of ballots issued but not returned for counting, including postal ballots not returned to the counting centre in time, but excluding spoilt ballots (e.g. torn or stained) which were replaced and therefore not counted as ballots issued",
-                "desc_bm": "[Integer] Jumlah kertas undi yang dikeluarkan tetapi tidak dikembalikan untuk pengiraan undi, termasuk kertas undi pos yang tidak dikembalikan ke pusat kiraan undi, tetapi tidak termasuk kertas undi rosak (contohnya terkoyak atau ternoda) yang telah digantikan maka tidak dikira sebagai kertas undi yang dikeluarkan"
-            },
-            {
-                "id": -1,
-                "name": "votes_rejected",
-                "title_en": "Votes Rejected",
-                "title_bm": "Undi Ditolak",
-                "desc_en": "[Integer] Number of ballots returned but declared invalid during counting because the candidate could not be determined",
-                "desc_bm": "[Integer] Jumlah kertas undi yang telah dikembalikan tetapi ditolak semasa proses kiraan undi kerana calon yang diundi tidak dapat ditentukan"
-            },
-            {
-                "id": -1,
-                "name": "voter_turnout",
-                "title_en": "Voter Turnout",
-                "title_bm": "Peratus Keluar",
-                "desc_en": "[Float] Derived as: (ballots_issued / voters_total) * 100",
-                "desc_bm": " [Apung] Diperolehi dengan formula: (ballots_issued / voters_total) * 100"
-            },
-            {
-                "id": -1,
-                "name": "votes_rejected_perc",
-                "title_en": "Percentage Rejected",
-                "title_bm": "Peratus Ditolak",
-                "desc_en": "[Float] Derived as: (votes_rejected / (ballots_issued - ballots_not_returned)) * 100",
-                "desc_bm": " [Apung] Diperolehi dengan formula: (votes_rejected / (ballots_issued - ballots_not_returned)) * 100"
-            }
-        ]
-    }
+	"file": {
+		"manual_trigger": 0,
+		"bucket": "elections_federal",
+		"file_name": "ge15_summary",
+		"category": "ELECTIONS",
+		"category_en": "Elections",
+		"category_bm": "Pilihanraya",
+		"subcategory": "FEDERAL",
+		"subcategory_en": "Federal",
+		"subcategory_bm": "Persekutuan",
+		"description": {
+			"en": "Analytical summary of the pre-Independence general election held in 1955.",
+			"bm": "Ringkasan analitik bagi pilihanraya umum pramerdeka yang diadakan pada tahun 1955."
+		},
+		"link_parquet": "https://storage.data.gov.my/elections/federal/ge15_summary.parquet",
+		"link_csv": "https://storage.data.gov.my/elections/federal/ge15_summary.csv",
+		"link_preview": "https://storage.data.gov.my/elections/federal/ge15_summary.parquet",
+		"variables": [
+			{
+				"id": 0,
+				"name": "ge15_summary",
+				"title_en": "GE-15: Summary",
+				"title_bm": "PRU-15: Rumusan",
+				"desc_en": "Analytical summary of the pre-Independence general election held on 27 July 1955.",
+				"desc_bm": "Ringkasan analitik bagi pilihanraya umum pramerdeka yang diadakan pada 27 Julai 1955.",
+				"catalog_data": {
+					"catalog_filters": {
+						"frequency": "INFREQUENT",
+						"geography": ["PARLIMEN", "STATE", "NATIONAL"],
+						"demographic": [],
+						"start": "2022",
+						"end": "2022",
+						"data_source": ["SPR"]
+					},
+					"metadata_neutral": {
+						"data_as_of": "1955-08-31 23:59",
+						"last_updated": "2023-07-18 23:59",
+						"next_update": "-"
+					},
+					"metadata_lang": {
+						"en": {
+							"methodology": "This data is a digital representation of the physical election results tabulated and gazetted per the Electoral Regulations (Conduct of Elections). The digitalisation process was rigorously cross-checked against physical records to ensure consistency and accuracy of information.",
+							"caveat": "As of now, this data has not been verified by SPR, and is shown here on the staging site to provide easy access for exploring and checking the data.",
+							"publication": "-"
+						},
+						"bm": {
+							"methodology": "Data ini merupakan rekod digital keputusan pilihanraya yang dikira dan diwartakan selaras dengan Peraturan-Peraturan Pilihan Raya (Penjalanan Pilihan Raya). Proses pendigitalan disemak silang dengan rekod fizikal untuk memastikan ketepatan maklumat.",
+							"caveat": "Setakat sekarang, data ini belum disemak dan diabsahkan oleh SPR, maka hanya dipaparkan di portal UAT ini bagi tujuan memudahkan proses semakan.",
+							"publication": "-"
+						}
+					},
+					"chart": {
+						"chart_type": "TABLE",
+						"chart_filters": {
+							"SLICE_BY": [],
+							"precision": 0
+						},
+						"chart_variables": {
+							"parents": [],
+							"exclude": [],
+							"freeze": ["state", "parlimen"]
+						}
+					}
+				}
+			},
+			{
+				"id": -1,
+				"name": "state",
+				"title_en": "State",
+				"title_bm": "Negeri",
+				"desc_en": "[String] 1 of 16 states",
+				"desc_bm": "[Rentetan] 1 antara 16 negeri"
+			},
+			{
+				"id": -1,
+				"name": "parlimen",
+				"title_en": "Parliament",
+				"title_bm": "Parlimen",
+				"desc_en": "[String] Name of seat as it appeared on the ballot on voting day",
+				"desc_bm": "[Rentetan] Nama kerusi seperti mana yang tertera di kertas undi pada hari mengundi"
+			},
+			{
+				"id": -1,
+				"name": "area_name",
+				"title_en": "Area Name",
+				"title_bm": "Nama Kawasan",
+				"desc_en": "[String] Name of the area, with seat code (P.xxx) stripped out, and area name historically harmonised. For example, Kota Baharu, Kota Bahru and Kota Bharu are all harmonised to the modern Kota Bharu.",
+				"desc_bm": "[Rentetan] Nama kawasan, tanpa kod kerusi (P.xxx) dan namanya diselaraskan mengambil kira perubahan dari zaman ke zaman. Contohnya, nama Kota Baharu, Kota Bahru, dan Kota Bharu semuanya diharmonikan kepada penggunaan moden iaitu Kota Bharu."
+			},
+			{
+				"id": -1,
+				"name": "voters_total",
+				"title_en": "Total Voters",
+				"title_bm": "Jumlah Pengundi",
+				"desc_en": "[Integer] Number of voters registered to vote in that seat at that election",
+				"desc_bm": "[Integer] Jumlah pengundi yang didaftarkan untuk mengundi di kerusi tersebut semasa PRU-00"
+			},
+			{
+				"id": -1,
+				"name": "ballots_issued",
+				"title_en": "Ballots Issued",
+				"title_bm": "Undi Dikeluarkan",
+				"desc_en": "[Integer] Number of ballots issued, including postal ballots, but not inclduing ballots accidentally damaged and immediately replace during the voting procedure",
+				"desc_bm": "[Integer] Jumlah kertas undi yang dikeluarkan, termasuk kertas undi pos, tetapi tidak termasuk kertas undi yang rosak dan terus digantikan semasa urusan mengundi dijalankan"
+			},
+			{
+				"id": -1,
+				"name": "ballots_not_returned",
+				"title_en": "Ballots Not Returned",
+				"title_bm": "Undi Tidak Dikembalikan",
+				"desc_en": "[Integer] Number of ballots issued but not returned for counting, including postal ballots not returned to the counting centre in time, but excluding spoilt ballots (e.g. torn or stained) which were replaced and therefore not counted as ballots issued",
+				"desc_bm": "[Integer] Jumlah kertas undi yang dikeluarkan tetapi tidak dikembalikan untuk pengiraan undi, termasuk kertas undi pos yang tidak dikembalikan ke pusat kiraan undi, tetapi tidak termasuk kertas undi rosak (contohnya terkoyak atau ternoda) yang telah digantikan maka tidak dikira sebagai kertas undi yang dikeluarkan"
+			},
+			{
+				"id": -1,
+				"name": "votes_rejected",
+				"title_en": "Votes Rejected",
+				"title_bm": "Undi Ditolak",
+				"desc_en": "[Integer] Number of ballots returned but declared invalid during counting because the candidate could not be determined",
+				"desc_bm": "[Integer] Jumlah kertas undi yang telah dikembalikan tetapi ditolak semasa proses kiraan undi kerana calon yang diundi tidak dapat ditentukan"
+			},
+			{
+				"id": -1,
+				"name": "voter_turnout",
+				"title_en": "Voter Turnout",
+				"title_bm": "Peratus Keluar",
+				"desc_en": "[Float] Derived as: (ballots_issued / voters_total) * 100",
+				"desc_bm": " [Apung] Diperolehi dengan formula: (ballots_issued / voters_total) * 100"
+			},
+			{
+				"id": -1,
+				"name": "votes_rejected_perc",
+				"title_en": "Percentage Rejected",
+				"title_bm": "Peratus Ditolak",
+				"desc_en": "[Float] Derived as: (votes_rejected / (ballots_issued - ballots_not_returned)) * 100",
+				"desc_bm": " [Apung] Diperolehi dengan formula: (votes_rejected / (ballots_issued - ballots_not_returned)) * 100"
+			}
+		]
+	}
 }

--- a/catalog/mwe_bar_1.json
+++ b/catalog/mwe_bar_1.json
@@ -51,7 +51,7 @@
 					"catalog_filters": {
 						"frequency": "MONTHLY",
 						"geography": ["NATIONAL"],
-						"demographic": [],
+						"demography": [],
 						"start": "2006",
 						"end": "2023",
 						"data_source": ["MAMPU"]

--- a/catalog/mwe_bar_1.json
+++ b/catalog/mwe_bar_1.json
@@ -1,104 +1,104 @@
 {
-  "file": {
-    "manual_trigger": "1",
-    "bucket": "dgmy-public-mwe",
-    "file_name": "mwe_bar_1",
-    "category": "METADATA",
-    "category_en": "Site Metadata",
-    "category_bm": "Metadata Portal",
-    "subcategory": "SAMPLE_CHART",
-    "subcategory_en": "Chart Samples",
-    "subcategory_bm": "Contoh Carta",
-    "description": {
-      "en": "Lorem ipsum.",
-      "bm": "Lorem ipsum."
-    },
-    "link_parquet": "https://dgmy-public-mwe.s3.ap-southeast-1.amazonaws.com/mwe_bar.parquet",
-    "link_csv": "https://dgmy-public-mwe.s3.ap-southeast-1.amazonaws.com/mwe_bar.csv",
-    "variables": [
-      {
-        "id": -1,
-        "name": "date",
-        "title_en": "Date",
-        "title_bm": "Tarikh",
-        "desc_en": "[Date] The date in YYYY-MM-DD format",
-        "desc_bm": "[Tarikh] Tarikh dalam format YYYY-MM-DD"
-      },
-      {
-        "id": -1,
-        "name": "state",
-        "title_en": "State",
-        "title_bm": "Negeri",
-        "desc_en": "[Categorical] Name of the state (16 in total) or Malaysia",
-        "desc_bm": "[Kategori] Name negeri (16 keseluruhan) atau Malaysia"
-      },
-      {
-        "id": -1,
-        "name": "var1",
-        "title_en": "Variable 1",
-        "title_bm": "Pembolehubah 1",
-        "desc_en": "[Integer] A precise, succinct description of this variable",
-        "desc_bm": "[Integer] A precise, succinct description of this variable"
-      },
-      {
-        "id": 0,
-        "name": "mwe_bar_1",
-        "title_en": "Vertical Bar (1 bar)",
-        "title_bm": "Bar Menegak (1 bar)",
-        "desc_en": "A precise, succinct description of this chart",
-        "desc_bm": "A precise, succinct description of this chart",
-        "catalog_data": {
-          "catalog_filters": {
-            "frequency": "MONTHLY",
-            "geographic": ["NATIONAL"],
-            "demographic": [],
-            "start": "2006",
-            "end": "2023",
-            "data_source": ["MAMPU"]
-          },
-          "metadata_neutral": {
-            "data_as_of": "2023-04-03 23:59",
-            "last_updated": "2023-04-04 06:00",
-            "next_update": "2023-04-05 06:00"
-          },
-          "metadata_lang": {
-            "en": {
-              "methodology": "Lorem Ipsum is simply dummy text of the printing and typesetting industry. Lorem Ipsum has been the industry's standard dummy text ever since the 1500s, when an unknown printer took a galley of type and scrambled it to make a type specimen book.",
-              "caveat": "Contrary to popular belief, Lorem Ipsum is not simply random text. It has roots in a piece of classical Latin literature from 45 BC, making it over 2000 years old. Richard McClintock, a Latin professor at Hampden-Sydney College in Virginia, looked up one of the more obscure Latin words, consectetur, from a Lorem Ipsum passage, and going through the cites of the word in classical literature, discovered the undoubtable source.",
-              "publication": "Lorem Ipsum comes from sections 1.10.32 and 1.10.33 of 'de Finibus Bonorum et Malorum' (The Extremes of Good and Evil) by Cicero, written in 45 BC. This book is a treatise on the theory of ethics, very popular during the Renaissance. The first line of Lorem Ipsum, 'Lorem ipsum dolor sit amet..'', comes from a line in section 1.10.32."
-            },
-            "bm": {
-              "methodology": "Lorem Ipsum is simply dummy text of the printing and typesetting industry. Lorem Ipsum has been the industry's standard dummy text ever since the 1500s, when an unknown printer took a galley of type and scrambled it to make a type specimen book.",
-              "caveat": "Contrary to popular belief, Lorem Ipsum is not simply random text. It has roots in a piece of classical Latin literature from 45 BC, making it over 2000 years old. Richard McClintock, a Latin professor at Hampden-Sydney College in Virginia, looked up one of the more obscure Latin words, consectetur, from a Lorem Ipsum passage, and going through the cites of the word in classical literature, discovered the undoubtable source.",
-              "publication": "Lorem Ipsum comes from sections 1.10.32 and 1.10.33 of 'de Finibus Bonorum et Malorum' (The Extremes of Good and Evil) by Cicero, written in 45 BC. This book is a treatise on the theory of ethics, very popular during the Renaissance. The first line of Lorem Ipsum, 'Lorem ipsum dolor sit amet..'', comes from a line in section 1.10.32."
-            }
-          },
-          "chart": {
-            "chart_type": "BAR",
-            "chart_filters": {
-              "SLICE_BY": [],
-              "precision": 0
-            },
-            "chart_variables": {
-              "parents": [],
-              "format": {
-                "x": "state",
-                "y": ["var1"]
-              }
-            }
-          },
-          "translations": {
-            "en": {
-              "x": "State",
-              "y": "Variable 1"
-            },
-            "bm": {
-              "x": "Negeri",
-              "y": "Pembolehubah 1"
-            }
-          }
-        }
-      }
-    ]
-  }
+	"file": {
+		"manual_trigger": "1",
+		"bucket": "dgmy-public-mwe",
+		"file_name": "mwe_bar_1",
+		"category": "METADATA",
+		"category_en": "Site Metadata",
+		"category_bm": "Metadata Portal",
+		"subcategory": "SAMPLE_CHART",
+		"subcategory_en": "Chart Samples",
+		"subcategory_bm": "Contoh Carta",
+		"description": {
+			"en": "Lorem ipsum.",
+			"bm": "Lorem ipsum."
+		},
+		"link_parquet": "https://dgmy-public-mwe.s3.ap-southeast-1.amazonaws.com/mwe_bar.parquet",
+		"link_csv": "https://dgmy-public-mwe.s3.ap-southeast-1.amazonaws.com/mwe_bar.csv",
+		"variables": [
+			{
+				"id": -1,
+				"name": "date",
+				"title_en": "Date",
+				"title_bm": "Tarikh",
+				"desc_en": "[Date] The date in YYYY-MM-DD format",
+				"desc_bm": "[Tarikh] Tarikh dalam format YYYY-MM-DD"
+			},
+			{
+				"id": -1,
+				"name": "state",
+				"title_en": "State",
+				"title_bm": "Negeri",
+				"desc_en": "[Categorical] Name of the state (16 in total) or Malaysia",
+				"desc_bm": "[Kategori] Name negeri (16 keseluruhan) atau Malaysia"
+			},
+			{
+				"id": -1,
+				"name": "var1",
+				"title_en": "Variable 1",
+				"title_bm": "Pembolehubah 1",
+				"desc_en": "[Integer] A precise, succinct description of this variable",
+				"desc_bm": "[Integer] A precise, succinct description of this variable"
+			},
+			{
+				"id": 0,
+				"name": "mwe_bar_1",
+				"title_en": "Vertical Bar (1 bar)",
+				"title_bm": "Bar Menegak (1 bar)",
+				"desc_en": "A precise, succinct description of this chart",
+				"desc_bm": "A precise, succinct description of this chart",
+				"catalog_data": {
+					"catalog_filters": {
+						"frequency": "MONTHLY",
+						"geography": ["NATIONAL"],
+						"demographic": [],
+						"start": "2006",
+						"end": "2023",
+						"data_source": ["MAMPU"]
+					},
+					"metadata_neutral": {
+						"data_as_of": "2023-04-03 23:59",
+						"last_updated": "2023-04-04 06:00",
+						"next_update": "2023-04-05 06:00"
+					},
+					"metadata_lang": {
+						"en": {
+							"methodology": "Lorem Ipsum is simply dummy text of the printing and typesetting industry. Lorem Ipsum has been the industry's standard dummy text ever since the 1500s, when an unknown printer took a galley of type and scrambled it to make a type specimen book.",
+							"caveat": "Contrary to popular belief, Lorem Ipsum is not simply random text. It has roots in a piece of classical Latin literature from 45 BC, making it over 2000 years old. Richard McClintock, a Latin professor at Hampden-Sydney College in Virginia, looked up one of the more obscure Latin words, consectetur, from a Lorem Ipsum passage, and going through the cites of the word in classical literature, discovered the undoubtable source.",
+							"publication": "Lorem Ipsum comes from sections 1.10.32 and 1.10.33 of 'de Finibus Bonorum et Malorum' (The Extremes of Good and Evil) by Cicero, written in 45 BC. This book is a treatise on the theory of ethics, very popular during the Renaissance. The first line of Lorem Ipsum, 'Lorem ipsum dolor sit amet..'', comes from a line in section 1.10.32."
+						},
+						"bm": {
+							"methodology": "Lorem Ipsum is simply dummy text of the printing and typesetting industry. Lorem Ipsum has been the industry's standard dummy text ever since the 1500s, when an unknown printer took a galley of type and scrambled it to make a type specimen book.",
+							"caveat": "Contrary to popular belief, Lorem Ipsum is not simply random text. It has roots in a piece of classical Latin literature from 45 BC, making it over 2000 years old. Richard McClintock, a Latin professor at Hampden-Sydney College in Virginia, looked up one of the more obscure Latin words, consectetur, from a Lorem Ipsum passage, and going through the cites of the word in classical literature, discovered the undoubtable source.",
+							"publication": "Lorem Ipsum comes from sections 1.10.32 and 1.10.33 of 'de Finibus Bonorum et Malorum' (The Extremes of Good and Evil) by Cicero, written in 45 BC. This book is a treatise on the theory of ethics, very popular during the Renaissance. The first line of Lorem Ipsum, 'Lorem ipsum dolor sit amet..'', comes from a line in section 1.10.32."
+						}
+					},
+					"chart": {
+						"chart_type": "BAR",
+						"chart_filters": {
+							"SLICE_BY": [],
+							"precision": 0
+						},
+						"chart_variables": {
+							"parents": [],
+							"format": {
+								"x": "state",
+								"y": ["var1"]
+							}
+						}
+					},
+					"translations": {
+						"en": {
+							"x": "State",
+							"y": "Variable 1"
+						},
+						"bm": {
+							"x": "Negeri",
+							"y": "Pembolehubah 1"
+						}
+					}
+				}
+			}
+		]
+	}
 }

--- a/catalog/mwe_bar_2.json
+++ b/catalog/mwe_bar_2.json
@@ -1,114 +1,114 @@
 {
-  "file": {
-    "manual_trigger": "1",
-    "bucket": "dgmy-public-mwe",
-    "file_name": "mwe_bar_2",
-    "category": "METADATA",
-    "category_en": "Site Metadata",
-    "category_bm": "Metadata Portal",
-    "subcategory": "SAMPLE_CHART",
-    "subcategory_en": "Chart Samples",
-    "subcategory_bm": "Contoh Carta",
-    "description": {
-      "en": "Lorem ipsum.",
-      "bm": "Lorem ipsum."
-    },
-    "link_parquet": "https://dgmy-public-mwe.s3.ap-southeast-1.amazonaws.com/mwe_bar.parquet",
-    "link_csv": "https://dgmy-public-mwe.s3.ap-southeast-1.amazonaws.com/mwe_bar.csv",
-    "variables": [
-      {
-        "id": -1,
-        "name": "date",
-        "title_en": "Date",
-        "title_bm": "Tarikh",
-        "desc_en": "[Date] The date in YYYY-MM-DD format",
-        "desc_bm": "[Tarikh] Tarikh dalam format YYYY-MM-DD"
-      },
-      {
-        "id": -1,
-        "name": "state",
-        "title_en": "State",
-        "title_bm": "Negeri",
-        "desc_en": "[Categorical] Name of the state (16 in total) or Malaysia",
-        "desc_bm": "[Kategori] Name negeri (16 keseluruhan) atau Malaysia"
-      },
-      {
-        "id": -1,
-        "name": "var1",
-        "title_en": "Variable 1",
-        "title_bm": "Pembolehubah 1",
-        "desc_en": "[Integer] A precise, succinct description of this variable",
-        "desc_bm": "[Integer] A precise, succinct description of this variable"
-      },
-      {
-        "id": -1,
-        "name": "var2",
-        "title_en": "Variable 2",
-        "title_bm": "Pembolehubah 2",
-        "desc_en": "[Integer] A precise, succinct description of this variable",
-        "desc_bm": "[Integer] A precise, succinct description of this variable"
-      },
-      {
-        "id": 0,
-        "name": "mwe_bar_2",
-        "title_en": "Vertical Bar (2 bars)",
-        "title_bm": "Bar Menegak (2 bar)",
-        "desc_en": "A precise, succinct description of this chart",
-        "desc_bm": "A precise, succinct description of this chart",
-        "catalog_data": {
-          "catalog_filters": {
-            "frequency": "MONTHLY",
-            "geographic": ["NATIONAL"],
-            "demographic": [],
-            "start": "2006",
-            "end": "2023",
-            "data_source": ["MAMPU"]
-          },
-          "metadata_neutral": {
-            "data_as_of": "2023-04-03 23:59",
-            "last_updated": "2023-04-04 06:00",
-            "next_update": "2023-04-05 06:00"
-          },
-          "metadata_lang": {
-            "en": {
-              "methodology": "Lorem Ipsum is simply dummy text of the printing and typesetting industry. Lorem Ipsum has been the industry's standard dummy text ever since the 1500s, when an unknown printer took a galley of type and scrambled it to make a type specimen book.",
-              "caveat": "Contrary to popular belief, Lorem Ipsum is not simply random text. It has roots in a piece of classical Latin literature from 45 BC, making it over 2000 years old. Richard McClintock, a Latin professor at Hampden-Sydney College in Virginia, looked up one of the more obscure Latin words, consectetur, from a Lorem Ipsum passage, and going through the cites of the word in classical literature, discovered the undoubtable source.",
-              "publication": "Lorem Ipsum comes from sections 1.10.32 and 1.10.33 of 'de Finibus Bonorum et Malorum' (The Extremes of Good and Evil) by Cicero, written in 45 BC. This book is a treatise on the theory of ethics, very popular during the Renaissance. The first line of Lorem Ipsum, 'Lorem ipsum dolor sit amet..'', comes from a line in section 1.10.32."
-            },
-            "bm": {
-              "methodology": "Lorem Ipsum is simply dummy text of the printing and typesetting industry. Lorem Ipsum has been the industry's standard dummy text ever since the 1500s, when an unknown printer took a galley of type and scrambled it to make a type specimen book.",
-              "caveat": "Contrary to popular belief, Lorem Ipsum is not simply random text. It has roots in a piece of classical Latin literature from 45 BC, making it over 2000 years old. Richard McClintock, a Latin professor at Hampden-Sydney College in Virginia, looked up one of the more obscure Latin words, consectetur, from a Lorem Ipsum passage, and going through the cites of the word in classical literature, discovered the undoubtable source.",
-              "publication": "Lorem Ipsum comes from sections 1.10.32 and 1.10.33 of 'de Finibus Bonorum et Malorum' (The Extremes of Good and Evil) by Cicero, written in 45 BC. This book is a treatise on the theory of ethics, very popular during the Renaissance. The first line of Lorem Ipsum, 'Lorem ipsum dolor sit amet..'', comes from a line in section 1.10.32."
-            }
-          },
-          "chart": {
-            "chart_type": "BAR",
-            "chart_filters": {
-              "SLICE_BY": [],
-              "precision": 0
-            },
-            "chart_variables": {
-              "parents": [],
-              "format": {
-                "x": "state",
-                "y": ["var1", "var2"]
-              }
-            }
-          },
-          "translations": {
-            "en": {
-              "x": "State",
-              "y1": "Variable 1",
-              "y2": "Variable 2"
-            },
-            "bm": {
-              "x": "Negeri",
-              "y1": "Pembolehubah 1",
-              "y2": "Pembolehubah 2"
-            }
-          }
-        }
-      }
-    ]
-  }
+	"file": {
+		"manual_trigger": "1",
+		"bucket": "dgmy-public-mwe",
+		"file_name": "mwe_bar_2",
+		"category": "METADATA",
+		"category_en": "Site Metadata",
+		"category_bm": "Metadata Portal",
+		"subcategory": "SAMPLE_CHART",
+		"subcategory_en": "Chart Samples",
+		"subcategory_bm": "Contoh Carta",
+		"description": {
+			"en": "Lorem ipsum.",
+			"bm": "Lorem ipsum."
+		},
+		"link_parquet": "https://dgmy-public-mwe.s3.ap-southeast-1.amazonaws.com/mwe_bar.parquet",
+		"link_csv": "https://dgmy-public-mwe.s3.ap-southeast-1.amazonaws.com/mwe_bar.csv",
+		"variables": [
+			{
+				"id": -1,
+				"name": "date",
+				"title_en": "Date",
+				"title_bm": "Tarikh",
+				"desc_en": "[Date] The date in YYYY-MM-DD format",
+				"desc_bm": "[Tarikh] Tarikh dalam format YYYY-MM-DD"
+			},
+			{
+				"id": -1,
+				"name": "state",
+				"title_en": "State",
+				"title_bm": "Negeri",
+				"desc_en": "[Categorical] Name of the state (16 in total) or Malaysia",
+				"desc_bm": "[Kategori] Name negeri (16 keseluruhan) atau Malaysia"
+			},
+			{
+				"id": -1,
+				"name": "var1",
+				"title_en": "Variable 1",
+				"title_bm": "Pembolehubah 1",
+				"desc_en": "[Integer] A precise, succinct description of this variable",
+				"desc_bm": "[Integer] A precise, succinct description of this variable"
+			},
+			{
+				"id": -1,
+				"name": "var2",
+				"title_en": "Variable 2",
+				"title_bm": "Pembolehubah 2",
+				"desc_en": "[Integer] A precise, succinct description of this variable",
+				"desc_bm": "[Integer] A precise, succinct description of this variable"
+			},
+			{
+				"id": 0,
+				"name": "mwe_bar_2",
+				"title_en": "Vertical Bar (2 bars)",
+				"title_bm": "Bar Menegak (2 bar)",
+				"desc_en": "A precise, succinct description of this chart",
+				"desc_bm": "A precise, succinct description of this chart",
+				"catalog_data": {
+					"catalog_filters": {
+						"frequency": "MONTHLY",
+						"geography": ["NATIONAL"],
+						"demographic": [],
+						"start": "2006",
+						"end": "2023",
+						"data_source": ["MAMPU"]
+					},
+					"metadata_neutral": {
+						"data_as_of": "2023-04-03 23:59",
+						"last_updated": "2023-04-04 06:00",
+						"next_update": "2023-04-05 06:00"
+					},
+					"metadata_lang": {
+						"en": {
+							"methodology": "Lorem Ipsum is simply dummy text of the printing and typesetting industry. Lorem Ipsum has been the industry's standard dummy text ever since the 1500s, when an unknown printer took a galley of type and scrambled it to make a type specimen book.",
+							"caveat": "Contrary to popular belief, Lorem Ipsum is not simply random text. It has roots in a piece of classical Latin literature from 45 BC, making it over 2000 years old. Richard McClintock, a Latin professor at Hampden-Sydney College in Virginia, looked up one of the more obscure Latin words, consectetur, from a Lorem Ipsum passage, and going through the cites of the word in classical literature, discovered the undoubtable source.",
+							"publication": "Lorem Ipsum comes from sections 1.10.32 and 1.10.33 of 'de Finibus Bonorum et Malorum' (The Extremes of Good and Evil) by Cicero, written in 45 BC. This book is a treatise on the theory of ethics, very popular during the Renaissance. The first line of Lorem Ipsum, 'Lorem ipsum dolor sit amet..'', comes from a line in section 1.10.32."
+						},
+						"bm": {
+							"methodology": "Lorem Ipsum is simply dummy text of the printing and typesetting industry. Lorem Ipsum has been the industry's standard dummy text ever since the 1500s, when an unknown printer took a galley of type and scrambled it to make a type specimen book.",
+							"caveat": "Contrary to popular belief, Lorem Ipsum is not simply random text. It has roots in a piece of classical Latin literature from 45 BC, making it over 2000 years old. Richard McClintock, a Latin professor at Hampden-Sydney College in Virginia, looked up one of the more obscure Latin words, consectetur, from a Lorem Ipsum passage, and going through the cites of the word in classical literature, discovered the undoubtable source.",
+							"publication": "Lorem Ipsum comes from sections 1.10.32 and 1.10.33 of 'de Finibus Bonorum et Malorum' (The Extremes of Good and Evil) by Cicero, written in 45 BC. This book is a treatise on the theory of ethics, very popular during the Renaissance. The first line of Lorem Ipsum, 'Lorem ipsum dolor sit amet..'', comes from a line in section 1.10.32."
+						}
+					},
+					"chart": {
+						"chart_type": "BAR",
+						"chart_filters": {
+							"SLICE_BY": [],
+							"precision": 0
+						},
+						"chart_variables": {
+							"parents": [],
+							"format": {
+								"x": "state",
+								"y": ["var1", "var2"]
+							}
+						}
+					},
+					"translations": {
+						"en": {
+							"x": "State",
+							"y1": "Variable 1",
+							"y2": "Variable 2"
+						},
+						"bm": {
+							"x": "Negeri",
+							"y1": "Pembolehubah 1",
+							"y2": "Pembolehubah 2"
+						}
+					}
+				}
+			}
+		]
+	}
 }

--- a/catalog/mwe_bar_2.json
+++ b/catalog/mwe_bar_2.json
@@ -59,7 +59,7 @@
 					"catalog_filters": {
 						"frequency": "MONTHLY",
 						"geography": ["NATIONAL"],
-						"demographic": [],
+						"demography": [],
 						"start": "2006",
 						"end": "2023",
 						"data_source": ["MAMPU"]

--- a/catalog/mwe_bar_3.json
+++ b/catalog/mwe_bar_3.json
@@ -67,7 +67,7 @@
 					"catalog_filters": {
 						"frequency": "MONTHLY",
 						"geography": ["NATIONAL"],
-						"demographic": [],
+						"demography": [],
 						"start": "2006",
 						"end": "2023",
 						"data_source": ["MAMPU"]

--- a/catalog/mwe_bar_3.json
+++ b/catalog/mwe_bar_3.json
@@ -1,124 +1,124 @@
 {
-  "file": {
-    "manual_trigger": "1",
-    "bucket": "dgmy-public-mwe",
-    "file_name": "mwe_bar_3",
-    "category": "METADATA",
-    "category_en": "Site Metadata",
-    "category_bm": "Metadata Portal",
-    "subcategory": "SAMPLE_CHART",
-    "subcategory_en": "Chart Samples",
-    "subcategory_bm": "Contoh Carta",
-    "description": {
-      "en": "Lorem ipsum.",
-      "bm": "Lorem ipsum."
-    },
-    "link_parquet": "https://dgmy-public-mwe.s3.ap-southeast-1.amazonaws.com/mwe_bar.parquet",
-    "link_csv": "https://dgmy-public-mwe.s3.ap-southeast-1.amazonaws.com/mwe_bar.csv",
-    "variables": [
-      {
-        "id": -1,
-        "name": "date",
-        "title_en": "Date",
-        "title_bm": "Tarikh",
-        "desc_en": "[Date] The date in YYYY-MM-DD format",
-        "desc_bm": "[Tarikh] Tarikh dalam format YYYY-MM-DD"
-      },
-      {
-        "id": -1,
-        "name": "state",
-        "title_en": "State",
-        "title_bm": "Negeri",
-        "desc_en": "[Categorical] Name of the state (16 in total) or Malaysia",
-        "desc_bm": "[Kategori] Name negeri (16 keseluruhan) atau Malaysia"
-      },
-      {
-        "id": -1,
-        "name": "var1",
-        "title_en": "Variable 1",
-        "title_bm": "Pembolehubah 1",
-        "desc_en": "[Integer] A precise, succinct description of this variable",
-        "desc_bm": "[Integer] A precise, succinct description of this variable"
-      },
-      {
-        "id": -1,
-        "name": "var2",
-        "title_en": "Variable 2",
-        "title_bm": "Pembolehubah 2",
-        "desc_en": "[Integer] A precise, succinct description of this variable",
-        "desc_bm": "[Integer] A precise, succinct description of this variable"
-      },
-      {
-        "id": -1,
-        "name": "var3",
-        "title_en": "Variable 3",
-        "title_bm": "Pembolehubah 3",
-        "desc_en": "[Integer] A precise, succinct description of this variable",
-        "desc_bm": "[Integer] A precise, succinct description of this variable"
-      },
-      {
-        "id": 0,
-        "name": "mwe_bar_3",
-        "title_en": "Vertical Bar (3 bars)",
-        "title_bm": "Bar Menegak (3 bar)",
-        "desc_en": "A precise, succinct description of this chart",
-        "desc_bm": "A precise, succinct description of this chart",
-        "catalog_data": {
-          "catalog_filters": {
-            "frequency": "MONTHLY",
-            "geographic": ["NATIONAL"],
-            "demographic": [],
-            "start": "2006",
-            "end": "2023",
-            "data_source": ["MAMPU"]
-          },
-          "metadata_neutral": {
-            "data_as_of": "2023-04-03 23:59",
-            "last_updated": "2023-04-04 06:00",
-            "next_update": "2023-04-05 06:00"
-          },
-          "metadata_lang": {
-            "en": {
-              "methodology": "Lorem Ipsum is simply dummy text of the printing and typesetting industry. Lorem Ipsum has been the industry's standard dummy text ever since the 1500s, when an unknown printer took a galley of type and scrambled it to make a type specimen book.",
-              "caveat": "Contrary to popular belief, Lorem Ipsum is not simply random text. It has roots in a piece of classical Latin literature from 45 BC, making it over 2000 years old. Richard McClintock, a Latin professor at Hampden-Sydney College in Virginia, looked up one of the more obscure Latin words, consectetur, from a Lorem Ipsum passage, and going through the cites of the word in classical literature, discovered the undoubtable source.",
-              "publication": "Lorem Ipsum comes from sections 1.10.32 and 1.10.33 of 'de Finibus Bonorum et Malorum' (The Extremes of Good and Evil) by Cicero, written in 45 BC. This book is a treatise on the theory of ethics, very popular during the Renaissance. The first line of Lorem Ipsum, 'Lorem ipsum dolor sit amet..'', comes from a line in section 1.10.32."
-            },
-            "bm": {
-              "methodology": "Lorem Ipsum is simply dummy text of the printing and typesetting industry. Lorem Ipsum has been the industry's standard dummy text ever since the 1500s, when an unknown printer took a galley of type and scrambled it to make a type specimen book.",
-              "caveat": "Contrary to popular belief, Lorem Ipsum is not simply random text. It has roots in a piece of classical Latin literature from 45 BC, making it over 2000 years old. Richard McClintock, a Latin professor at Hampden-Sydney College in Virginia, looked up one of the more obscure Latin words, consectetur, from a Lorem Ipsum passage, and going through the cites of the word in classical literature, discovered the undoubtable source.",
-              "publication": "Lorem Ipsum comes from sections 1.10.32 and 1.10.33 of 'de Finibus Bonorum et Malorum' (The Extremes of Good and Evil) by Cicero, written in 45 BC. This book is a treatise on the theory of ethics, very popular during the Renaissance. The first line of Lorem Ipsum, 'Lorem ipsum dolor sit amet..'', comes from a line in section 1.10.32."
-            }
-          },
-          "chart": {
-            "chart_type": "BAR",
-            "chart_filters": {
-              "SLICE_BY": [],
-              "precision": 0
-            },
-            "chart_variables": {
-              "parents": [],
-              "format": {
-                "x": "state",
-                "y": ["var1", "var2", "var3"]
-              }
-            }
-          },
-          "translations": {
-            "en": {
-              "x": "State",
-              "y1": "Variable 1",
-              "y2": "Variable 2",
-              "y3": "Variable 3"
-            },
-            "bm": {
-              "x": "Negeri",
-              "y1": "Pembolehubah 1",
-              "y2": "Pembolehubah 2",
-              "y3": "Pembolehubah 3"
-            }
-          }
-        }
-      }
-    ]
-  }
+	"file": {
+		"manual_trigger": "1",
+		"bucket": "dgmy-public-mwe",
+		"file_name": "mwe_bar_3",
+		"category": "METADATA",
+		"category_en": "Site Metadata",
+		"category_bm": "Metadata Portal",
+		"subcategory": "SAMPLE_CHART",
+		"subcategory_en": "Chart Samples",
+		"subcategory_bm": "Contoh Carta",
+		"description": {
+			"en": "Lorem ipsum.",
+			"bm": "Lorem ipsum."
+		},
+		"link_parquet": "https://dgmy-public-mwe.s3.ap-southeast-1.amazonaws.com/mwe_bar.parquet",
+		"link_csv": "https://dgmy-public-mwe.s3.ap-southeast-1.amazonaws.com/mwe_bar.csv",
+		"variables": [
+			{
+				"id": -1,
+				"name": "date",
+				"title_en": "Date",
+				"title_bm": "Tarikh",
+				"desc_en": "[Date] The date in YYYY-MM-DD format",
+				"desc_bm": "[Tarikh] Tarikh dalam format YYYY-MM-DD"
+			},
+			{
+				"id": -1,
+				"name": "state",
+				"title_en": "State",
+				"title_bm": "Negeri",
+				"desc_en": "[Categorical] Name of the state (16 in total) or Malaysia",
+				"desc_bm": "[Kategori] Name negeri (16 keseluruhan) atau Malaysia"
+			},
+			{
+				"id": -1,
+				"name": "var1",
+				"title_en": "Variable 1",
+				"title_bm": "Pembolehubah 1",
+				"desc_en": "[Integer] A precise, succinct description of this variable",
+				"desc_bm": "[Integer] A precise, succinct description of this variable"
+			},
+			{
+				"id": -1,
+				"name": "var2",
+				"title_en": "Variable 2",
+				"title_bm": "Pembolehubah 2",
+				"desc_en": "[Integer] A precise, succinct description of this variable",
+				"desc_bm": "[Integer] A precise, succinct description of this variable"
+			},
+			{
+				"id": -1,
+				"name": "var3",
+				"title_en": "Variable 3",
+				"title_bm": "Pembolehubah 3",
+				"desc_en": "[Integer] A precise, succinct description of this variable",
+				"desc_bm": "[Integer] A precise, succinct description of this variable"
+			},
+			{
+				"id": 0,
+				"name": "mwe_bar_3",
+				"title_en": "Vertical Bar (3 bars)",
+				"title_bm": "Bar Menegak (3 bar)",
+				"desc_en": "A precise, succinct description of this chart",
+				"desc_bm": "A precise, succinct description of this chart",
+				"catalog_data": {
+					"catalog_filters": {
+						"frequency": "MONTHLY",
+						"geography": ["NATIONAL"],
+						"demographic": [],
+						"start": "2006",
+						"end": "2023",
+						"data_source": ["MAMPU"]
+					},
+					"metadata_neutral": {
+						"data_as_of": "2023-04-03 23:59",
+						"last_updated": "2023-04-04 06:00",
+						"next_update": "2023-04-05 06:00"
+					},
+					"metadata_lang": {
+						"en": {
+							"methodology": "Lorem Ipsum is simply dummy text of the printing and typesetting industry. Lorem Ipsum has been the industry's standard dummy text ever since the 1500s, when an unknown printer took a galley of type and scrambled it to make a type specimen book.",
+							"caveat": "Contrary to popular belief, Lorem Ipsum is not simply random text. It has roots in a piece of classical Latin literature from 45 BC, making it over 2000 years old. Richard McClintock, a Latin professor at Hampden-Sydney College in Virginia, looked up one of the more obscure Latin words, consectetur, from a Lorem Ipsum passage, and going through the cites of the word in classical literature, discovered the undoubtable source.",
+							"publication": "Lorem Ipsum comes from sections 1.10.32 and 1.10.33 of 'de Finibus Bonorum et Malorum' (The Extremes of Good and Evil) by Cicero, written in 45 BC. This book is a treatise on the theory of ethics, very popular during the Renaissance. The first line of Lorem Ipsum, 'Lorem ipsum dolor sit amet..'', comes from a line in section 1.10.32."
+						},
+						"bm": {
+							"methodology": "Lorem Ipsum is simply dummy text of the printing and typesetting industry. Lorem Ipsum has been the industry's standard dummy text ever since the 1500s, when an unknown printer took a galley of type and scrambled it to make a type specimen book.",
+							"caveat": "Contrary to popular belief, Lorem Ipsum is not simply random text. It has roots in a piece of classical Latin literature from 45 BC, making it over 2000 years old. Richard McClintock, a Latin professor at Hampden-Sydney College in Virginia, looked up one of the more obscure Latin words, consectetur, from a Lorem Ipsum passage, and going through the cites of the word in classical literature, discovered the undoubtable source.",
+							"publication": "Lorem Ipsum comes from sections 1.10.32 and 1.10.33 of 'de Finibus Bonorum et Malorum' (The Extremes of Good and Evil) by Cicero, written in 45 BC. This book is a treatise on the theory of ethics, very popular during the Renaissance. The first line of Lorem Ipsum, 'Lorem ipsum dolor sit amet..'', comes from a line in section 1.10.32."
+						}
+					},
+					"chart": {
+						"chart_type": "BAR",
+						"chart_filters": {
+							"SLICE_BY": [],
+							"precision": 0
+						},
+						"chart_variables": {
+							"parents": [],
+							"format": {
+								"x": "state",
+								"y": ["var1", "var2", "var3"]
+							}
+						}
+					},
+					"translations": {
+						"en": {
+							"x": "State",
+							"y1": "Variable 1",
+							"y2": "Variable 2",
+							"y3": "Variable 3"
+						},
+						"bm": {
+							"x": "Negeri",
+							"y1": "Pembolehubah 1",
+							"y2": "Pembolehubah 2",
+							"y3": "Pembolehubah 3"
+						}
+					}
+				}
+			}
+		]
+	}
 }

--- a/catalog/mwe_bar_4.json
+++ b/catalog/mwe_bar_4.json
@@ -1,134 +1,134 @@
 {
-  "file": {
-    "manual_trigger": "1",
-    "bucket": "dgmy-public-mwe",
-    "file_name": "mwe_bar_4",
-    "category": "METADATA",
-    "category_en": "Site Metadata",
-    "category_bm": "Metadata Portal",
-    "subcategory": "SAMPLE_CHART",
-    "subcategory_en": "Chart Samples",
-    "subcategory_bm": "Contoh Carta",
-    "description": {
-      "en": "Lorem ipsum.",
-      "bm": "Lorem ipsum."
-    },
-    "link_parquet": "https://dgmy-public-mwe.s3.ap-southeast-1.amazonaws.com/mwe_bar.parquet",
-    "link_csv": "https://dgmy-public-mwe.s3.ap-southeast-1.amazonaws.com/mwe_bar.csv",
-    "variables": [
-      {
-        "id": -1,
-        "name": "date",
-        "title_en": "Date",
-        "title_bm": "Tarikh",
-        "desc_en": "[Date] The date in YYYY-MM-DD format",
-        "desc_bm": "[Tarikh] Tarikh dalam format YYYY-MM-DD"
-      },
-      {
-        "id": -1,
-        "name": "state",
-        "title_en": "State",
-        "title_bm": "Negeri",
-        "desc_en": "[Categorical] Name of the state (16 in total) or Malaysia",
-        "desc_bm": "[Kategori] Name negeri (16 keseluruhan) atau Malaysia"
-      },
-      {
-        "id": -1,
-        "name": "var1",
-        "title_en": "Variable 1",
-        "title_bm": "Pembolehubah 1",
-        "desc_en": "[Integer] A precise, succinct description of this variable",
-        "desc_bm": "[Integer] A precise, succinct description of this variable"
-      },
-      {
-        "id": -1,
-        "name": "var2",
-        "title_en": "Variable 2",
-        "title_bm": "Pembolehubah 2",
-        "desc_en": "[Integer] A precise, succinct description of this variable",
-        "desc_bm": "[Integer] A precise, succinct description of this variable"
-      },
-      {
-        "id": -1,
-        "name": "var3",
-        "title_en": "Variable 3",
-        "title_bm": "Pembolehubah 3",
-        "desc_en": "[Integer] A precise, succinct description of this variable",
-        "desc_bm": "[Integer] A precise, succinct description of this variable"
-      },
-      {
-        "id": -1,
-        "name": "var4",
-        "title_en": "Variable 4",
-        "title_bm": "Pembolehubah 4",
-        "desc_en": "[Integer] A precise, succinct description of this variable",
-        "desc_bm": "[Integer] A precise, succinct description of this variable"
-      },
-      {
-        "id": 0,
-        "name": "mwe_bar_4",
-        "title_en": "Vertical Bar (4 bars)",
-        "title_bm": "Bar Menegak (4 bar)",
-        "desc_en": "A precise, succinct description of this chart",
-        "desc_bm": "A precise, succinct description of this chart",
-        "catalog_data": {
-          "catalog_filters": {
-            "frequency": "MONTHLY",
-            "geographic": ["NATIONAL"],
-            "demographic": [],
-            "start": "2006",
-            "end": "2023",
-            "data_source": ["MAMPU"]
-          },
-          "metadata_neutral": {
-            "data_as_of": "2023-04-03 23:59",
-            "last_updated": "2023-04-04 06:00",
-            "next_update": "2023-04-05 06:00"
-          },
-          "metadata_lang": {
-            "en": {
-              "methodology": "Lorem Ipsum is simply dummy text of the printing and typesetting industry. Lorem Ipsum has been the industry's standard dummy text ever since the 1500s, when an unknown printer took a galley of type and scrambled it to make a type specimen book.",
-              "caveat": "Contrary to popular belief, Lorem Ipsum is not simply random text. It has roots in a piece of classical Latin literature from 45 BC, making it over 2000 years old. Richard McClintock, a Latin professor at Hampden-Sydney College in Virginia, looked up one of the more obscure Latin words, consectetur, from a Lorem Ipsum passage, and going through the cites of the word in classical literature, discovered the undoubtable source.",
-              "publication": "Lorem Ipsum comes from sections 1.10.32 and 1.10.33 of 'de Finibus Bonorum et Malorum' (The Extremes of Good and Evil) by Cicero, written in 45 BC. This book is a treatise on the theory of ethics, very popular during the Renaissance. The first line of Lorem Ipsum, 'Lorem ipsum dolor sit amet..'', comes from a line in section 1.10.32."
-            },
-            "bm": {
-              "methodology": "Lorem Ipsum is simply dummy text of the printing and typesetting industry. Lorem Ipsum has been the industry's standard dummy text ever since the 1500s, when an unknown printer took a galley of type and scrambled it to make a type specimen book.",
-              "caveat": "Contrary to popular belief, Lorem Ipsum is not simply random text. It has roots in a piece of classical Latin literature from 45 BC, making it over 2000 years old. Richard McClintock, a Latin professor at Hampden-Sydney College in Virginia, looked up one of the more obscure Latin words, consectetur, from a Lorem Ipsum passage, and going through the cites of the word in classical literature, discovered the undoubtable source.",
-              "publication": "Lorem Ipsum comes from sections 1.10.32 and 1.10.33 of 'de Finibus Bonorum et Malorum' (The Extremes of Good and Evil) by Cicero, written in 45 BC. This book is a treatise on the theory of ethics, very popular during the Renaissance. The first line of Lorem Ipsum, 'Lorem ipsum dolor sit amet..'', comes from a line in section 1.10.32."
-            }
-          },
-          "chart": {
-            "chart_type": "BAR",
-            "chart_filters": {
-              "SLICE_BY": [],
-              "precision": 0
-            },
-            "chart_variables": {
-              "parents": [],
-              "format": {
-                "x": "state",
-                "y": ["var1", "var2", "var3", "var4"]
-              }
-            }
-          },
-          "translations": {
-            "en": {
-              "x": "State",
-              "y1": "Variable 1",
-              "y2": "Variable 2",
-              "y3": "Variable 3",
-              "y4": "Variable 4"
-            },
-            "bm": {
-              "x": "Negeri",
-              "y1": "Pembolehubah 1",
-              "y2": "Pembolehubah 2",
-              "y3": "Pembolehubah 3",
-              "y4": "Pembolehubah 4"
-            }
-          }
-        }
-      }
-    ]
-  }
+	"file": {
+		"manual_trigger": "1",
+		"bucket": "dgmy-public-mwe",
+		"file_name": "mwe_bar_4",
+		"category": "METADATA",
+		"category_en": "Site Metadata",
+		"category_bm": "Metadata Portal",
+		"subcategory": "SAMPLE_CHART",
+		"subcategory_en": "Chart Samples",
+		"subcategory_bm": "Contoh Carta",
+		"description": {
+			"en": "Lorem ipsum.",
+			"bm": "Lorem ipsum."
+		},
+		"link_parquet": "https://dgmy-public-mwe.s3.ap-southeast-1.amazonaws.com/mwe_bar.parquet",
+		"link_csv": "https://dgmy-public-mwe.s3.ap-southeast-1.amazonaws.com/mwe_bar.csv",
+		"variables": [
+			{
+				"id": -1,
+				"name": "date",
+				"title_en": "Date",
+				"title_bm": "Tarikh",
+				"desc_en": "[Date] The date in YYYY-MM-DD format",
+				"desc_bm": "[Tarikh] Tarikh dalam format YYYY-MM-DD"
+			},
+			{
+				"id": -1,
+				"name": "state",
+				"title_en": "State",
+				"title_bm": "Negeri",
+				"desc_en": "[Categorical] Name of the state (16 in total) or Malaysia",
+				"desc_bm": "[Kategori] Name negeri (16 keseluruhan) atau Malaysia"
+			},
+			{
+				"id": -1,
+				"name": "var1",
+				"title_en": "Variable 1",
+				"title_bm": "Pembolehubah 1",
+				"desc_en": "[Integer] A precise, succinct description of this variable",
+				"desc_bm": "[Integer] A precise, succinct description of this variable"
+			},
+			{
+				"id": -1,
+				"name": "var2",
+				"title_en": "Variable 2",
+				"title_bm": "Pembolehubah 2",
+				"desc_en": "[Integer] A precise, succinct description of this variable",
+				"desc_bm": "[Integer] A precise, succinct description of this variable"
+			},
+			{
+				"id": -1,
+				"name": "var3",
+				"title_en": "Variable 3",
+				"title_bm": "Pembolehubah 3",
+				"desc_en": "[Integer] A precise, succinct description of this variable",
+				"desc_bm": "[Integer] A precise, succinct description of this variable"
+			},
+			{
+				"id": -1,
+				"name": "var4",
+				"title_en": "Variable 4",
+				"title_bm": "Pembolehubah 4",
+				"desc_en": "[Integer] A precise, succinct description of this variable",
+				"desc_bm": "[Integer] A precise, succinct description of this variable"
+			},
+			{
+				"id": 0,
+				"name": "mwe_bar_4",
+				"title_en": "Vertical Bar (4 bars)",
+				"title_bm": "Bar Menegak (4 bar)",
+				"desc_en": "A precise, succinct description of this chart",
+				"desc_bm": "A precise, succinct description of this chart",
+				"catalog_data": {
+					"catalog_filters": {
+						"frequency": "MONTHLY",
+						"geography": ["NATIONAL"],
+						"demographic": [],
+						"start": "2006",
+						"end": "2023",
+						"data_source": ["MAMPU"]
+					},
+					"metadata_neutral": {
+						"data_as_of": "2023-04-03 23:59",
+						"last_updated": "2023-04-04 06:00",
+						"next_update": "2023-04-05 06:00"
+					},
+					"metadata_lang": {
+						"en": {
+							"methodology": "Lorem Ipsum is simply dummy text of the printing and typesetting industry. Lorem Ipsum has been the industry's standard dummy text ever since the 1500s, when an unknown printer took a galley of type and scrambled it to make a type specimen book.",
+							"caveat": "Contrary to popular belief, Lorem Ipsum is not simply random text. It has roots in a piece of classical Latin literature from 45 BC, making it over 2000 years old. Richard McClintock, a Latin professor at Hampden-Sydney College in Virginia, looked up one of the more obscure Latin words, consectetur, from a Lorem Ipsum passage, and going through the cites of the word in classical literature, discovered the undoubtable source.",
+							"publication": "Lorem Ipsum comes from sections 1.10.32 and 1.10.33 of 'de Finibus Bonorum et Malorum' (The Extremes of Good and Evil) by Cicero, written in 45 BC. This book is a treatise on the theory of ethics, very popular during the Renaissance. The first line of Lorem Ipsum, 'Lorem ipsum dolor sit amet..'', comes from a line in section 1.10.32."
+						},
+						"bm": {
+							"methodology": "Lorem Ipsum is simply dummy text of the printing and typesetting industry. Lorem Ipsum has been the industry's standard dummy text ever since the 1500s, when an unknown printer took a galley of type and scrambled it to make a type specimen book.",
+							"caveat": "Contrary to popular belief, Lorem Ipsum is not simply random text. It has roots in a piece of classical Latin literature from 45 BC, making it over 2000 years old. Richard McClintock, a Latin professor at Hampden-Sydney College in Virginia, looked up one of the more obscure Latin words, consectetur, from a Lorem Ipsum passage, and going through the cites of the word in classical literature, discovered the undoubtable source.",
+							"publication": "Lorem Ipsum comes from sections 1.10.32 and 1.10.33 of 'de Finibus Bonorum et Malorum' (The Extremes of Good and Evil) by Cicero, written in 45 BC. This book is a treatise on the theory of ethics, very popular during the Renaissance. The first line of Lorem Ipsum, 'Lorem ipsum dolor sit amet..'', comes from a line in section 1.10.32."
+						}
+					},
+					"chart": {
+						"chart_type": "BAR",
+						"chart_filters": {
+							"SLICE_BY": [],
+							"precision": 0
+						},
+						"chart_variables": {
+							"parents": [],
+							"format": {
+								"x": "state",
+								"y": ["var1", "var2", "var3", "var4"]
+							}
+						}
+					},
+					"translations": {
+						"en": {
+							"x": "State",
+							"y1": "Variable 1",
+							"y2": "Variable 2",
+							"y3": "Variable 3",
+							"y4": "Variable 4"
+						},
+						"bm": {
+							"x": "Negeri",
+							"y1": "Pembolehubah 1",
+							"y2": "Pembolehubah 2",
+							"y3": "Pembolehubah 3",
+							"y4": "Pembolehubah 4"
+						}
+					}
+				}
+			}
+		]
+	}
 }

--- a/catalog/mwe_bar_4.json
+++ b/catalog/mwe_bar_4.json
@@ -75,7 +75,7 @@
 					"catalog_filters": {
 						"frequency": "MONTHLY",
 						"geography": ["NATIONAL"],
-						"demographic": [],
+						"demography": [],
 						"start": "2006",
 						"end": "2023",
 						"data_source": ["MAMPU"]

--- a/catalog/mwe_choropleth.json
+++ b/catalog/mwe_choropleth.json
@@ -1,90 +1,90 @@
 {
-  "file": {
-    "manual_trigger": "1",
-    "bucket": "dgmy-public-mwe",
-    "file_name": "mwe_choropleth",
-    "category": "METADATA",
-    "category_en": "Site Metadata",
-    "category_bm": "Metadata Portal",
-    "subcategory": "SAMPLE_CHART",
-    "subcategory_en": "Chart Samples",
-    "subcategory_bm": "Contoh Carta",
-    "description": {
-      "en": "Lorem ipsum.",
-      "bm": "Lorem ipsum."
-    },
-    "link_parquet": "https://dgmy-public-mwe.s3.ap-southeast-1.amazonaws.com/mwe_choropleth.parquet",
-    "link_csv": "https://dgmy-public-mwe.s3.ap-southeast-1.amazonaws.com/mwe_choropleth.csv",
-    "variables": [
-      {
-        "id": -1,
-        "name": "state",
-        "title_en": "State",
-        "title_bm": "Negeri",
-        "desc_en": "[Categorical] Name of the state (16 in total) or Malaysia",
-        "desc_bm": "[Kategori] Name negeri (16 keseluruhan) atau Malaysia"
-      },
-      {
-        "id": 0,
-        "name": "mwe_choropleth",
-        "title_en": "Choropleth",
-        "title_bm": "Choropleth",
-        "desc_en": "[Integer] A precise, succinct description of this variable",
-        "desc_bm": "[Integer] A precise, succinct description of this variable",
-        "catalog_data": {
-          "catalog_filters": {
-            "frequency": "YEARLY",
-            "geographic": ["NATIONAL"],
-            "demographic": [],
-            "start": "2006",
-            "end": "2023",
-            "data_source": ["MAMPU"]
-          },
-          "metadata_neutral": {
-            "data_as_of": "2023-04-03 23:59",
-            "last_updated": "2023-04-04 06:00",
-            "next_update": "2023-04-05 06:00"
-          },
-          "metadata_lang": {
-            "en": {
-              "methodology": "Lorem Ipsum is simply dummy text of the printing and typesetting industry. Lorem Ipsum has been the industry's standard dummy text ever since the 1500s, when an unknown printer took a galley of type and scrambled it to make a type specimen book.",
-              "caveat": "Contrary to popular belief, Lorem Ipsum is not simply random text. It has roots in a piece of classical Latin literature from 45 BC, making it over 2000 years old. Richard McClintock, a Latin professor at Hampden-Sydney College in Virginia, looked up one of the more obscure Latin words, consectetur, from a Lorem Ipsum passage, and going through the cites of the word in classical literature, discovered the undoubtable source.",
-              "publication": "Lorem Ipsum comes from sections 1.10.32 and 1.10.33 of 'de Finibus Bonorum et Malorum' (The Extremes of Good and Evil) by Cicero, written in 45 BC. This book is a treatise on the theory of ethics, very popular during the Renaissance. The first line of Lorem Ipsum, 'Lorem ipsum dolor sit amet..'', comes from a line in section 1.10.32."
-            },
-            "bm": {
-              "methodology": "Lorem Ipsum is simply dummy text of the printing and typesetting industry. Lorem Ipsum has been the industry's standard dummy text ever since the 1500s, when an unknown printer took a galley of type and scrambled it to make a type specimen book.",
-              "caveat": "Contrary to popular belief, Lorem Ipsum is not simply random text. It has roots in a piece of classical Latin literature from 45 BC, making it over 2000 years old. Richard McClintock, a Latin professor at Hampden-Sydney College in Virginia, looked up one of the more obscure Latin words, consectetur, from a Lorem Ipsum passage, and going through the cites of the word in classical literature, discovered the undoubtable source.",
-              "publication": "Lorem Ipsum comes from sections 1.10.32 and 1.10.33 of 'de Finibus Bonorum et Malorum' (The Extremes of Good and Evil) by Cicero, written in 45 BC. This book is a treatise on the theory of ethics, very popular during the Renaissance. The first line of Lorem Ipsum, 'Lorem ipsum dolor sit amet..'', comes from a line in section 1.10.32."
-            }
-          },
-          "chart": {
-            "chart_type": "CHOROPLETH",
-            "chart_filters": {
-              "SLICE_BY": [],
-              "precision": 0
-            },
-            "chart_variables": {
-              "parents": [],
-              "file_json": "parlimen",
-              "colour": "greens",
-              "format": {
-                "x": "parliament",
-                "y": "voter_turnout"
-              }
-            }
-          },
-          "translations": {
-            "en": {
-              "x": "Parliament",
-              "y": "Voter Turnout"
-            },
-            "bm": {
-              "x": "Parlimen",
-              "y": "Peratus Keluar Mengundi"
-            }
-          }
-        }
-      }
-    ]
-  }
+	"file": {
+		"manual_trigger": "1",
+		"bucket": "dgmy-public-mwe",
+		"file_name": "mwe_choropleth",
+		"category": "METADATA",
+		"category_en": "Site Metadata",
+		"category_bm": "Metadata Portal",
+		"subcategory": "SAMPLE_CHART",
+		"subcategory_en": "Chart Samples",
+		"subcategory_bm": "Contoh Carta",
+		"description": {
+			"en": "Lorem ipsum.",
+			"bm": "Lorem ipsum."
+		},
+		"link_parquet": "https://dgmy-public-mwe.s3.ap-southeast-1.amazonaws.com/mwe_choropleth.parquet",
+		"link_csv": "https://dgmy-public-mwe.s3.ap-southeast-1.amazonaws.com/mwe_choropleth.csv",
+		"variables": [
+			{
+				"id": -1,
+				"name": "state",
+				"title_en": "State",
+				"title_bm": "Negeri",
+				"desc_en": "[Categorical] Name of the state (16 in total) or Malaysia",
+				"desc_bm": "[Kategori] Name negeri (16 keseluruhan) atau Malaysia"
+			},
+			{
+				"id": 0,
+				"name": "mwe_choropleth",
+				"title_en": "Choropleth",
+				"title_bm": "Choropleth",
+				"desc_en": "[Integer] A precise, succinct description of this variable",
+				"desc_bm": "[Integer] A precise, succinct description of this variable",
+				"catalog_data": {
+					"catalog_filters": {
+						"frequency": "YEARLY",
+						"geography": ["NATIONAL"],
+						"demographic": [],
+						"start": "2006",
+						"end": "2023",
+						"data_source": ["MAMPU"]
+					},
+					"metadata_neutral": {
+						"data_as_of": "2023-04-03 23:59",
+						"last_updated": "2023-04-04 06:00",
+						"next_update": "2023-04-05 06:00"
+					},
+					"metadata_lang": {
+						"en": {
+							"methodology": "Lorem Ipsum is simply dummy text of the printing and typesetting industry. Lorem Ipsum has been the industry's standard dummy text ever since the 1500s, when an unknown printer took a galley of type and scrambled it to make a type specimen book.",
+							"caveat": "Contrary to popular belief, Lorem Ipsum is not simply random text. It has roots in a piece of classical Latin literature from 45 BC, making it over 2000 years old. Richard McClintock, a Latin professor at Hampden-Sydney College in Virginia, looked up one of the more obscure Latin words, consectetur, from a Lorem Ipsum passage, and going through the cites of the word in classical literature, discovered the undoubtable source.",
+							"publication": "Lorem Ipsum comes from sections 1.10.32 and 1.10.33 of 'de Finibus Bonorum et Malorum' (The Extremes of Good and Evil) by Cicero, written in 45 BC. This book is a treatise on the theory of ethics, very popular during the Renaissance. The first line of Lorem Ipsum, 'Lorem ipsum dolor sit amet..'', comes from a line in section 1.10.32."
+						},
+						"bm": {
+							"methodology": "Lorem Ipsum is simply dummy text of the printing and typesetting industry. Lorem Ipsum has been the industry's standard dummy text ever since the 1500s, when an unknown printer took a galley of type and scrambled it to make a type specimen book.",
+							"caveat": "Contrary to popular belief, Lorem Ipsum is not simply random text. It has roots in a piece of classical Latin literature from 45 BC, making it over 2000 years old. Richard McClintock, a Latin professor at Hampden-Sydney College in Virginia, looked up one of the more obscure Latin words, consectetur, from a Lorem Ipsum passage, and going through the cites of the word in classical literature, discovered the undoubtable source.",
+							"publication": "Lorem Ipsum comes from sections 1.10.32 and 1.10.33 of 'de Finibus Bonorum et Malorum' (The Extremes of Good and Evil) by Cicero, written in 45 BC. This book is a treatise on the theory of ethics, very popular during the Renaissance. The first line of Lorem Ipsum, 'Lorem ipsum dolor sit amet..'', comes from a line in section 1.10.32."
+						}
+					},
+					"chart": {
+						"chart_type": "CHOROPLETH",
+						"chart_filters": {
+							"SLICE_BY": [],
+							"precision": 0
+						},
+						"chart_variables": {
+							"parents": [],
+							"file_json": "parlimen",
+							"colour": "greens",
+							"format": {
+								"x": "parliament",
+								"y": "voter_turnout"
+							}
+						}
+					},
+					"translations": {
+						"en": {
+							"x": "Parliament",
+							"y": "Voter Turnout"
+						},
+						"bm": {
+							"x": "Parlimen",
+							"y": "Peratus Keluar Mengundi"
+						}
+					}
+				}
+			}
+		]
+	}
 }

--- a/catalog/mwe_choropleth.json
+++ b/catalog/mwe_choropleth.json
@@ -35,7 +35,7 @@
 					"catalog_filters": {
 						"frequency": "YEARLY",
 						"geography": ["NATIONAL"],
-						"demographic": [],
+						"demography": [],
 						"start": "2006",
 						"end": "2023",
 						"data_source": ["MAMPU"]

--- a/catalog/mwe_geochoropleth.json
+++ b/catalog/mwe_geochoropleth.json
@@ -1,90 +1,90 @@
 {
-  "file": {
-    "manual_trigger": "",
-    "bucket": "dgmy-public-mwe",
-    "file_name": "mwe_geochoropleth",
-    "category": "METADATA",
-    "category_en": "Site Metadata",
-    "category_bm": "Metadata Portal",
-    "subcategory": "SAMPLE_CHART",
-    "subcategory_en": "Chart Samples",
-    "subcategory_bm": "Contoh Carta",
-    "description": {
-      "en": "Lorem ipsum.",
-      "bm": "Lorem ipsum."
-    },
-    "link_parquet": "https://dgmy-public-mwe.s3.ap-southeast-1.amazonaws.com/mwe_choropleth.parquet",
-    "link_csv": "https://dgmy-public-mwe.s3.ap-southeast-1.amazonaws.com/mwe_choropleth.csv",
-    "variables": [
-      {
-        "id": -1,
-        "name": "state",
-        "title_en": "State",
-        "title_bm": "Negeri",
-        "desc_en": "[Categorical] Name of the state (16 in total) or Malaysia",
-        "desc_bm": "[Kategori] Name negeri (16 keseluruhan) atau Malaysia"
-      },
-      {
-        "id": 0,
-        "name": "mwe_geochoropleth",
-        "title_en": "Geochoropleth",
-        "title_bm": "Geochoropleth",
-        "desc_en": "[Integer] A precise, succinct description of this variable",
-        "desc_bm": "[Integer] A precise, succinct description of this variable",
-        "catalog_data": {
-          "catalog_filters": {
-            "frequency": "YEARLY",
-            "geographic": ["NATIONAL"],
-            "demographic": [],
-            "start": "2006",
-            "end": "2023",
-            "data_source": ["MAMPU"]
-          },
-          "metadata_neutral": {
-            "data_as_of": "2023-04-03 23:59",
-            "last_updated": "2023-04-04 06:00",
-            "next_update": "2023-04-05 06:00"
-          },
-          "metadata_lang": {
-            "en": {
-              "methodology": "Lorem Ipsum is simply dummy text of the printing and typesetting industry. Lorem Ipsum has been the industry's standard dummy text ever since the 1500s, when an unknown printer took a galley of type and scrambled it to make a type specimen book.",
-              "caveat": "Contrary to popular belief, Lorem Ipsum is not simply random text. It has roots in a piece of classical Latin literature from 45 BC, making it over 2000 years old. Richard McClintock, a Latin professor at Hampden-Sydney College in Virginia, looked up one of the more obscure Latin words, consectetur, from a Lorem Ipsum passage, and going through the cites of the word in classical literature, discovered the undoubtable source.",
-              "publication": "Lorem Ipsum comes from sections 1.10.32 and 1.10.33 of 'de Finibus Bonorum et Malorum' (The Extremes of Good and Evil) by Cicero, written in 45 BC. This book is a treatise on the theory of ethics, very popular during the Renaissance. The first line of Lorem Ipsum, 'Lorem ipsum dolor sit amet..'', comes from a line in section 1.10.32."
-            },
-            "bm": {
-              "methodology": "Lorem Ipsum is simply dummy text of the printing and typesetting industry. Lorem Ipsum has been the industry's standard dummy text ever since the 1500s, when an unknown printer took a galley of type and scrambled it to make a type specimen book.",
-              "caveat": "Contrary to popular belief, Lorem Ipsum is not simply random text. It has roots in a piece of classical Latin literature from 45 BC, making it over 2000 years old. Richard McClintock, a Latin professor at Hampden-Sydney College in Virginia, looked up one of the more obscure Latin words, consectetur, from a Lorem Ipsum passage, and going through the cites of the word in classical literature, discovered the undoubtable source.",
-              "publication": "Lorem Ipsum comes from sections 1.10.32 and 1.10.33 of 'de Finibus Bonorum et Malorum' (The Extremes of Good and Evil) by Cicero, written in 45 BC. This book is a treatise on the theory of ethics, very popular during the Renaissance. The first line of Lorem Ipsum, 'Lorem ipsum dolor sit amet..'', comes from a line in section 1.10.32."
-            }
-          },
-          "chart": {
-            "chart_type": "GEOCHOROPLETH",
-            "chart_filters": {
-              "SLICE_BY": [],
-              "precision": 0
-            },
-            "chart_variables": {
-              "parents": [],
-              "file_json": "parlimen",
-              "colour": "greens",
-              "format": {
-                "x": "parliament",
-                "y": "voter_turnout"
-              }
-            }
-          },
-          "translations": {
-            "en": {
-              "x": "Parliament",
-              "y": "Voter Turnout"
-            },
-            "bm": {
-              "x": "Parlimen",
-              "y": "Peratus Keluar Mengundi"
-            }
-          }
-        }
-      }
-    ]
-  }
+	"file": {
+		"manual_trigger": "",
+		"bucket": "dgmy-public-mwe",
+		"file_name": "mwe_geochoropleth",
+		"category": "METADATA",
+		"category_en": "Site Metadata",
+		"category_bm": "Metadata Portal",
+		"subcategory": "SAMPLE_CHART",
+		"subcategory_en": "Chart Samples",
+		"subcategory_bm": "Contoh Carta",
+		"description": {
+			"en": "Lorem ipsum.",
+			"bm": "Lorem ipsum."
+		},
+		"link_parquet": "https://dgmy-public-mwe.s3.ap-southeast-1.amazonaws.com/mwe_choropleth.parquet",
+		"link_csv": "https://dgmy-public-mwe.s3.ap-southeast-1.amazonaws.com/mwe_choropleth.csv",
+		"variables": [
+			{
+				"id": -1,
+				"name": "state",
+				"title_en": "State",
+				"title_bm": "Negeri",
+				"desc_en": "[Categorical] Name of the state (16 in total) or Malaysia",
+				"desc_bm": "[Kategori] Name negeri (16 keseluruhan) atau Malaysia"
+			},
+			{
+				"id": 0,
+				"name": "mwe_geochoropleth",
+				"title_en": "Geochoropleth",
+				"title_bm": "Geochoropleth",
+				"desc_en": "[Integer] A precise, succinct description of this variable",
+				"desc_bm": "[Integer] A precise, succinct description of this variable",
+				"catalog_data": {
+					"catalog_filters": {
+						"frequency": "YEARLY",
+						"geography": ["NATIONAL"],
+						"demographic": [],
+						"start": "2006",
+						"end": "2023",
+						"data_source": ["MAMPU"]
+					},
+					"metadata_neutral": {
+						"data_as_of": "2023-04-03 23:59",
+						"last_updated": "2023-04-04 06:00",
+						"next_update": "2023-04-05 06:00"
+					},
+					"metadata_lang": {
+						"en": {
+							"methodology": "Lorem Ipsum is simply dummy text of the printing and typesetting industry. Lorem Ipsum has been the industry's standard dummy text ever since the 1500s, when an unknown printer took a galley of type and scrambled it to make a type specimen book.",
+							"caveat": "Contrary to popular belief, Lorem Ipsum is not simply random text. It has roots in a piece of classical Latin literature from 45 BC, making it over 2000 years old. Richard McClintock, a Latin professor at Hampden-Sydney College in Virginia, looked up one of the more obscure Latin words, consectetur, from a Lorem Ipsum passage, and going through the cites of the word in classical literature, discovered the undoubtable source.",
+							"publication": "Lorem Ipsum comes from sections 1.10.32 and 1.10.33 of 'de Finibus Bonorum et Malorum' (The Extremes of Good and Evil) by Cicero, written in 45 BC. This book is a treatise on the theory of ethics, very popular during the Renaissance. The first line of Lorem Ipsum, 'Lorem ipsum dolor sit amet..'', comes from a line in section 1.10.32."
+						},
+						"bm": {
+							"methodology": "Lorem Ipsum is simply dummy text of the printing and typesetting industry. Lorem Ipsum has been the industry's standard dummy text ever since the 1500s, when an unknown printer took a galley of type and scrambled it to make a type specimen book.",
+							"caveat": "Contrary to popular belief, Lorem Ipsum is not simply random text. It has roots in a piece of classical Latin literature from 45 BC, making it over 2000 years old. Richard McClintock, a Latin professor at Hampden-Sydney College in Virginia, looked up one of the more obscure Latin words, consectetur, from a Lorem Ipsum passage, and going through the cites of the word in classical literature, discovered the undoubtable source.",
+							"publication": "Lorem Ipsum comes from sections 1.10.32 and 1.10.33 of 'de Finibus Bonorum et Malorum' (The Extremes of Good and Evil) by Cicero, written in 45 BC. This book is a treatise on the theory of ethics, very popular during the Renaissance. The first line of Lorem Ipsum, 'Lorem ipsum dolor sit amet..'', comes from a line in section 1.10.32."
+						}
+					},
+					"chart": {
+						"chart_type": "GEOCHOROPLETH",
+						"chart_filters": {
+							"SLICE_BY": [],
+							"precision": 0
+						},
+						"chart_variables": {
+							"parents": [],
+							"file_json": "parlimen",
+							"colour": "greens",
+							"format": {
+								"x": "parliament",
+								"y": "voter_turnout"
+							}
+						}
+					},
+					"translations": {
+						"en": {
+							"x": "Parliament",
+							"y": "Voter Turnout"
+						},
+						"bm": {
+							"x": "Parlimen",
+							"y": "Peratus Keluar Mengundi"
+						}
+					}
+				}
+			}
+		]
+	}
 }

--- a/catalog/mwe_geochoropleth.json
+++ b/catalog/mwe_geochoropleth.json
@@ -35,7 +35,7 @@
 					"catalog_filters": {
 						"frequency": "YEARLY",
 						"geography": ["NATIONAL"],
-						"demographic": [],
+						"demography": [],
 						"start": "2006",
 						"end": "2023",
 						"data_source": ["MAMPU"]

--- a/catalog/mwe_geodata.json
+++ b/catalog/mwe_geodata.json
@@ -26,7 +26,7 @@
 					"catalog_filters": {
 						"frequency": "AS_REQUIRED",
 						"geography": ["DISTRICT"],
-						"demographic": ["SEX", "MARITAL"],
+						"demography": ["SEX", "MARITAL"],
 						"start": "2023",
 						"end": "2023",
 						"data_source": ["MAMPU"]

--- a/catalog/mwe_geodata.json
+++ b/catalog/mwe_geodata.json
@@ -1,80 +1,80 @@
 {
-  "file": {
-    "manual_trigger": "",
-    "bucket": "dgmy-public-mwe",
-    "file_name": "mwe_geodata",
-    "category": "METADATA",
-    "category_en": "Site Metadata",
-    "category_bm": "Metadata Portal",
-    "subcategory": "SAMPLE_CHART",
-    "subcategory_en": "Chart Samples",
-    "subcategory_bm": "Contoh Carta",
-    "description": {
-      "en": "Lorem ipsum.",
-      "bm": "Lorem ipsum."
-    },
-    "link_geojson": "https://storage.googleapis.com/dosm-public-geodata/admin_2_district.geojson",
-    "variables": [
-      {
-        "id": 0,
-        "name": "mwe_geodata",
-        "title_en": "Geodata",
-        "title_bm": "Geodata",
-        "desc_en": "Lorem ipsum.",
-        "desc_bm": "Lorem ipsum.",
-        "catalog_data": {
-          "catalog_filters": {
-            "frequency": "AS_REQUIRED",
-            "geographic": ["DISTRICT"],
-            "demographic": ["SEX", "MARITAL"],
-            "start": "2023",
-            "end": "2023",
-            "data_source": ["MAMPU"]
-          },
-          "metadata_neutral": {
-            "data_as_of": "2022-01-31 23:59",
-            "last_updated": "2022-02-01 12:00",
-            "next_update": "n/a"
-          },
-          "metadata_lang": {
-            "en": {
-              "methodology": "Lorem ipsum.",
-              "caveat": "Lorem ipsum."
-            },
-            "bm": {
-              "methodology": "Lorem ipsum.",
-              "caveat": "Lorem ipsum."
-            }
-          },
-          "chart": {
-            "chart_type": "GEOJSON",
-            "chart_filters": {
-              "SLICE_BY": []
-            },
-            "chart_variables": {
-              "parents": [],
-              "color": "reds",
-              "file_json": "district"
-            }
-          }
-        }
-      },
-      {
-        "id": -1,
-        "name": "state",
-        "title_en": "State",
-        "title_bm": "Negeri",
-        "desc_en": "[Categorical] Name of the state, with 16 states in total.",
-        "desc_bm": "[Kategori] Nama negeri, dengan 16 negeri secara keseluruhan."
-      },
-      {
-        "id": -1,
-        "name": "district",
-        "title_en": "District",
-        "title_bm": "Daerah",
-        "desc_en": "[Categorical] Name of the district, with 160 districts in total.",
-        "desc_bm": "[Kategori] Nama daerah, dengan 160 daerah secara keseluruhan."
-      }
-    ]
-  }
+	"file": {
+		"manual_trigger": "",
+		"bucket": "dgmy-public-mwe",
+		"file_name": "mwe_geodata",
+		"category": "METADATA",
+		"category_en": "Site Metadata",
+		"category_bm": "Metadata Portal",
+		"subcategory": "SAMPLE_CHART",
+		"subcategory_en": "Chart Samples",
+		"subcategory_bm": "Contoh Carta",
+		"description": {
+			"en": "Lorem ipsum.",
+			"bm": "Lorem ipsum."
+		},
+		"link_geojson": "https://storage.googleapis.com/dosm-public-geodata/admin_2_district.geojson",
+		"variables": [
+			{
+				"id": 0,
+				"name": "mwe_geodata",
+				"title_en": "Geodata",
+				"title_bm": "Geodata",
+				"desc_en": "Lorem ipsum.",
+				"desc_bm": "Lorem ipsum.",
+				"catalog_data": {
+					"catalog_filters": {
+						"frequency": "AS_REQUIRED",
+						"geography": ["DISTRICT"],
+						"demographic": ["SEX", "MARITAL"],
+						"start": "2023",
+						"end": "2023",
+						"data_source": ["MAMPU"]
+					},
+					"metadata_neutral": {
+						"data_as_of": "2022-01-31 23:59",
+						"last_updated": "2022-02-01 12:00",
+						"next_update": "n/a"
+					},
+					"metadata_lang": {
+						"en": {
+							"methodology": "Lorem ipsum.",
+							"caveat": "Lorem ipsum."
+						},
+						"bm": {
+							"methodology": "Lorem ipsum.",
+							"caveat": "Lorem ipsum."
+						}
+					},
+					"chart": {
+						"chart_type": "GEOJSON",
+						"chart_filters": {
+							"SLICE_BY": []
+						},
+						"chart_variables": {
+							"parents": [],
+							"color": "reds",
+							"file_json": "district"
+						}
+					}
+				}
+			},
+			{
+				"id": -1,
+				"name": "state",
+				"title_en": "State",
+				"title_bm": "Negeri",
+				"desc_en": "[Categorical] Name of the state, with 16 states in total.",
+				"desc_bm": "[Kategori] Nama negeri, dengan 16 negeri secara keseluruhan."
+			},
+			{
+				"id": -1,
+				"name": "district",
+				"title_en": "District",
+				"title_bm": "Daerah",
+				"desc_en": "[Categorical] Name of the district, with 160 districts in total.",
+				"desc_bm": "[Kategori] Nama daerah, dengan 160 daerah secara keseluruhan."
+			}
+		]
+	}
 }

--- a/catalog/mwe_geopoint.json
+++ b/catalog/mwe_geopoint.json
@@ -43,7 +43,7 @@
 					"catalog_filters": {
 						"frequency": "YEARLY",
 						"geography": ["STATE", "NATIONAL"],
-						"demographic": [],
+						"demography": [],
 						"start": "2006",
 						"end": "2023",
 						"data_source": ["MAMPU"]

--- a/catalog/mwe_geopoint.json
+++ b/catalog/mwe_geopoint.json
@@ -1,83 +1,88 @@
 {
-  "file": {
-    "manual_trigger": "",
-    "bucket": "dgmy-public-mwe",
-    "file_name": "mwe_geopoint",
-    "category": "METADATA",
-    "category_en": "Site Metadata",
-    "category_bm": "Metadata Portal",
-    "subcategory": "SAMPLE_CHART",
-    "subcategory_en": "Chart Samples",
-    "subcategory_bm": "Contoh Carta",
-    "description": {
-      "en": "Lorem ipsum.",
-      "bm": "Lorem ipsum."
-    },
-    "link_parquet": "https://dgmy-public-mwe.s3.ap-southeast-1.amazonaws.com/mwe_geopoint.parquet",
-    "link_csv": "https://dgmy-public-mwe.s3.ap-southeast-1.amazonaws.com/mwe_geopoint.csv",
-    "variables": [
-      {
-        "id": -1,
-        "name": "date",
-        "title_en": "Date",
-        "title_bm": "Tarikh",
-        "desc_en": "[Date] The date in YYYY-MM-DD format",
-        "desc_bm": "[Tarikh] Tarikh dalam format YYYY-MM-DD"
-      },
-      {
-        "id": -1,
-        "name": "state",
-        "title_en": "State",
-        "title_bm": "Negeri",
-        "desc_en": "[Categorical] Name of the state (16 in total) or Malaysia",
-        "desc_bm": "[Kategori] Name negeri (16 keseluruhan) atau Malaysia"
-      },
-      {
-        "id": 0,
-        "name": "mwe_geopoint",
-        "title_en": "Geopoint",
-        "title_bm": "Geopoint sample",
-        "desc_en": "A precise, succinct description of this chart",
-        "desc_bm": "A precise, succinct description of this chart",
-        "catalog_data": {
-          "catalog_filters": {
-            "frequency": "YEARLY",
-            "geographic": ["STATE", "NATIONAL"],
-            "demographic": [],
-            "start": "2006",
-            "end": "2023",
-            "data_source": ["MAMPU"]
-          },
-          "metadata_neutral": {
-            "data_as_of": "2023-04-03 23:59",
-            "last_updated": "2023-04-04 06:00",
-            "next_update": "2023-04-05 06:00"
-          },
-          "metadata_lang": {
-            "en": {
-              "methodology": "Lorem Ipsum is simply dummy text of the printing and typesetting industry. Lorem Ipsum has been the industry's standard dummy text ever since the 1500s, when an unknown printer took a galley of type and scrambled it to make a type specimen book.",
-              "caveat": "Contrary to popular belief, Lorem Ipsum is not simply random text. It has roots in a piece of classical Latin literature from 45 BC, making it over 2000 years old. Richard McClintock, a Latin professor at Hampden-Sydney College in Virginia, looked up one of the more obscure Latin words, consectetur, from a Lorem Ipsum passage, and going through the cites of the word in classical literature, discovered the undoubtable source.",
-              "publication": "Lorem Ipsum comes from sections 1.10.32 and 1.10.33 of 'de Finibus Bonorum et Malorum' (The Extremes of Good and Evil) by Cicero, written in 45 BC. This book is a treatise on the theory of ethics, very popular during the Renaissance. The first line of Lorem Ipsum, 'Lorem ipsum dolor sit amet..'', comes from a line in section 1.10.32."
-            },
-            "bm": {
-              "methodology": "Lorem Ipsum is simply dummy text of the printing and typesetting industry. Lorem Ipsum has been the industry's standard dummy text ever since the 1500s, when an unknown printer took a galley of type and scrambled it to make a type specimen book.",
-              "caveat": "Contrary to popular belief, Lorem Ipsum is not simply random text. It has roots in a piece of classical Latin literature from 45 BC, making it over 2000 years old. Richard McClintock, a Latin professor at Hampden-Sydney College in Virginia, looked up one of the more obscure Latin words, consectetur, from a Lorem Ipsum passage, and going through the cites of the word in classical literature, discovered the undoubtable source.",
-              "publication": "Lorem Ipsum comes from sections 1.10.32 and 1.10.33 of 'de Finibus Bonorum et Malorum' (The Extremes of Good and Evil) by Cicero, written in 45 BC. This book is a treatise on the theory of ethics, very popular during the Renaissance. The first line of Lorem Ipsum, 'Lorem ipsum dolor sit amet..'', comes from a line in section 1.10.32."
-            }
-          },
-          "chart": {
-            "chart_type": "GEOPOINT",
-            "chart_filters": {
-              "SLICE_BY": [],
-              "precision": 0
-            },
-            "chart_variables": {
-              "parents": [],
-              "include": ["school", "state", "district", "postcode"]
-            }
-          }
-        }
-      }
-    ]
-  }
+	"file": {
+		"manual_trigger": "",
+		"bucket": "dgmy-public-mwe",
+		"file_name": "mwe_geopoint",
+		"category": "METADATA",
+		"category_en": "Site Metadata",
+		"category_bm": "Metadata Portal",
+		"subcategory": "SAMPLE_CHART",
+		"subcategory_en": "Chart Samples",
+		"subcategory_bm": "Contoh Carta",
+		"description": {
+			"en": "Lorem ipsum.",
+			"bm": "Lorem ipsum."
+		},
+		"link_parquet": "https://dgmy-public-mwe.s3.ap-southeast-1.amazonaws.com/mwe_geopoint.parquet",
+		"link_csv": "https://dgmy-public-mwe.s3.ap-southeast-1.amazonaws.com/mwe_geopoint.csv",
+		"variables": [
+			{
+				"id": -1,
+				"name": "date",
+				"title_en": "Date",
+				"title_bm": "Tarikh",
+				"desc_en": "[Date] The date in YYYY-MM-DD format",
+				"desc_bm": "[Tarikh] Tarikh dalam format YYYY-MM-DD"
+			},
+			{
+				"id": -1,
+				"name": "state",
+				"title_en": "State",
+				"title_bm": "Negeri",
+				"desc_en": "[Categorical] Name of the state (16 in total) or Malaysia",
+				"desc_bm": "[Kategori] Name negeri (16 keseluruhan) atau Malaysia"
+			},
+			{
+				"id": 0,
+				"name": "mwe_geopoint",
+				"title_en": "Geopoint",
+				"title_bm": "Geopoint sample",
+				"desc_en": "A precise, succinct description of this chart",
+				"desc_bm": "A precise, succinct description of this chart",
+				"catalog_data": {
+					"catalog_filters": {
+						"frequency": "YEARLY",
+						"geography": ["STATE", "NATIONAL"],
+						"demographic": [],
+						"start": "2006",
+						"end": "2023",
+						"data_source": ["MAMPU"]
+					},
+					"metadata_neutral": {
+						"data_as_of": "2023-04-03 23:59",
+						"last_updated": "2023-04-04 06:00",
+						"next_update": "2023-04-05 06:00"
+					},
+					"metadata_lang": {
+						"en": {
+							"methodology": "Lorem Ipsum is simply dummy text of the printing and typesetting industry. Lorem Ipsum has been the industry's standard dummy text ever since the 1500s, when an unknown printer took a galley of type and scrambled it to make a type specimen book.",
+							"caveat": "Contrary to popular belief, Lorem Ipsum is not simply random text. It has roots in a piece of classical Latin literature from 45 BC, making it over 2000 years old. Richard McClintock, a Latin professor at Hampden-Sydney College in Virginia, looked up one of the more obscure Latin words, consectetur, from a Lorem Ipsum passage, and going through the cites of the word in classical literature, discovered the undoubtable source.",
+							"publication": "Lorem Ipsum comes from sections 1.10.32 and 1.10.33 of 'de Finibus Bonorum et Malorum' (The Extremes of Good and Evil) by Cicero, written in 45 BC. This book is a treatise on the theory of ethics, very popular during the Renaissance. The first line of Lorem Ipsum, 'Lorem ipsum dolor sit amet..'', comes from a line in section 1.10.32."
+						},
+						"bm": {
+							"methodology": "Lorem Ipsum is simply dummy text of the printing and typesetting industry. Lorem Ipsum has been the industry's standard dummy text ever since the 1500s, when an unknown printer took a galley of type and scrambled it to make a type specimen book.",
+							"caveat": "Contrary to popular belief, Lorem Ipsum is not simply random text. It has roots in a piece of classical Latin literature from 45 BC, making it over 2000 years old. Richard McClintock, a Latin professor at Hampden-Sydney College in Virginia, looked up one of the more obscure Latin words, consectetur, from a Lorem Ipsum passage, and going through the cites of the word in classical literature, discovered the undoubtable source.",
+							"publication": "Lorem Ipsum comes from sections 1.10.32 and 1.10.33 of 'de Finibus Bonorum et Malorum' (The Extremes of Good and Evil) by Cicero, written in 45 BC. This book is a treatise on the theory of ethics, very popular during the Renaissance. The first line of Lorem Ipsum, 'Lorem ipsum dolor sit amet..'', comes from a line in section 1.10.32."
+						}
+					},
+					"chart": {
+						"chart_type": "GEOPOINT",
+						"chart_filters": {
+							"SLICE_BY": [],
+							"precision": 0
+						},
+						"chart_variables": {
+							"parents": [],
+							"include": [
+								"school",
+								"state",
+								"district",
+								"postcode"
+							]
+						}
+					}
+				}
+			}
+		]
+	}
 }

--- a/catalog/mwe_hbar_1.json
+++ b/catalog/mwe_hbar_1.json
@@ -43,7 +43,7 @@
 					"catalog_filters": {
 						"frequency": "MONTHLY",
 						"geography": ["NATIONAL"],
-						"demographic": [],
+						"demography": [],
 						"start": "2006",
 						"end": "2023",
 						"data_source": ["MAMPU"]

--- a/catalog/mwe_hbar_1.json
+++ b/catalog/mwe_hbar_1.json
@@ -1,96 +1,96 @@
 {
-  "file": {
-    "manual_trigger": "",
-    "bucket": "dgmy-public-mwe",
-    "file_name": "mwe_hbar_1",
-    "category": "METADATA",
-    "category_en": "Site Metadata",
-    "category_bm": "Metadata Portal",
-    "subcategory": "SAMPLE_CHART",
-    "subcategory_en": "Chart Samples",
-    "subcategory_bm": "Contoh Carta",
-    "description": {
-      "en": "Lorem ipsum.",
-      "bm": "Lorem ipsum."
-    },
-    "link_parquet": "https://dgmy-public-mwe.s3.ap-southeast-1.amazonaws.com/mwe_bar.parquet",
-    "link_csv": "https://dgmy-public-mwe.s3.ap-southeast-1.amazonaws.com/mwe_bar.csv",
-    "variables": [
-      {
-        "id": -1,
-        "name": "date",
-        "title_en": "Date",
-        "title_bm": "Tarikh",
-        "desc_en": "[Date] The date in YYYY-MM-DD format",
-        "desc_bm": "[Tarikh] Tarikh dalam format YYYY-MM-DD"
-      },
-      {
-        "id": -1,
-        "name": "state",
-        "title_en": "State",
-        "title_bm": "Negeri",
-        "desc_en": "[Categorical] Name of the state (16 in total) or Malaysia",
-        "desc_bm": "[Kategori] Name negeri (16 keseluruhan) atau Malaysia"
-      },
-      {
-        "id": 0,
-        "name": "mwe_hbar_1",
-        "title_en": "Horizontal Bar (1 bar)",
-        "title_bm": "Bar Melintang (1 bar)",
-        "desc_en": "[Integer] A precise, succinct description of this variable",
-        "desc_bm": "[Integer] A precise, succinct description of this variable",
-        "catalog_data": {
-          "catalog_filters": {
-            "frequency": "MONTHLY",
-            "geographic": ["NATIONAL"],
-            "demographic": [],
-            "start": "2006",
-            "end": "2023",
-            "data_source": ["MAMPU"]
-          },
-          "metadata_neutral": {
-            "data_as_of": "2023-04-03 23:59",
-            "last_updated": "2023-04-04 06:00",
-            "next_update": "2023-04-05 06:00"
-          },
-          "metadata_lang": {
-            "en": {
-              "methodology": "Lorem Ipsum is simply dummy text of the printing and typesetting industry. Lorem Ipsum has been the industry's standard dummy text ever since the 1500s, when an unknown printer took a galley of type and scrambled it to make a type specimen book.",
-              "caveat": "Contrary to popular belief, Lorem Ipsum is not simply random text. It has roots in a piece of classical Latin literature from 45 BC, making it over 2000 years old. Richard McClintock, a Latin professor at Hampden-Sydney College in Virginia, looked up one of the more obscure Latin words, consectetur, from a Lorem Ipsum passage, and going through the cites of the word in classical literature, discovered the undoubtable source.",
-              "publication": "Lorem Ipsum comes from sections 1.10.32 and 1.10.33 of 'de Finibus Bonorum et Malorum' (The Extremes of Good and Evil) by Cicero, written in 45 BC. This book is a treatise on the theory of ethics, very popular during the Renaissance. The first line of Lorem Ipsum, 'Lorem ipsum dolor sit amet..'', comes from a line in section 1.10.32."
-            },
-            "bm": {
-              "methodology": "Lorem Ipsum is simply dummy text of the printing and typesetting industry. Lorem Ipsum has been the industry's standard dummy text ever since the 1500s, when an unknown printer took a galley of type and scrambled it to make a type specimen book.",
-              "caveat": "Contrary to popular belief, Lorem Ipsum is not simply random text. It has roots in a piece of classical Latin literature from 45 BC, making it over 2000 years old. Richard McClintock, a Latin professor at Hampden-Sydney College in Virginia, looked up one of the more obscure Latin words, consectetur, from a Lorem Ipsum passage, and going through the cites of the word in classical literature, discovered the undoubtable source.",
-              "publication": "Lorem Ipsum comes from sections 1.10.32 and 1.10.33 of 'de Finibus Bonorum et Malorum' (The Extremes of Good and Evil) by Cicero, written in 45 BC. This book is a treatise on the theory of ethics, very popular during the Renaissance. The first line of Lorem Ipsum, 'Lorem ipsum dolor sit amet..'', comes from a line in section 1.10.32."
-            }
-          },
-          "chart": {
-            "chart_type": "HBAR",
-            "chart_filters": {
-              "SLICE_BY": [],
-              "precision": 0
-            },
-            "chart_variables": {
-              "parents": [],
-              "format": {
-                "x": "state",
-                "y": ["var1"]
-              }
-            }
-          },
-          "translations": {
-            "en": {
-              "x": "State",
-              "y1": "Variable 1"
-            },
-            "bm": {
-              "x": "Negeri",
-              "y1": "Pembolehubah 1"
-            }
-          }
-        }
-      }
-    ]
-  }
+	"file": {
+		"manual_trigger": "",
+		"bucket": "dgmy-public-mwe",
+		"file_name": "mwe_hbar_1",
+		"category": "METADATA",
+		"category_en": "Site Metadata",
+		"category_bm": "Metadata Portal",
+		"subcategory": "SAMPLE_CHART",
+		"subcategory_en": "Chart Samples",
+		"subcategory_bm": "Contoh Carta",
+		"description": {
+			"en": "Lorem ipsum.",
+			"bm": "Lorem ipsum."
+		},
+		"link_parquet": "https://dgmy-public-mwe.s3.ap-southeast-1.amazonaws.com/mwe_bar.parquet",
+		"link_csv": "https://dgmy-public-mwe.s3.ap-southeast-1.amazonaws.com/mwe_bar.csv",
+		"variables": [
+			{
+				"id": -1,
+				"name": "date",
+				"title_en": "Date",
+				"title_bm": "Tarikh",
+				"desc_en": "[Date] The date in YYYY-MM-DD format",
+				"desc_bm": "[Tarikh] Tarikh dalam format YYYY-MM-DD"
+			},
+			{
+				"id": -1,
+				"name": "state",
+				"title_en": "State",
+				"title_bm": "Negeri",
+				"desc_en": "[Categorical] Name of the state (16 in total) or Malaysia",
+				"desc_bm": "[Kategori] Name negeri (16 keseluruhan) atau Malaysia"
+			},
+			{
+				"id": 0,
+				"name": "mwe_hbar_1",
+				"title_en": "Horizontal Bar (1 bar)",
+				"title_bm": "Bar Melintang (1 bar)",
+				"desc_en": "[Integer] A precise, succinct description of this variable",
+				"desc_bm": "[Integer] A precise, succinct description of this variable",
+				"catalog_data": {
+					"catalog_filters": {
+						"frequency": "MONTHLY",
+						"geography": ["NATIONAL"],
+						"demographic": [],
+						"start": "2006",
+						"end": "2023",
+						"data_source": ["MAMPU"]
+					},
+					"metadata_neutral": {
+						"data_as_of": "2023-04-03 23:59",
+						"last_updated": "2023-04-04 06:00",
+						"next_update": "2023-04-05 06:00"
+					},
+					"metadata_lang": {
+						"en": {
+							"methodology": "Lorem Ipsum is simply dummy text of the printing and typesetting industry. Lorem Ipsum has been the industry's standard dummy text ever since the 1500s, when an unknown printer took a galley of type and scrambled it to make a type specimen book.",
+							"caveat": "Contrary to popular belief, Lorem Ipsum is not simply random text. It has roots in a piece of classical Latin literature from 45 BC, making it over 2000 years old. Richard McClintock, a Latin professor at Hampden-Sydney College in Virginia, looked up one of the more obscure Latin words, consectetur, from a Lorem Ipsum passage, and going through the cites of the word in classical literature, discovered the undoubtable source.",
+							"publication": "Lorem Ipsum comes from sections 1.10.32 and 1.10.33 of 'de Finibus Bonorum et Malorum' (The Extremes of Good and Evil) by Cicero, written in 45 BC. This book is a treatise on the theory of ethics, very popular during the Renaissance. The first line of Lorem Ipsum, 'Lorem ipsum dolor sit amet..'', comes from a line in section 1.10.32."
+						},
+						"bm": {
+							"methodology": "Lorem Ipsum is simply dummy text of the printing and typesetting industry. Lorem Ipsum has been the industry's standard dummy text ever since the 1500s, when an unknown printer took a galley of type and scrambled it to make a type specimen book.",
+							"caveat": "Contrary to popular belief, Lorem Ipsum is not simply random text. It has roots in a piece of classical Latin literature from 45 BC, making it over 2000 years old. Richard McClintock, a Latin professor at Hampden-Sydney College in Virginia, looked up one of the more obscure Latin words, consectetur, from a Lorem Ipsum passage, and going through the cites of the word in classical literature, discovered the undoubtable source.",
+							"publication": "Lorem Ipsum comes from sections 1.10.32 and 1.10.33 of 'de Finibus Bonorum et Malorum' (The Extremes of Good and Evil) by Cicero, written in 45 BC. This book is a treatise on the theory of ethics, very popular during the Renaissance. The first line of Lorem Ipsum, 'Lorem ipsum dolor sit amet..'', comes from a line in section 1.10.32."
+						}
+					},
+					"chart": {
+						"chart_type": "HBAR",
+						"chart_filters": {
+							"SLICE_BY": [],
+							"precision": 0
+						},
+						"chart_variables": {
+							"parents": [],
+							"format": {
+								"x": "state",
+								"y": ["var1"]
+							}
+						}
+					},
+					"translations": {
+						"en": {
+							"x": "State",
+							"y1": "Variable 1"
+						},
+						"bm": {
+							"x": "Negeri",
+							"y1": "Pembolehubah 1"
+						}
+					}
+				}
+			}
+		]
+	}
 }

--- a/catalog/mwe_hbar_2.json
+++ b/catalog/mwe_hbar_2.json
@@ -43,7 +43,7 @@
 					"catalog_filters": {
 						"frequency": "MONTHLY",
 						"geography": ["NATIONAL"],
-						"demographic": [],
+						"demography": [],
 						"start": "2006",
 						"end": "2023",
 						"data_source": ["MAMPU"]

--- a/catalog/mwe_hbar_2.json
+++ b/catalog/mwe_hbar_2.json
@@ -1,98 +1,98 @@
 {
-  "file": {
-    "manual_trigger": "",
-    "bucket": "dgmy-public-mwe",
-    "file_name": "mwe_hbar_2",
-    "category": "METADATA",
-    "category_en": "Site Metadata",
-    "category_bm": "Metadata Portal",
-    "subcategory": "SAMPLE_CHART",
-    "subcategory_en": "Chart Samples",
-    "subcategory_bm": "Contoh Carta",
-    "description": {
-      "en": "Lorem ipsum.",
-      "bm": "Lorem ipsum."
-    },
-    "link_parquet": "https://dgmy-public-mwe.s3.ap-southeast-1.amazonaws.com/mwe_bar.parquet",
-    "link_csv": "https://dgmy-public-mwe.s3.ap-southeast-1.amazonaws.com/mwe_bar.csv",
-    "variables": [
-      {
-        "id": -1,
-        "name": "date",
-        "title_en": "Date",
-        "title_bm": "Tarikh",
-        "desc_en": "[Date] The date in YYYY-MM-DD format",
-        "desc_bm": "[Tarikh] Tarikh dalam format YYYY-MM-DD"
-      },
-      {
-        "id": -1,
-        "name": "state",
-        "title_en": "State",
-        "title_bm": "Negeri",
-        "desc_en": "[Categorical] Name of the state (16 in total) or Malaysia",
-        "desc_bm": "[Kategori] Name negeri (16 keseluruhan) atau Malaysia"
-      },
-      {
-        "id": 0,
-        "name": "mwe_hbar_2",
-        "title_en": "Horizontal Bar (2 bars)",
-        "title_bm": "Bar Melintang (2 bar)",
-        "desc_en": "[Integer] A precise, succinct description of this variable",
-        "desc_bm": "[Integer] A precise, succinct description of this variable",
-        "catalog_data": {
-          "catalog_filters": {
-            "frequency": "MONTHLY",
-            "geographic": ["NATIONAL"],
-            "demographic": [],
-            "start": "2006",
-            "end": "2023",
-            "data_source": ["MAMPU"]
-          },
-          "metadata_neutral": {
-            "data_as_of": "2023-04-03 23:59",
-            "last_updated": "2023-04-04 06:00",
-            "next_update": "2023-04-05 06:00"
-          },
-          "metadata_lang": {
-            "en": {
-              "methodology": "Lorem Ipsum is simply dummy text of the printing and typesetting industry. Lorem Ipsum has been the industry's standard dummy text ever since the 1500s, when an unknown printer took a galley of type and scrambled it to make a type specimen book.",
-              "caveat": "Contrary to popular belief, Lorem Ipsum is not simply random text. It has roots in a piece of classical Latin literature from 45 BC, making it over 2000 years old. Richard McClintock, a Latin professor at Hampden-Sydney College in Virginia, looked up one of the more obscure Latin words, consectetur, from a Lorem Ipsum passage, and going through the cites of the word in classical literature, discovered the undoubtable source.",
-              "publication": "Lorem Ipsum comes from sections 1.10.32 and 1.10.33 of 'de Finibus Bonorum et Malorum' (The Extremes of Good and Evil) by Cicero, written in 45 BC. This book is a treatise on the theory of ethics, very popular during the Renaissance. The first line of Lorem Ipsum, 'Lorem ipsum dolor sit amet..'', comes from a line in section 1.10.32."
-            },
-            "bm": {
-              "methodology": "Lorem Ipsum is simply dummy text of the printing and typesetting industry. Lorem Ipsum has been the industry's standard dummy text ever since the 1500s, when an unknown printer took a galley of type and scrambled it to make a type specimen book.",
-              "caveat": "Contrary to popular belief, Lorem Ipsum is not simply random text. It has roots in a piece of classical Latin literature from 45 BC, making it over 2000 years old. Richard McClintock, a Latin professor at Hampden-Sydney College in Virginia, looked up one of the more obscure Latin words, consectetur, from a Lorem Ipsum passage, and going through the cites of the word in classical literature, discovered the undoubtable source.",
-              "publication": "Lorem Ipsum comes from sections 1.10.32 and 1.10.33 of 'de Finibus Bonorum et Malorum' (The Extremes of Good and Evil) by Cicero, written in 45 BC. This book is a treatise on the theory of ethics, very popular during the Renaissance. The first line of Lorem Ipsum, 'Lorem ipsum dolor sit amet..'', comes from a line in section 1.10.32."
-            }
-          },
-          "chart": {
-            "chart_type": "HBAR",
-            "chart_filters": {
-              "SLICE_BY": [],
-              "precision": 0
-            },
-            "chart_variables": {
-              "parents": [],
-              "format": {
-                "x": "state",
-                "y": ["var1", "var2"]
-              }
-            }
-          },
-          "translations": {
-            "en": {
-              "x": "State",
-              "y1": "Variable 1",
-              "y2": "Variable 2"
-            },
-            "bm": {
-              "x": "Negeri",
-              "y1": "Pembolehubah 1",
-              "y2": "Pembolehubah 2"
-            }
-          }
-        }
-      }
-    ]
-  }
+	"file": {
+		"manual_trigger": "",
+		"bucket": "dgmy-public-mwe",
+		"file_name": "mwe_hbar_2",
+		"category": "METADATA",
+		"category_en": "Site Metadata",
+		"category_bm": "Metadata Portal",
+		"subcategory": "SAMPLE_CHART",
+		"subcategory_en": "Chart Samples",
+		"subcategory_bm": "Contoh Carta",
+		"description": {
+			"en": "Lorem ipsum.",
+			"bm": "Lorem ipsum."
+		},
+		"link_parquet": "https://dgmy-public-mwe.s3.ap-southeast-1.amazonaws.com/mwe_bar.parquet",
+		"link_csv": "https://dgmy-public-mwe.s3.ap-southeast-1.amazonaws.com/mwe_bar.csv",
+		"variables": [
+			{
+				"id": -1,
+				"name": "date",
+				"title_en": "Date",
+				"title_bm": "Tarikh",
+				"desc_en": "[Date] The date in YYYY-MM-DD format",
+				"desc_bm": "[Tarikh] Tarikh dalam format YYYY-MM-DD"
+			},
+			{
+				"id": -1,
+				"name": "state",
+				"title_en": "State",
+				"title_bm": "Negeri",
+				"desc_en": "[Categorical] Name of the state (16 in total) or Malaysia",
+				"desc_bm": "[Kategori] Name negeri (16 keseluruhan) atau Malaysia"
+			},
+			{
+				"id": 0,
+				"name": "mwe_hbar_2",
+				"title_en": "Horizontal Bar (2 bars)",
+				"title_bm": "Bar Melintang (2 bar)",
+				"desc_en": "[Integer] A precise, succinct description of this variable",
+				"desc_bm": "[Integer] A precise, succinct description of this variable",
+				"catalog_data": {
+					"catalog_filters": {
+						"frequency": "MONTHLY",
+						"geography": ["NATIONAL"],
+						"demographic": [],
+						"start": "2006",
+						"end": "2023",
+						"data_source": ["MAMPU"]
+					},
+					"metadata_neutral": {
+						"data_as_of": "2023-04-03 23:59",
+						"last_updated": "2023-04-04 06:00",
+						"next_update": "2023-04-05 06:00"
+					},
+					"metadata_lang": {
+						"en": {
+							"methodology": "Lorem Ipsum is simply dummy text of the printing and typesetting industry. Lorem Ipsum has been the industry's standard dummy text ever since the 1500s, when an unknown printer took a galley of type and scrambled it to make a type specimen book.",
+							"caveat": "Contrary to popular belief, Lorem Ipsum is not simply random text. It has roots in a piece of classical Latin literature from 45 BC, making it over 2000 years old. Richard McClintock, a Latin professor at Hampden-Sydney College in Virginia, looked up one of the more obscure Latin words, consectetur, from a Lorem Ipsum passage, and going through the cites of the word in classical literature, discovered the undoubtable source.",
+							"publication": "Lorem Ipsum comes from sections 1.10.32 and 1.10.33 of 'de Finibus Bonorum et Malorum' (The Extremes of Good and Evil) by Cicero, written in 45 BC. This book is a treatise on the theory of ethics, very popular during the Renaissance. The first line of Lorem Ipsum, 'Lorem ipsum dolor sit amet..'', comes from a line in section 1.10.32."
+						},
+						"bm": {
+							"methodology": "Lorem Ipsum is simply dummy text of the printing and typesetting industry. Lorem Ipsum has been the industry's standard dummy text ever since the 1500s, when an unknown printer took a galley of type and scrambled it to make a type specimen book.",
+							"caveat": "Contrary to popular belief, Lorem Ipsum is not simply random text. It has roots in a piece of classical Latin literature from 45 BC, making it over 2000 years old. Richard McClintock, a Latin professor at Hampden-Sydney College in Virginia, looked up one of the more obscure Latin words, consectetur, from a Lorem Ipsum passage, and going through the cites of the word in classical literature, discovered the undoubtable source.",
+							"publication": "Lorem Ipsum comes from sections 1.10.32 and 1.10.33 of 'de Finibus Bonorum et Malorum' (The Extremes of Good and Evil) by Cicero, written in 45 BC. This book is a treatise on the theory of ethics, very popular during the Renaissance. The first line of Lorem Ipsum, 'Lorem ipsum dolor sit amet..'', comes from a line in section 1.10.32."
+						}
+					},
+					"chart": {
+						"chart_type": "HBAR",
+						"chart_filters": {
+							"SLICE_BY": [],
+							"precision": 0
+						},
+						"chart_variables": {
+							"parents": [],
+							"format": {
+								"x": "state",
+								"y": ["var1", "var2"]
+							}
+						}
+					},
+					"translations": {
+						"en": {
+							"x": "State",
+							"y1": "Variable 1",
+							"y2": "Variable 2"
+						},
+						"bm": {
+							"x": "Negeri",
+							"y1": "Pembolehubah 1",
+							"y2": "Pembolehubah 2"
+						}
+					}
+				}
+			}
+		]
+	}
 }

--- a/catalog/mwe_hbar_3.json
+++ b/catalog/mwe_hbar_3.json
@@ -43,7 +43,7 @@
 					"catalog_filters": {
 						"frequency": "MONTHLY",
 						"geography": ["NATIONAL"],
-						"demographic": [],
+						"demography": [],
 						"start": "2006",
 						"end": "2023",
 						"data_source": ["MAMPU"]

--- a/catalog/mwe_hbar_3.json
+++ b/catalog/mwe_hbar_3.json
@@ -1,100 +1,100 @@
 {
-  "file": {
-    "manual_trigger": "",
-    "bucket": "dgmy-public-mwe",
-    "file_name": "mwe_hbar_3",
-    "category": "METADATA",
-    "category_en": "Site Metadata",
-    "category_bm": "Metadata Portal",
-    "subcategory": "SAMPLE_CHART",
-    "subcategory_en": "Chart Samples",
-    "subcategory_bm": "Contoh Carta",
-    "description": {
-      "en": "Lorem ipsum.",
-      "bm": "Lorem ipsum."
-    },
-    "link_parquet": "https://dgmy-public-mwe.s3.ap-southeast-1.amazonaws.com/mwe_bar.parquet",
-    "link_csv": "https://dgmy-public-mwe.s3.ap-southeast-1.amazonaws.com/mwe_bar.csv",
-    "variables": [
-      {
-        "id": -1,
-        "name": "date",
-        "title_en": "Date",
-        "title_bm": "Tarikh",
-        "desc_en": "[Date] The date in YYYY-MM-DD format",
-        "desc_bm": "[Tarikh] Tarikh dalam format YYYY-MM-DD"
-      },
-      {
-        "id": -1,
-        "name": "state",
-        "title_en": "State",
-        "title_bm": "Negeri",
-        "desc_en": "[Categorical] Name of the state (16 in total) or Malaysia",
-        "desc_bm": "[Kategori] Name negeri (16 keseluruhan) atau Malaysia"
-      },
-      {
-        "id": 0,
-        "name": "mwe_hbar_3",
-        "title_en": "Horizontal Bar (3 bars)",
-        "title_bm": "Bar Melintang (3 bar)",
-        "desc_en": "[Integer] A precise, succinct description of this variable",
-        "desc_bm": "[Integer] A precise, succinct description of this variable",
-        "catalog_data": {
-          "catalog_filters": {
-            "frequency": "MONTHLY",
-            "geographic": ["NATIONAL"],
-            "demographic": [],
-            "start": "2006",
-            "end": "2023",
-            "data_source": ["MAMPU"]
-          },
-          "metadata_neutral": {
-            "data_as_of": "2023-04-03 23:59",
-            "last_updated": "2023-04-04 06:00",
-            "next_update": "2023-04-05 06:00"
-          },
-          "metadata_lang": {
-            "en": {
-              "methodology": "Lorem Ipsum is simply dummy text of the printing and typesetting industry. Lorem Ipsum has been the industry's standard dummy text ever since the 1500s, when an unknown printer took a galley of type and scrambled it to make a type specimen book.",
-              "caveat": "Contrary to popular belief, Lorem Ipsum is not simply random text. It has roots in a piece of classical Latin literature from 45 BC, making it over 2000 years old. Richard McClintock, a Latin professor at Hampden-Sydney College in Virginia, looked up one of the more obscure Latin words, consectetur, from a Lorem Ipsum passage, and going through the cites of the word in classical literature, discovered the undoubtable source.",
-              "publication": "Lorem Ipsum comes from sections 1.10.32 and 1.10.33 of 'de Finibus Bonorum et Malorum' (The Extremes of Good and Evil) by Cicero, written in 45 BC. This book is a treatise on the theory of ethics, very popular during the Renaissance. The first line of Lorem Ipsum, 'Lorem ipsum dolor sit amet..'', comes from a line in section 1.10.32."
-            },
-            "bm": {
-              "methodology": "Lorem Ipsum is simply dummy text of the printing and typesetting industry. Lorem Ipsum has been the industry's standard dummy text ever since the 1500s, when an unknown printer took a galley of type and scrambled it to make a type specimen book.",
-              "caveat": "Contrary to popular belief, Lorem Ipsum is not simply random text. It has roots in a piece of classical Latin literature from 45 BC, making it over 2000 years old. Richard McClintock, a Latin professor at Hampden-Sydney College in Virginia, looked up one of the more obscure Latin words, consectetur, from a Lorem Ipsum passage, and going through the cites of the word in classical literature, discovered the undoubtable source.",
-              "publication": "Lorem Ipsum comes from sections 1.10.32 and 1.10.33 of 'de Finibus Bonorum et Malorum' (The Extremes of Good and Evil) by Cicero, written in 45 BC. This book is a treatise on the theory of ethics, very popular during the Renaissance. The first line of Lorem Ipsum, 'Lorem ipsum dolor sit amet..'', comes from a line in section 1.10.32."
-            }
-          },
-          "chart": {
-            "chart_type": "HBAR",
-            "chart_filters": {
-              "SLICE_BY": [],
-              "precision": 0
-            },
-            "chart_variables": {
-              "parents": [],
-              "format": {
-                "x": "state",
-                "y": ["var1", "var2", "var3"]
-              }
-            }
-          },
-          "translations": {
-            "en": {
-              "x": "State",
-              "y1": "Variable 1",
-              "y2": "Variable 2",
-              "y3": "Variable 3"
-            },
-            "bm": {
-              "x": "Negeri",
-              "y1": "Pembolehubah 1",
-              "y2": "Pembolehubah 2",
-              "y3": "Pembolehubah 3"
-            }
-          }
-        }
-      }
-    ]
-  }
+	"file": {
+		"manual_trigger": "",
+		"bucket": "dgmy-public-mwe",
+		"file_name": "mwe_hbar_3",
+		"category": "METADATA",
+		"category_en": "Site Metadata",
+		"category_bm": "Metadata Portal",
+		"subcategory": "SAMPLE_CHART",
+		"subcategory_en": "Chart Samples",
+		"subcategory_bm": "Contoh Carta",
+		"description": {
+			"en": "Lorem ipsum.",
+			"bm": "Lorem ipsum."
+		},
+		"link_parquet": "https://dgmy-public-mwe.s3.ap-southeast-1.amazonaws.com/mwe_bar.parquet",
+		"link_csv": "https://dgmy-public-mwe.s3.ap-southeast-1.amazonaws.com/mwe_bar.csv",
+		"variables": [
+			{
+				"id": -1,
+				"name": "date",
+				"title_en": "Date",
+				"title_bm": "Tarikh",
+				"desc_en": "[Date] The date in YYYY-MM-DD format",
+				"desc_bm": "[Tarikh] Tarikh dalam format YYYY-MM-DD"
+			},
+			{
+				"id": -1,
+				"name": "state",
+				"title_en": "State",
+				"title_bm": "Negeri",
+				"desc_en": "[Categorical] Name of the state (16 in total) or Malaysia",
+				"desc_bm": "[Kategori] Name negeri (16 keseluruhan) atau Malaysia"
+			},
+			{
+				"id": 0,
+				"name": "mwe_hbar_3",
+				"title_en": "Horizontal Bar (3 bars)",
+				"title_bm": "Bar Melintang (3 bar)",
+				"desc_en": "[Integer] A precise, succinct description of this variable",
+				"desc_bm": "[Integer] A precise, succinct description of this variable",
+				"catalog_data": {
+					"catalog_filters": {
+						"frequency": "MONTHLY",
+						"geography": ["NATIONAL"],
+						"demographic": [],
+						"start": "2006",
+						"end": "2023",
+						"data_source": ["MAMPU"]
+					},
+					"metadata_neutral": {
+						"data_as_of": "2023-04-03 23:59",
+						"last_updated": "2023-04-04 06:00",
+						"next_update": "2023-04-05 06:00"
+					},
+					"metadata_lang": {
+						"en": {
+							"methodology": "Lorem Ipsum is simply dummy text of the printing and typesetting industry. Lorem Ipsum has been the industry's standard dummy text ever since the 1500s, when an unknown printer took a galley of type and scrambled it to make a type specimen book.",
+							"caveat": "Contrary to popular belief, Lorem Ipsum is not simply random text. It has roots in a piece of classical Latin literature from 45 BC, making it over 2000 years old. Richard McClintock, a Latin professor at Hampden-Sydney College in Virginia, looked up one of the more obscure Latin words, consectetur, from a Lorem Ipsum passage, and going through the cites of the word in classical literature, discovered the undoubtable source.",
+							"publication": "Lorem Ipsum comes from sections 1.10.32 and 1.10.33 of 'de Finibus Bonorum et Malorum' (The Extremes of Good and Evil) by Cicero, written in 45 BC. This book is a treatise on the theory of ethics, very popular during the Renaissance. The first line of Lorem Ipsum, 'Lorem ipsum dolor sit amet..'', comes from a line in section 1.10.32."
+						},
+						"bm": {
+							"methodology": "Lorem Ipsum is simply dummy text of the printing and typesetting industry. Lorem Ipsum has been the industry's standard dummy text ever since the 1500s, when an unknown printer took a galley of type and scrambled it to make a type specimen book.",
+							"caveat": "Contrary to popular belief, Lorem Ipsum is not simply random text. It has roots in a piece of classical Latin literature from 45 BC, making it over 2000 years old. Richard McClintock, a Latin professor at Hampden-Sydney College in Virginia, looked up one of the more obscure Latin words, consectetur, from a Lorem Ipsum passage, and going through the cites of the word in classical literature, discovered the undoubtable source.",
+							"publication": "Lorem Ipsum comes from sections 1.10.32 and 1.10.33 of 'de Finibus Bonorum et Malorum' (The Extremes of Good and Evil) by Cicero, written in 45 BC. This book is a treatise on the theory of ethics, very popular during the Renaissance. The first line of Lorem Ipsum, 'Lorem ipsum dolor sit amet..'', comes from a line in section 1.10.32."
+						}
+					},
+					"chart": {
+						"chart_type": "HBAR",
+						"chart_filters": {
+							"SLICE_BY": [],
+							"precision": 0
+						},
+						"chart_variables": {
+							"parents": [],
+							"format": {
+								"x": "state",
+								"y": ["var1", "var2", "var3"]
+							}
+						}
+					},
+					"translations": {
+						"en": {
+							"x": "State",
+							"y1": "Variable 1",
+							"y2": "Variable 2",
+							"y3": "Variable 3"
+						},
+						"bm": {
+							"x": "Negeri",
+							"y1": "Pembolehubah 1",
+							"y2": "Pembolehubah 2",
+							"y3": "Pembolehubah 3"
+						}
+					}
+				}
+			}
+		]
+	}
 }

--- a/catalog/mwe_hbar_4.json
+++ b/catalog/mwe_hbar_4.json
@@ -43,7 +43,7 @@
 					"catalog_filters": {
 						"frequency": "MONTHLY",
 						"geography": ["NATIONAL"],
-						"demographic": [],
+						"demography": [],
 						"start": "2006",
 						"end": "2023",
 						"data_source": ["MAMPU"]

--- a/catalog/mwe_hbar_4.json
+++ b/catalog/mwe_hbar_4.json
@@ -1,102 +1,102 @@
 {
-  "file": {
-    "manual_trigger": "",
-    "bucket": "dgmy-public-mwe",
-    "file_name": "mwe_hbar_4",
-    "category": "METADATA",
-    "category_en": "Site Metadata",
-    "category_bm": "Metadata Portal",
-    "subcategory": "SAMPLE_CHART",
-    "subcategory_en": "Chart Samples",
-    "subcategory_bm": "Contoh Carta",
-    "description": {
-      "en": "Lorem ipsum.",
-      "bm": "Lorem ipsum."
-    },
-    "link_parquet": "https://dgmy-public-mwe.s3.ap-southeast-1.amazonaws.com/mwe_bar.parquet",
-    "link_csv": "https://dgmy-public-mwe.s3.ap-southeast-1.amazonaws.com/mwe_bar.csv",
-    "variables": [
-      {
-        "id": -1,
-        "name": "date",
-        "title_en": "Date",
-        "title_bm": "Tarikh",
-        "desc_en": "[Date] The date in YYYY-MM-DD format",
-        "desc_bm": "[Tarikh] Tarikh dalam format YYYY-MM-DD"
-      },
-      {
-        "id": -1,
-        "name": "state",
-        "title_en": "State",
-        "title_bm": "Negeri",
-        "desc_en": "[Categorical] Name of the state (16 in total) or Malaysia",
-        "desc_bm": "[Kategori] Name negeri (16 keseluruhan) atau Malaysia"
-      },
-      {
-        "id": 0,
-        "name": "mwe_hbar_4",
-        "title_en": "Horizontal Bar (4 bars)",
-        "title_bm": "Bar Melintang (4 bar)",
-        "desc_en": "[Integer] A precise, succinct description of this variable",
-        "desc_bm": "[Integer] A precise, succinct description of this variable",
-        "catalog_data": {
-          "catalog_filters": {
-            "frequency": "MONTHLY",
-            "geographic": ["NATIONAL"],
-            "demographic": [],
-            "start": "2006",
-            "end": "2023",
-            "data_source": ["MAMPU"]
-          },
-          "metadata_neutral": {
-            "data_as_of": "2023-04-03 23:59",
-            "last_updated": "2023-04-04 06:00",
-            "next_update": "2023-04-05 06:00"
-          },
-          "metadata_lang": {
-            "en": {
-              "methodology": "Lorem Ipsum is simply dummy text of the printing and typesetting industry. Lorem Ipsum has been the industry's standard dummy text ever since the 1500s, when an unknown printer took a galley of type and scrambled it to make a type specimen book.",
-              "caveat": "Contrary to popular belief, Lorem Ipsum is not simply random text. It has roots in a piece of classical Latin literature from 45 BC, making it over 2000 years old. Richard McClintock, a Latin professor at Hampden-Sydney College in Virginia, looked up one of the more obscure Latin words, consectetur, from a Lorem Ipsum passage, and going through the cites of the word in classical literature, discovered the undoubtable source.",
-              "publication": "Lorem Ipsum comes from sections 1.10.32 and 1.10.33 of 'de Finibus Bonorum et Malorum' (The Extremes of Good and Evil) by Cicero, written in 45 BC. This book is a treatise on the theory of ethics, very popular during the Renaissance. The first line of Lorem Ipsum, 'Lorem ipsum dolor sit amet..'', comes from a line in section 1.10.32."
-            },
-            "bm": {
-              "methodology": "Lorem Ipsum is simply dummy text of the printing and typesetting industry. Lorem Ipsum has been the industry's standard dummy text ever since the 1500s, when an unknown printer took a galley of type and scrambled it to make a type specimen book.",
-              "caveat": "Contrary to popular belief, Lorem Ipsum is not simply random text. It has roots in a piece of classical Latin literature from 45 BC, making it over 2000 years old. Richard McClintock, a Latin professor at Hampden-Sydney College in Virginia, looked up one of the more obscure Latin words, consectetur, from a Lorem Ipsum passage, and going through the cites of the word in classical literature, discovered the undoubtable source.",
-              "publication": "Lorem Ipsum comes from sections 1.10.32 and 1.10.33 of 'de Finibus Bonorum et Malorum' (The Extremes of Good and Evil) by Cicero, written in 45 BC. This book is a treatise on the theory of ethics, very popular during the Renaissance. The first line of Lorem Ipsum, 'Lorem ipsum dolor sit amet..'', comes from a line in section 1.10.32."
-            }
-          },
-          "chart": {
-            "chart_type": "HBAR",
-            "chart_filters": {
-              "SLICE_BY": [],
-              "precision": 0
-            },
-            "chart_variables": {
-              "parents": [],
-              "format": {
-                "x": "state",
-                "y": ["var1", "var2", "var3", "var4"]
-              }
-            }
-          },
-          "translations": {
-            "en": {
-              "x": "State",
-              "y1": "Variable 1",
-              "y2": "Variable 2",
-              "y3": "Variable 3",
-              "y4": "Variable 4"
-            },
-            "bm": {
-              "x": "Negeri",
-              "y1": "Pembolehubah 1",
-              "y2": "Pembolehubah 2",
-              "y3": "Pembolehubah 3",
-              "y4": "Pembolehubah 4"
-            }
-          }
-        }
-      }
-    ]
-  }
+	"file": {
+		"manual_trigger": "",
+		"bucket": "dgmy-public-mwe",
+		"file_name": "mwe_hbar_4",
+		"category": "METADATA",
+		"category_en": "Site Metadata",
+		"category_bm": "Metadata Portal",
+		"subcategory": "SAMPLE_CHART",
+		"subcategory_en": "Chart Samples",
+		"subcategory_bm": "Contoh Carta",
+		"description": {
+			"en": "Lorem ipsum.",
+			"bm": "Lorem ipsum."
+		},
+		"link_parquet": "https://dgmy-public-mwe.s3.ap-southeast-1.amazonaws.com/mwe_bar.parquet",
+		"link_csv": "https://dgmy-public-mwe.s3.ap-southeast-1.amazonaws.com/mwe_bar.csv",
+		"variables": [
+			{
+				"id": -1,
+				"name": "date",
+				"title_en": "Date",
+				"title_bm": "Tarikh",
+				"desc_en": "[Date] The date in YYYY-MM-DD format",
+				"desc_bm": "[Tarikh] Tarikh dalam format YYYY-MM-DD"
+			},
+			{
+				"id": -1,
+				"name": "state",
+				"title_en": "State",
+				"title_bm": "Negeri",
+				"desc_en": "[Categorical] Name of the state (16 in total) or Malaysia",
+				"desc_bm": "[Kategori] Name negeri (16 keseluruhan) atau Malaysia"
+			},
+			{
+				"id": 0,
+				"name": "mwe_hbar_4",
+				"title_en": "Horizontal Bar (4 bars)",
+				"title_bm": "Bar Melintang (4 bar)",
+				"desc_en": "[Integer] A precise, succinct description of this variable",
+				"desc_bm": "[Integer] A precise, succinct description of this variable",
+				"catalog_data": {
+					"catalog_filters": {
+						"frequency": "MONTHLY",
+						"geography": ["NATIONAL"],
+						"demographic": [],
+						"start": "2006",
+						"end": "2023",
+						"data_source": ["MAMPU"]
+					},
+					"metadata_neutral": {
+						"data_as_of": "2023-04-03 23:59",
+						"last_updated": "2023-04-04 06:00",
+						"next_update": "2023-04-05 06:00"
+					},
+					"metadata_lang": {
+						"en": {
+							"methodology": "Lorem Ipsum is simply dummy text of the printing and typesetting industry. Lorem Ipsum has been the industry's standard dummy text ever since the 1500s, when an unknown printer took a galley of type and scrambled it to make a type specimen book.",
+							"caveat": "Contrary to popular belief, Lorem Ipsum is not simply random text. It has roots in a piece of classical Latin literature from 45 BC, making it over 2000 years old. Richard McClintock, a Latin professor at Hampden-Sydney College in Virginia, looked up one of the more obscure Latin words, consectetur, from a Lorem Ipsum passage, and going through the cites of the word in classical literature, discovered the undoubtable source.",
+							"publication": "Lorem Ipsum comes from sections 1.10.32 and 1.10.33 of 'de Finibus Bonorum et Malorum' (The Extremes of Good and Evil) by Cicero, written in 45 BC. This book is a treatise on the theory of ethics, very popular during the Renaissance. The first line of Lorem Ipsum, 'Lorem ipsum dolor sit amet..'', comes from a line in section 1.10.32."
+						},
+						"bm": {
+							"methodology": "Lorem Ipsum is simply dummy text of the printing and typesetting industry. Lorem Ipsum has been the industry's standard dummy text ever since the 1500s, when an unknown printer took a galley of type and scrambled it to make a type specimen book.",
+							"caveat": "Contrary to popular belief, Lorem Ipsum is not simply random text. It has roots in a piece of classical Latin literature from 45 BC, making it over 2000 years old. Richard McClintock, a Latin professor at Hampden-Sydney College in Virginia, looked up one of the more obscure Latin words, consectetur, from a Lorem Ipsum passage, and going through the cites of the word in classical literature, discovered the undoubtable source.",
+							"publication": "Lorem Ipsum comes from sections 1.10.32 and 1.10.33 of 'de Finibus Bonorum et Malorum' (The Extremes of Good and Evil) by Cicero, written in 45 BC. This book is a treatise on the theory of ethics, very popular during the Renaissance. The first line of Lorem Ipsum, 'Lorem ipsum dolor sit amet..'', comes from a line in section 1.10.32."
+						}
+					},
+					"chart": {
+						"chart_type": "HBAR",
+						"chart_filters": {
+							"SLICE_BY": [],
+							"precision": 0
+						},
+						"chart_variables": {
+							"parents": [],
+							"format": {
+								"x": "state",
+								"y": ["var1", "var2", "var3", "var4"]
+							}
+						}
+					},
+					"translations": {
+						"en": {
+							"x": "State",
+							"y1": "Variable 1",
+							"y2": "Variable 2",
+							"y3": "Variable 3",
+							"y4": "Variable 4"
+						},
+						"bm": {
+							"x": "Negeri",
+							"y1": "Pembolehubah 1",
+							"y2": "Pembolehubah 2",
+							"y3": "Pembolehubah 3",
+							"y4": "Pembolehubah 4"
+						}
+					}
+				}
+			}
+		]
+	}
 }

--- a/catalog/mwe_heatmap.json
+++ b/catalog/mwe_heatmap.json
@@ -43,7 +43,7 @@
 					"catalog_filters": {
 						"frequency": "DAILY",
 						"geography": ["STATE", "NATIONAL"],
-						"demographic": ["SEX", "MARITAL"],
+						"demography": ["SEX", "MARITAL"],
 						"start": "2006",
 						"end": "2023",
 						"data_source": ["MAMPU"]

--- a/catalog/mwe_heatmap.json
+++ b/catalog/mwe_heatmap.json
@@ -1,105 +1,105 @@
 {
-  "file": {
-    "manual_trigger": "2",
-    "bucket": "dgmy-public-mwe",
-    "file_name": "mwe_heattable",
-    "category": "METADATA",
-    "category_en": "Site Metadata",
-    "category_bm": "Metadata Portal",
-    "subcategory": "SAMPLE_CHART",
-    "subcategory_en": "Chart Samples",
-    "subcategory_bm": "Contoh Carta",
-    "description": {
-      "en": "Lorem ipsum.",
-      "bm": "Lorem ipsum."
-    },
-    "link_parquet": "https://dgmy-public-mwe.s3.ap-southeast-1.amazonaws.com/mwe_heattable.parquet",
-    "link_csv": "https://dgmy-public-mwe.s3.ap-southeast-1.amazonaws.com/mwe_heattable.csv",
-    "variables": [
-      {
-        "id": -1,
-        "name": "date",
-        "title_en": "Date",
-        "title_bm": "Tarikh",
-        "desc_en": "[Date] The date in YYYY-MM-DD format",
-        "desc_bm": "[Tarikh] Tarikh dalam format YYYY-MM-DD"
-      },
-      {
-        "id": -1,
-        "name": "state",
-        "title_en": "State",
-        "title_bm": "Negeri",
-        "desc_en": "[Categorical] Name of the state (16 in total) or Malaysia",
-        "desc_bm": "[Kategori] Name negeri (16 keseluruhan) atau Malaysia"
-      },
-      {
-        "id": 0,
-        "name": "heatmap_table",
-        "title_en": "Heatmap Table",
-        "title_bm": "Jadual Peta Haba",
-        "desc_en": "A precise, succinct description of this chart",
-        "desc_bm": "A precise, succinct description of this chart",
-        "catalog_data": {
-          "catalog_filters": {
-            "frequency": "DAILY",
-            "geographic": ["STATE", "NATIONAL"],
-            "demographic": ["SEX", "MARITAL"],
-            "start": "2006",
-            "end": "2023",
-            "data_source": ["MAMPU"]
-          },
-          "metadata_neutral": {
-            "data_as_of": "2023-04-03 23:59",
-            "last_updated": "2023-04-04 06:00",
-            "next_update": "2023-04-05 06:00"
-          },
-          "metadata_lang": {
-            "en": {
-              "methodology": "Lorem Ipsum is simply dummy text of the printing and typesetting industry. Lorem Ipsum has been the industry's standard dummy text ever since the 1500s, when an unknown printer took a galley of type and scrambled it to make a type specimen book.",
-              "caveat": "Contrary to popular belief, Lorem Ipsum is not simply random text. It has roots in a piece of classical Latin literature from 45 BC, making it over 2000 years old. Richard McClintock, a Latin professor at Hampden-Sydney College in Virginia, looked up one of the more obscure Latin words, consectetur, from a Lorem Ipsum passage, and going through the cites of the word in classical literature, discovered the undoubtable source.",
-              "publication": "Lorem Ipsum comes from sections 1.10.32 and 1.10.33 of 'de Finibus Bonorum et Malorum' (The Extremes of Good and Evil) by Cicero, written in 45 BC. This book is a treatise on the theory of ethics, very popular during the Renaissance. The first line of Lorem Ipsum, 'Lorem ipsum dolor sit amet..'', comes from a line in section 1.10.32."
-            },
-            "bm": {
-              "methodology": "Lorem Ipsum is simply dummy text of the printing and typesetting industry. Lorem Ipsum has been the industry's standard dummy text ever since the 1500s, when an unknown printer took a galley of type and scrambled it to make a type specimen book.",
-              "caveat": "Contrary to popular belief, Lorem Ipsum is not simply random text. It has roots in a piece of classical Latin literature from 45 BC, making it over 2000 years old. Richard McClintock, a Latin professor at Hampden-Sydney College in Virginia, looked up one of the more obscure Latin words, consectetur, from a Lorem Ipsum passage, and going through the cites of the word in classical literature, discovered the undoubtable source.",
-              "publication": "Lorem Ipsum comes from sections 1.10.32 and 1.10.33 of 'de Finibus Bonorum et Malorum' (The Extremes of Good and Evil) by Cicero, written in 45 BC. This book is a treatise on the theory of ethics, very popular during the Renaissance. The first line of Lorem Ipsum, 'Lorem ipsum dolor sit amet..'', comes from a line in section 1.10.32."
-            }
-          },
-          "chart": {
-            "chart_type": "HEATTABLE",
-            "chart_filters": {
-              "SLICE_BY": [],
-              "precision": 0
-            },
-            "chart_variables": {
-              "parents": [],
-              "colour": "greens"
-            }
-          },
-          "translations": {
-            "en": {
-              "indian_male": "Indian (male)",
-              "chinese_male": "Chinese (male)",
-              "malay_male": "Malay (male)",
-              "other_male": "Others (male)",
-              "indian_female": "Indian (female)",
-              "chinese_female": "Chinese (female)",
-              "malay_female": "Malay (female)",
-              "other_female": "Others (female)"
-            },
-            "bm": {
-              "indian_male": "India (lelaki)",
-              "chinese_male": "Cina (lelaki)",
-              "malay_male": "Melayu (lelaki)",
-              "other_male": "Lain-lain (lelaki)",
-              "indian_female": "India (perempuan)",
-              "chinese_female": "Cina (perempuan)",
-              "malay_female": "Melayu (perempuan)",
-              "other_female": "Lain-lain (perempuan)"
-            }
-          }
-        }
-      }
-    ]
-  }
+	"file": {
+		"manual_trigger": "2",
+		"bucket": "dgmy-public-mwe",
+		"file_name": "mwe_heattable",
+		"category": "METADATA",
+		"category_en": "Site Metadata",
+		"category_bm": "Metadata Portal",
+		"subcategory": "SAMPLE_CHART",
+		"subcategory_en": "Chart Samples",
+		"subcategory_bm": "Contoh Carta",
+		"description": {
+			"en": "Lorem ipsum.",
+			"bm": "Lorem ipsum."
+		},
+		"link_parquet": "https://dgmy-public-mwe.s3.ap-southeast-1.amazonaws.com/mwe_heattable.parquet",
+		"link_csv": "https://dgmy-public-mwe.s3.ap-southeast-1.amazonaws.com/mwe_heattable.csv",
+		"variables": [
+			{
+				"id": -1,
+				"name": "date",
+				"title_en": "Date",
+				"title_bm": "Tarikh",
+				"desc_en": "[Date] The date in YYYY-MM-DD format",
+				"desc_bm": "[Tarikh] Tarikh dalam format YYYY-MM-DD"
+			},
+			{
+				"id": -1,
+				"name": "state",
+				"title_en": "State",
+				"title_bm": "Negeri",
+				"desc_en": "[Categorical] Name of the state (16 in total) or Malaysia",
+				"desc_bm": "[Kategori] Name negeri (16 keseluruhan) atau Malaysia"
+			},
+			{
+				"id": 0,
+				"name": "heatmap_table",
+				"title_en": "Heatmap Table",
+				"title_bm": "Jadual Peta Haba",
+				"desc_en": "A precise, succinct description of this chart",
+				"desc_bm": "A precise, succinct description of this chart",
+				"catalog_data": {
+					"catalog_filters": {
+						"frequency": "DAILY",
+						"geography": ["STATE", "NATIONAL"],
+						"demographic": ["SEX", "MARITAL"],
+						"start": "2006",
+						"end": "2023",
+						"data_source": ["MAMPU"]
+					},
+					"metadata_neutral": {
+						"data_as_of": "2023-04-03 23:59",
+						"last_updated": "2023-04-04 06:00",
+						"next_update": "2023-04-05 06:00"
+					},
+					"metadata_lang": {
+						"en": {
+							"methodology": "Lorem Ipsum is simply dummy text of the printing and typesetting industry. Lorem Ipsum has been the industry's standard dummy text ever since the 1500s, when an unknown printer took a galley of type and scrambled it to make a type specimen book.",
+							"caveat": "Contrary to popular belief, Lorem Ipsum is not simply random text. It has roots in a piece of classical Latin literature from 45 BC, making it over 2000 years old. Richard McClintock, a Latin professor at Hampden-Sydney College in Virginia, looked up one of the more obscure Latin words, consectetur, from a Lorem Ipsum passage, and going through the cites of the word in classical literature, discovered the undoubtable source.",
+							"publication": "Lorem Ipsum comes from sections 1.10.32 and 1.10.33 of 'de Finibus Bonorum et Malorum' (The Extremes of Good and Evil) by Cicero, written in 45 BC. This book is a treatise on the theory of ethics, very popular during the Renaissance. The first line of Lorem Ipsum, 'Lorem ipsum dolor sit amet..'', comes from a line in section 1.10.32."
+						},
+						"bm": {
+							"methodology": "Lorem Ipsum is simply dummy text of the printing and typesetting industry. Lorem Ipsum has been the industry's standard dummy text ever since the 1500s, when an unknown printer took a galley of type and scrambled it to make a type specimen book.",
+							"caveat": "Contrary to popular belief, Lorem Ipsum is not simply random text. It has roots in a piece of classical Latin literature from 45 BC, making it over 2000 years old. Richard McClintock, a Latin professor at Hampden-Sydney College in Virginia, looked up one of the more obscure Latin words, consectetur, from a Lorem Ipsum passage, and going through the cites of the word in classical literature, discovered the undoubtable source.",
+							"publication": "Lorem Ipsum comes from sections 1.10.32 and 1.10.33 of 'de Finibus Bonorum et Malorum' (The Extremes of Good and Evil) by Cicero, written in 45 BC. This book is a treatise on the theory of ethics, very popular during the Renaissance. The first line of Lorem Ipsum, 'Lorem ipsum dolor sit amet..'', comes from a line in section 1.10.32."
+						}
+					},
+					"chart": {
+						"chart_type": "HEATTABLE",
+						"chart_filters": {
+							"SLICE_BY": [],
+							"precision": 0
+						},
+						"chart_variables": {
+							"parents": [],
+							"colour": "greens"
+						}
+					},
+					"translations": {
+						"en": {
+							"indian_male": "Indian (male)",
+							"chinese_male": "Chinese (male)",
+							"malay_male": "Malay (male)",
+							"other_male": "Others (male)",
+							"indian_female": "Indian (female)",
+							"chinese_female": "Chinese (female)",
+							"malay_female": "Malay (female)",
+							"other_female": "Others (female)"
+						},
+						"bm": {
+							"indian_male": "India (lelaki)",
+							"chinese_male": "Cina (lelaki)",
+							"malay_male": "Melayu (lelaki)",
+							"other_male": "Lain-lain (lelaki)",
+							"indian_female": "India (perempuan)",
+							"chinese_female": "Cina (perempuan)",
+							"malay_female": "Melayu (perempuan)",
+							"other_female": "Lain-lain (perempuan)"
+						}
+					}
+				}
+			}
+		]
+	}
 }

--- a/catalog/mwe_line_1.json
+++ b/catalog/mwe_line_1.json
@@ -51,7 +51,7 @@
 					"catalog_filters": {
 						"frequency": "MONTHLY",
 						"geography": ["NATIONAL"],
-						"demographic": [],
+						"demography": [],
 						"start": "2006",
 						"end": "2023",
 						"data_source": ["MAMPU"]

--- a/catalog/mwe_line_1.json
+++ b/catalog/mwe_line_1.json
@@ -1,107 +1,110 @@
 {
-  "file": {
-    "manual_trigger": "1",
-    "bucket": "dgmy-public-mwe",
-    "file_name": "mwe_line_1",
-    "category": "METADATA",
-    "category_en": "Site Metadata",
-    "category_bm": "Metadata Portal",
-    "subcategory": "SAMPLE_CHART",
-    "subcategory_en": "Chart Samples",
-    "subcategory_bm": "Contoh Carta",
-    "description": {
-      "en": "Lorem ipsum.",
-      "bm": "Lorem ipsum."
-    },
-    "link_parquet": "https://dgmy-public-mwe.s3.ap-southeast-1.amazonaws.com/mwe_line.parquet",
-    "link_csv": "https://dgmy-public-mwe.s3.ap-southeast-1.amazonaws.com/mwe_line.csv",
-    "variables": [
-      {
-        "id": -1,
-        "name": "date",
-        "title_en": "Date",
-        "title_bm": "Tarikh",
-        "desc_en": "[Date] The date in YYYY-MM-DD format",
-        "desc_bm": "[Tarikh] Tarikh dalam format YYYY-MM-DD"
-      },
-      {
-        "id": -1,
-        "name": "state",
-        "title_en": "State",
-        "title_bm": "Negeri",
-        "desc_en": "[Categorical] Name of the state (16 in total) or Malaysia",
-        "desc_bm": "[Kategori] Name negeri (16 keseluruhan) atau Malaysia"
-      },
-      {
-        "id": -1,
-        "name": "var1",
-        "title_en": "Variable 1",
-        "title_bm": "Pembolehubah 1",
-        "desc_en": "[Integer] A precise, succinct description of this variable",
-        "desc_bm": "[Integer] A precise, succinct description of this variable"
-      },
-      {
-        "id": 0,
-        "name": "mwe_line_1",
-        "title_en": "Line Chart (1 Line)",
-        "title_bm": "Carta Garisan (1 Garisan)",
-        "desc_en": "A precise, succinct description of this chart",
-        "desc_bm": "A precise, succinct description of this chart",
-        "catalog_data": {
-          "catalog_filters": {
-            "frequency": "MONTHLY",
-            "geographic": ["NATIONAL"],
-            "demographic": [],
-            "start": "2006",
-            "end": "2023",
-            "data_source": ["MAMPU"]
-          },
-          "metadata_neutral": {
-            "data_as_of": "2023-04-03 23:59",
-            "last_updated": "2023-04-04 06:00",
-            "next_update": "2023-04-05 06:00"
-          },
-          "metadata_lang": {
-            "en": {
-              "methodology": "Lorem Ipsum is simply dummy text of the printing and typesetting industry. Lorem Ipsum has been the industry's standard dummy text ever since the 1500s, when an unknown printer took a galley of type and scrambled it to make a type specimen book.",
-              "caveat": "Contrary to popular belief, Lorem Ipsum is not simply random text. It has roots in a piece of classical Latin literature from 45 BC, making it over 2000 years old. Richard McClintock, a Latin professor at Hampden-Sydney College in Virginia, looked up one of the more obscure Latin words, consectetur, from a Lorem Ipsum passage, and going through the cites of the word in classical literature, discovered the undoubtable source.",
-              "publication": "Lorem Ipsum comes from sections 1.10.32 and 1.10.33 of 'de Finibus Bonorum et Malorum' (The Extremes of Good and Evil) by Cicero, written in 45 BC. This book is a treatise on the theory of ethics, very popular during the Renaissance. The first line of Lorem Ipsum, 'Lorem ipsum dolor sit amet..'', comes from a line in section 1.10.32."
-            },
-            "bm": {
-              "methodology": "Lorem Ipsum is simply dummy text of the printing and typesetting industry. Lorem Ipsum has been the industry's standard dummy text ever since the 1500s, when an unknown printer took a galley of type and scrambled it to make a type specimen book.",
-              "caveat": "Contrary to popular belief, Lorem Ipsum is not simply random text. It has roots in a piece of classical Latin literature from 45 BC, making it over 2000 years old. Richard McClintock, a Latin professor at Hampden-Sydney College in Virginia, looked up one of the more obscure Latin words, consectetur, from a Lorem Ipsum passage, and going through the cites of the word in classical literature, discovered the undoubtable source.",
-              "publication": "Lorem Ipsum comes from sections 1.10.32 and 1.10.33 of 'de Finibus Bonorum et Malorum' (The Extremes of Good and Evil) by Cicero, written in 45 BC. This book is a treatise on the theory of ethics, very popular during the Renaissance. The first line of Lorem Ipsum, 'Lorem ipsum dolor sit amet..'', comes from a line in section 1.10.32."
-            }
-          },
-          "chart": {
-            "chart_type": "LINE",
-            "chart_filters": {
-              "SLICE_BY": [],
-              "precision": 0
-            },
-            "chart_variables": {
-              "parents": [],
-              "line_type": {
-                "y1": { "stepped": true, "tension": 0 }
-              },
-              "format": {
-                "x": "taxable_income",
-                "y": ["tax_paid"]
-              }
-            }
-          },
-          "translations": {
-            "en": {
-              "x": "Taxable Income",
-              "y1": "Tax Paid"
-            },
-            "bm": {
-              "x": "Pendapatan Bercukai",
-              "y1": "Cukai Dibayar"
-            }
-          }
-        }
-      }
-    ]
-  }
+	"file": {
+		"manual_trigger": "1",
+		"bucket": "dgmy-public-mwe",
+		"file_name": "mwe_line_1",
+		"category": "METADATA",
+		"category_en": "Site Metadata",
+		"category_bm": "Metadata Portal",
+		"subcategory": "SAMPLE_CHART",
+		"subcategory_en": "Chart Samples",
+		"subcategory_bm": "Contoh Carta",
+		"description": {
+			"en": "Lorem ipsum.",
+			"bm": "Lorem ipsum."
+		},
+		"link_parquet": "https://dgmy-public-mwe.s3.ap-southeast-1.amazonaws.com/mwe_line.parquet",
+		"link_csv": "https://dgmy-public-mwe.s3.ap-southeast-1.amazonaws.com/mwe_line.csv",
+		"variables": [
+			{
+				"id": -1,
+				"name": "date",
+				"title_en": "Date",
+				"title_bm": "Tarikh",
+				"desc_en": "[Date] The date in YYYY-MM-DD format",
+				"desc_bm": "[Tarikh] Tarikh dalam format YYYY-MM-DD"
+			},
+			{
+				"id": -1,
+				"name": "state",
+				"title_en": "State",
+				"title_bm": "Negeri",
+				"desc_en": "[Categorical] Name of the state (16 in total) or Malaysia",
+				"desc_bm": "[Kategori] Name negeri (16 keseluruhan) atau Malaysia"
+			},
+			{
+				"id": -1,
+				"name": "var1",
+				"title_en": "Variable 1",
+				"title_bm": "Pembolehubah 1",
+				"desc_en": "[Integer] A precise, succinct description of this variable",
+				"desc_bm": "[Integer] A precise, succinct description of this variable"
+			},
+			{
+				"id": 0,
+				"name": "mwe_line_1",
+				"title_en": "Line Chart (1 Line)",
+				"title_bm": "Carta Garisan (1 Garisan)",
+				"desc_en": "A precise, succinct description of this chart",
+				"desc_bm": "A precise, succinct description of this chart",
+				"catalog_data": {
+					"catalog_filters": {
+						"frequency": "MONTHLY",
+						"geography": ["NATIONAL"],
+						"demographic": [],
+						"start": "2006",
+						"end": "2023",
+						"data_source": ["MAMPU"]
+					},
+					"metadata_neutral": {
+						"data_as_of": "2023-04-03 23:59",
+						"last_updated": "2023-04-04 06:00",
+						"next_update": "2023-04-05 06:00"
+					},
+					"metadata_lang": {
+						"en": {
+							"methodology": "Lorem Ipsum is simply dummy text of the printing and typesetting industry. Lorem Ipsum has been the industry's standard dummy text ever since the 1500s, when an unknown printer took a galley of type and scrambled it to make a type specimen book.",
+							"caveat": "Contrary to popular belief, Lorem Ipsum is not simply random text. It has roots in a piece of classical Latin literature from 45 BC, making it over 2000 years old. Richard McClintock, a Latin professor at Hampden-Sydney College in Virginia, looked up one of the more obscure Latin words, consectetur, from a Lorem Ipsum passage, and going through the cites of the word in classical literature, discovered the undoubtable source.",
+							"publication": "Lorem Ipsum comes from sections 1.10.32 and 1.10.33 of 'de Finibus Bonorum et Malorum' (The Extremes of Good and Evil) by Cicero, written in 45 BC. This book is a treatise on the theory of ethics, very popular during the Renaissance. The first line of Lorem Ipsum, 'Lorem ipsum dolor sit amet..'', comes from a line in section 1.10.32."
+						},
+						"bm": {
+							"methodology": "Lorem Ipsum is simply dummy text of the printing and typesetting industry. Lorem Ipsum has been the industry's standard dummy text ever since the 1500s, when an unknown printer took a galley of type and scrambled it to make a type specimen book.",
+							"caveat": "Contrary to popular belief, Lorem Ipsum is not simply random text. It has roots in a piece of classical Latin literature from 45 BC, making it over 2000 years old. Richard McClintock, a Latin professor at Hampden-Sydney College in Virginia, looked up one of the more obscure Latin words, consectetur, from a Lorem Ipsum passage, and going through the cites of the word in classical literature, discovered the undoubtable source.",
+							"publication": "Lorem Ipsum comes from sections 1.10.32 and 1.10.33 of 'de Finibus Bonorum et Malorum' (The Extremes of Good and Evil) by Cicero, written in 45 BC. This book is a treatise on the theory of ethics, very popular during the Renaissance. The first line of Lorem Ipsum, 'Lorem ipsum dolor sit amet..'', comes from a line in section 1.10.32."
+						}
+					},
+					"chart": {
+						"chart_type": "LINE",
+						"chart_filters": {
+							"SLICE_BY": [],
+							"precision": 0
+						},
+						"chart_variables": {
+							"parents": [],
+							"line_type": {
+								"y1": {
+									"stepped": true,
+									"tension": 0
+								}
+							},
+							"format": {
+								"x": "taxable_income",
+								"y": ["tax_paid"]
+							}
+						}
+					},
+					"translations": {
+						"en": {
+							"x": "Taxable Income",
+							"y1": "Tax Paid"
+						},
+						"bm": {
+							"x": "Pendapatan Bercukai",
+							"y1": "Cukai Dibayar"
+						}
+					}
+				}
+			}
+		]
+	}
 }

--- a/catalog/mwe_line_2.json
+++ b/catalog/mwe_line_2.json
@@ -1,118 +1,124 @@
 {
-  "file": {
-    "manual_trigger": "1",
-    "bucket": "dgmy-public-mwe",
-    "file_name": "mwe_line_2",
-    "category": "METADATA",
-    "category_en": "Site Metadata",
-    "category_bm": "Metadata Portal",
-    "subcategory": "SAMPLE_CHART",
-    "subcategory_en": "Chart Samples",
-    "subcategory_bm": "Contoh Carta",
-    "description": {
-      "en": "Lorem ipsum.",
-      "bm": "Lorem ipsum."
-    },
-    "link_parquet": "https://dgmy-public-mwe.s3.ap-southeast-1.amazonaws.com/mwe_line.parquet",
-    "link_csv": "https://dgmy-public-mwe.s3.ap-southeast-1.amazonaws.com/mwe_line.csv",
-    "variables": [
-      {
-        "id": -1,
-        "name": "date",
-        "title_en": "Date",
-        "title_bm": "Tarikh",
-        "desc_en": "[Date] The date in YYYY-MM-DD format",
-        "desc_bm": "[Tarikh] Tarikh dalam format YYYY-MM-DD"
-      },
-      {
-        "id": -1,
-        "name": "state",
-        "title_en": "State",
-        "title_bm": "Negeri",
-        "desc_en": "[Categorical] Name of the state (16 in total) or Malaysia",
-        "desc_bm": "[Kategori] Name negeri (16 keseluruhan) atau Malaysia"
-      },
-      {
-        "id": -1,
-        "name": "var1",
-        "title_en": "Variable 1",
-        "title_bm": "Pembolehubah 1",
-        "desc_en": "[Integer] A precise, succinct description of this variable",
-        "desc_bm": "[Integer] A precise, succinct description of this variable"
-      },
-      {
-        "id": -1,
-        "name": "var2",
-        "title_en": "Variable 2",
-        "title_bm": "Pembolehubah 2",
-        "desc_en": "[Integer] A precise, succinct description of this variable",
-        "desc_bm": "[Integer] A precise, succinct description of this variable"
-      },
-      {
-        "id": 0,
-        "name": "mwe_line_2",
-        "title_en": "Line Chart (2 Line)",
-        "title_bm": "Carta Garisan (2 Garisan)",
-        "desc_en": "A precise, succinct description of this chart",
-        "desc_bm": "A precise, succinct description of this chart",
-        "catalog_data": {
-          "catalog_filters": {
-            "frequency": "MONTHLY",
-            "geographic": ["NATIONAL"],
-            "demographic": [],
-            "start": "2006",
-            "end": "2023",
-            "data_source": ["MAMPU"]
-          },
-          "metadata_neutral": {
-            "data_as_of": "2023-04-03 23:59",
-            "last_updated": "2023-04-04 06:00",
-            "next_update": "2023-04-05 06:00"
-          },
-          "metadata_lang": {
-            "en": {
-              "methodology": "Lorem Ipsum is simply dummy text of the printing and typesetting industry. Lorem Ipsum has been the industry's standard dummy text ever since the 1500s, when an unknown printer took a galley of type and scrambled it to make a type specimen book.",
-              "caveat": "Contrary to popular belief, Lorem Ipsum is not simply random text. It has roots in a piece of classical Latin literature from 45 BC, making it over 2000 years old. Richard McClintock, a Latin professor at Hampden-Sydney College in Virginia, looked up one of the more obscure Latin words, consectetur, from a Lorem Ipsum passage, and going through the cites of the word in classical literature, discovered the undoubtable source.",
-              "publication": "Lorem Ipsum comes from sections 1.10.32 and 1.10.33 of 'de Finibus Bonorum et Malorum' (The Extremes of Good and Evil) by Cicero, written in 45 BC. This book is a treatise on the theory of ethics, very popular during the Renaissance. The first line of Lorem Ipsum, 'Lorem ipsum dolor sit amet..'', comes from a line in section 1.10.32."
-            },
-            "bm": {
-              "methodology": "Lorem Ipsum is simply dummy text of the printing and typesetting industry. Lorem Ipsum has been the industry's standard dummy text ever since the 1500s, when an unknown printer took a galley of type and scrambled it to make a type specimen book.",
-              "caveat": "Contrary to popular belief, Lorem Ipsum is not simply random text. It has roots in a piece of classical Latin literature from 45 BC, making it over 2000 years old. Richard McClintock, a Latin professor at Hampden-Sydney College in Virginia, looked up one of the more obscure Latin words, consectetur, from a Lorem Ipsum passage, and going through the cites of the word in classical literature, discovered the undoubtable source.",
-              "publication": "Lorem Ipsum comes from sections 1.10.32 and 1.10.33 of 'de Finibus Bonorum et Malorum' (The Extremes of Good and Evil) by Cicero, written in 45 BC. This book is a treatise on the theory of ethics, very popular during the Renaissance. The first line of Lorem Ipsum, 'Lorem ipsum dolor sit amet..'', comes from a line in section 1.10.32."
-            }
-          },
-          "chart": {
-            "chart_type": "LINE",
-            "chart_filters": {
-              "SLICE_BY": [],
-              "precision": 0
-            },
-            "chart_variables": {
-              "parents": [],
-              "line_type": {
-                "y1": { "stepped": true, "tension": 0 },
-                "y2": { "stepped": true, "tension": 0 }
-              },
-              "format": {
-                "x": "taxable_income",
-                "y": ["atr", "mtr"]
-              }
-            }
-          },
-          "translations": {
-            "en": {
-              "x": "Taxable Income",
-              "y1": "Average Tax Rate",
-              "y2": "Marginal Tax Rate"
-            },
-            "bm": {
-              "x": "Pendapatan Bercukai",
-              "y1": "Kadar Cukai Purata",
-              "y2": "Kadar Cukai Membelanjakan"
-            }
-          }
-        }
-      }
-    ]
-  }
+	"file": {
+		"manual_trigger": "1",
+		"bucket": "dgmy-public-mwe",
+		"file_name": "mwe_line_2",
+		"category": "METADATA",
+		"category_en": "Site Metadata",
+		"category_bm": "Metadata Portal",
+		"subcategory": "SAMPLE_CHART",
+		"subcategory_en": "Chart Samples",
+		"subcategory_bm": "Contoh Carta",
+		"description": {
+			"en": "Lorem ipsum.",
+			"bm": "Lorem ipsum."
+		},
+		"link_parquet": "https://dgmy-public-mwe.s3.ap-southeast-1.amazonaws.com/mwe_line.parquet",
+		"link_csv": "https://dgmy-public-mwe.s3.ap-southeast-1.amazonaws.com/mwe_line.csv",
+		"variables": [
+			{
+				"id": -1,
+				"name": "date",
+				"title_en": "Date",
+				"title_bm": "Tarikh",
+				"desc_en": "[Date] The date in YYYY-MM-DD format",
+				"desc_bm": "[Tarikh] Tarikh dalam format YYYY-MM-DD"
+			},
+			{
+				"id": -1,
+				"name": "state",
+				"title_en": "State",
+				"title_bm": "Negeri",
+				"desc_en": "[Categorical] Name of the state (16 in total) or Malaysia",
+				"desc_bm": "[Kategori] Name negeri (16 keseluruhan) atau Malaysia"
+			},
+			{
+				"id": -1,
+				"name": "var1",
+				"title_en": "Variable 1",
+				"title_bm": "Pembolehubah 1",
+				"desc_en": "[Integer] A precise, succinct description of this variable",
+				"desc_bm": "[Integer] A precise, succinct description of this variable"
+			},
+			{
+				"id": -1,
+				"name": "var2",
+				"title_en": "Variable 2",
+				"title_bm": "Pembolehubah 2",
+				"desc_en": "[Integer] A precise, succinct description of this variable",
+				"desc_bm": "[Integer] A precise, succinct description of this variable"
+			},
+			{
+				"id": 0,
+				"name": "mwe_line_2",
+				"title_en": "Line Chart (2 Line)",
+				"title_bm": "Carta Garisan (2 Garisan)",
+				"desc_en": "A precise, succinct description of this chart",
+				"desc_bm": "A precise, succinct description of this chart",
+				"catalog_data": {
+					"catalog_filters": {
+						"frequency": "MONTHLY",
+						"geography": ["NATIONAL"],
+						"demographic": [],
+						"start": "2006",
+						"end": "2023",
+						"data_source": ["MAMPU"]
+					},
+					"metadata_neutral": {
+						"data_as_of": "2023-04-03 23:59",
+						"last_updated": "2023-04-04 06:00",
+						"next_update": "2023-04-05 06:00"
+					},
+					"metadata_lang": {
+						"en": {
+							"methodology": "Lorem Ipsum is simply dummy text of the printing and typesetting industry. Lorem Ipsum has been the industry's standard dummy text ever since the 1500s, when an unknown printer took a galley of type and scrambled it to make a type specimen book.",
+							"caveat": "Contrary to popular belief, Lorem Ipsum is not simply random text. It has roots in a piece of classical Latin literature from 45 BC, making it over 2000 years old. Richard McClintock, a Latin professor at Hampden-Sydney College in Virginia, looked up one of the more obscure Latin words, consectetur, from a Lorem Ipsum passage, and going through the cites of the word in classical literature, discovered the undoubtable source.",
+							"publication": "Lorem Ipsum comes from sections 1.10.32 and 1.10.33 of 'de Finibus Bonorum et Malorum' (The Extremes of Good and Evil) by Cicero, written in 45 BC. This book is a treatise on the theory of ethics, very popular during the Renaissance. The first line of Lorem Ipsum, 'Lorem ipsum dolor sit amet..'', comes from a line in section 1.10.32."
+						},
+						"bm": {
+							"methodology": "Lorem Ipsum is simply dummy text of the printing and typesetting industry. Lorem Ipsum has been the industry's standard dummy text ever since the 1500s, when an unknown printer took a galley of type and scrambled it to make a type specimen book.",
+							"caveat": "Contrary to popular belief, Lorem Ipsum is not simply random text. It has roots in a piece of classical Latin literature from 45 BC, making it over 2000 years old. Richard McClintock, a Latin professor at Hampden-Sydney College in Virginia, looked up one of the more obscure Latin words, consectetur, from a Lorem Ipsum passage, and going through the cites of the word in classical literature, discovered the undoubtable source.",
+							"publication": "Lorem Ipsum comes from sections 1.10.32 and 1.10.33 of 'de Finibus Bonorum et Malorum' (The Extremes of Good and Evil) by Cicero, written in 45 BC. This book is a treatise on the theory of ethics, very popular during the Renaissance. The first line of Lorem Ipsum, 'Lorem ipsum dolor sit amet..'', comes from a line in section 1.10.32."
+						}
+					},
+					"chart": {
+						"chart_type": "LINE",
+						"chart_filters": {
+							"SLICE_BY": [],
+							"precision": 0
+						},
+						"chart_variables": {
+							"parents": [],
+							"line_type": {
+								"y1": {
+									"stepped": true,
+									"tension": 0
+								},
+								"y2": {
+									"stepped": true,
+									"tension": 0
+								}
+							},
+							"format": {
+								"x": "taxable_income",
+								"y": ["atr", "mtr"]
+							}
+						}
+					},
+					"translations": {
+						"en": {
+							"x": "Taxable Income",
+							"y1": "Average Tax Rate",
+							"y2": "Marginal Tax Rate"
+						},
+						"bm": {
+							"x": "Pendapatan Bercukai",
+							"y1": "Kadar Cukai Purata",
+							"y2": "Kadar Cukai Membelanjakan"
+						}
+					}
+				}
+			}
+		]
+	}
 }

--- a/catalog/mwe_line_2.json
+++ b/catalog/mwe_line_2.json
@@ -59,7 +59,7 @@
 					"catalog_filters": {
 						"frequency": "MONTHLY",
 						"geography": ["NATIONAL"],
-						"demographic": [],
+						"demography": [],
 						"start": "2006",
 						"end": "2023",
 						"data_source": ["MAMPU"]

--- a/catalog/mwe_pyramid.json
+++ b/catalog/mwe_pyramid.json
@@ -67,7 +67,7 @@
 					"catalog_filters": {
 						"frequency": "YEARLY",
 						"geography": ["NATIONAL"],
-						"demographic": [],
+						"demography": [],
 						"start": "2010",
 						"end": "2022",
 						"data_source": ["MAMPU"]

--- a/catalog/mwe_pyramid.json
+++ b/catalog/mwe_pyramid.json
@@ -1,121 +1,120 @@
 {
-  "file": {
-    "manual_trigger": "",
-    "bucket": "dgmy-public-mwe",
-    "file_name": "mwe_pyramid",
-    "category": "METADATA",
-    "category_en": "Site Metadata",
-    "category_bm": "Metadata Portal",
-    "subcategory": "SAMPLE_CHART",
-    "subcategory_en": "Chart Samples",
-    "subcategory_bm": "Contoh Carta",
-    "description": {
-      "en": "Lorem ipsum.",
-      "bm": "Lorem ipsum."
-    },
-    "link_parquet": "https://dgmy-public-mwe.s3.ap-southeast-1.amazonaws.com/mwe_pyramid.parquet",
-    "link_csv": "https://dgmy-public-mwe.s3.ap-southeast-1.amazonaws.com/mwe_pyramid.csv",
-    "variables": [
-      {
-        "id": -1,
-        "name": "date",
-        "title_en": "Date",
-        "title_bm": "Tarikh",
-        "desc_en": "[Date] Date in YYYY-MM-DD format",
-        "desc_bm": "[Tarikh] Tarikh dalam format YYYY-MM-DD"
-      },
-
-      {
-        "id": -1,
-        "name": "ethnicity",
-        "title_en": "Ethnicity",
-        "title_bm": "Etnik",
-        "desc_en": "[Categorical] Total, Malay, Other Bumiputera, Chinese, Indian, Other Citizen, Non-citizen",
-        "desc_bm": "[Kategori] Keseluruhan, Melayu, Bumiptutera lain, Cina, India, Lain-lain Warganegara, Bukan Warganegara"
-      },
-      {
-        "id": -1,
-        "name": "age",
-        "title_en": "Age Group",
-        "title_bm": "Kumpulan Umur",
-        "desc_en": "[Categorical] 5-year groups from 0-4 until 85+",
-        "desc_bm": "[Kategori] Kumpulan umur dengan julat 5 tahun, dari 0-4 hingga 85+"
-      },
-      {
-        "id": -1,
-        "name": "male",
-        "title_en": "Male Population",
-        "title_bm": "Populasi Lelaki",
-        "desc_en": "[Integer] Estimated number of people",
-        "desc_bm": "[Integer] Anggaran jumlah penduduk"
-      },
-      {
-        "id": -1,
-        "name": "female",
-        "title_en": "Female Population",
-        "title_bm": "Populasi Perempuan",
-        "desc_en": "[Integer] Estimated number of people",
-        "desc_bm": "[Integer] Anggaran jumlah penduduk"
-      },
-      {
-        "id": 0,
-        "name": "mwe_pyramid",
-        "title_en": "Pyramid Bar",
-        "title_bm": "Pyramid Bar",
-        "desc_en": "Population pyramid for Malaysia",
-        "desc_bm": "Piramid populasi bagi Malaysia",
-        "catalog_data": {
-          "catalog_filters": {
-            "frequency": "YEARLY",
-            "geographic": ["NATIONAL"],
-            "demographic": [],
-            "start": "2010",
-            "end": "2022",
-            "data_source": ["MAMPU"]
-          },
-          "metadata_neutral": {
-            "data_as_of": "2022-12-31 23:59",
-            "last_updated": "2023-01-25 12:00",
-            "next_update": "2023-01-26 12:00"
-          },
-          "metadata_lang": {
-            "en": {
-              "methodology": "Lorem ipsum",
-              "caveat": "Lorem ipsum",
-              "publication": "Lorem ipsum"
-            },
-            "bm": {
-              "methodology": "Lorem ipsum",
-              "caveat": "Lorem ipsum",
-              "publication": "Lorem ipsum"
-            }
-          },
-          "chart": {
-            "chart_type": "PYRAMID",
-            "chart_filters": {
-              "SLICE_BY": ["ethnicity"],
-              "precision": 0
-            },
-            "chart_variables": {
-              "parents": ["ethnicity"],
-              "x": "age",
-              "y": ["male", "female"]
-            }
-          },
-          "translations": {
-            "en": {
-              "x": "Age",
-              "y1": "Male",
-              "y2": "Female"
-            },
-            "bm": {
-              "x": "Negeri",
-              "y1": "Lelaki",
-              "y2": "Perempuan"
-            }
-          }
-        }
-      }
-    ]
-  }
+	"file": {
+		"manual_trigger": "",
+		"bucket": "dgmy-public-mwe",
+		"file_name": "mwe_pyramid",
+		"category": "METADATA",
+		"category_en": "Site Metadata",
+		"category_bm": "Metadata Portal",
+		"subcategory": "SAMPLE_CHART",
+		"subcategory_en": "Chart Samples",
+		"subcategory_bm": "Contoh Carta",
+		"description": {
+			"en": "Lorem ipsum.",
+			"bm": "Lorem ipsum."
+		},
+		"link_parquet": "https://dgmy-public-mwe.s3.ap-southeast-1.amazonaws.com/mwe_pyramid.parquet",
+		"link_csv": "https://dgmy-public-mwe.s3.ap-southeast-1.amazonaws.com/mwe_pyramid.csv",
+		"variables": [
+			{
+				"id": -1,
+				"name": "date",
+				"title_en": "Date",
+				"title_bm": "Tarikh",
+				"desc_en": "[Date] Date in YYYY-MM-DD format",
+				"desc_bm": "[Tarikh] Tarikh dalam format YYYY-MM-DD"
+			},
+			{
+				"id": -1,
+				"name": "ethnicity",
+				"title_en": "Ethnicity",
+				"title_bm": "Etnik",
+				"desc_en": "[Categorical] Total, Malay, Other Bumiputera, Chinese, Indian, Other Citizen, Non-citizen",
+				"desc_bm": "[Kategori] Keseluruhan, Melayu, Bumiptutera lain, Cina, India, Lain-lain Warganegara, Bukan Warganegara"
+			},
+			{
+				"id": -1,
+				"name": "age",
+				"title_en": "Age Group",
+				"title_bm": "Kumpulan Umur",
+				"desc_en": "[Categorical] 5-year groups from 0-4 until 85+",
+				"desc_bm": "[Kategori] Kumpulan umur dengan julat 5 tahun, dari 0-4 hingga 85+"
+			},
+			{
+				"id": -1,
+				"name": "male",
+				"title_en": "Male Population",
+				"title_bm": "Populasi Lelaki",
+				"desc_en": "[Integer] Estimated number of people",
+				"desc_bm": "[Integer] Anggaran jumlah penduduk"
+			},
+			{
+				"id": -1,
+				"name": "female",
+				"title_en": "Female Population",
+				"title_bm": "Populasi Perempuan",
+				"desc_en": "[Integer] Estimated number of people",
+				"desc_bm": "[Integer] Anggaran jumlah penduduk"
+			},
+			{
+				"id": 0,
+				"name": "mwe_pyramid",
+				"title_en": "Pyramid Bar",
+				"title_bm": "Pyramid Bar",
+				"desc_en": "Population pyramid for Malaysia",
+				"desc_bm": "Piramid populasi bagi Malaysia",
+				"catalog_data": {
+					"catalog_filters": {
+						"frequency": "YEARLY",
+						"geography": ["NATIONAL"],
+						"demographic": [],
+						"start": "2010",
+						"end": "2022",
+						"data_source": ["MAMPU"]
+					},
+					"metadata_neutral": {
+						"data_as_of": "2022-12-31 23:59",
+						"last_updated": "2023-01-25 12:00",
+						"next_update": "2023-01-26 12:00"
+					},
+					"metadata_lang": {
+						"en": {
+							"methodology": "Lorem ipsum",
+							"caveat": "Lorem ipsum",
+							"publication": "Lorem ipsum"
+						},
+						"bm": {
+							"methodology": "Lorem ipsum",
+							"caveat": "Lorem ipsum",
+							"publication": "Lorem ipsum"
+						}
+					},
+					"chart": {
+						"chart_type": "PYRAMID",
+						"chart_filters": {
+							"SLICE_BY": ["ethnicity"],
+							"precision": 0
+						},
+						"chart_variables": {
+							"parents": ["ethnicity"],
+							"x": "age",
+							"y": ["male", "female"]
+						}
+					},
+					"translations": {
+						"en": {
+							"x": "Age",
+							"y1": "Male",
+							"y2": "Female"
+						},
+						"bm": {
+							"x": "Negeri",
+							"y1": "Lelaki",
+							"y2": "Perempuan"
+						}
+					}
+				}
+			}
+		]
+	}
 }

--- a/catalog/mwe_scatter.json
+++ b/catalog/mwe_scatter.json
@@ -35,7 +35,7 @@
 					"catalog_filters": {
 						"frequency": "YEARLY",
 						"geography": ["STATE", "NATIONAL"],
-						"demographic": ["SEX"],
+						"demography": ["SEX"],
 						"start": "2006",
 						"end": "2023",
 						"data_source": ["MAMPU"]

--- a/catalog/mwe_scatter.json
+++ b/catalog/mwe_scatter.json
@@ -1,74 +1,74 @@
 {
-  "file": {
-    "manual_trigger": "",
-    "bucket": "dgmy-public-mwe",
-    "file_name": "mwe_scatterplot",
-    "category": "METADATA",
-    "category_en": "Site Metadata",
-    "category_bm": "Metadata Portal",
-    "subcategory": "SAMPLE_CHART",
-    "subcategory_en": "Chart Samples",
-    "subcategory_bm": "Contoh Carta",
-    "description": {
-      "en": "Lorem ipsum.",
-      "bm": "Lorem ipsum."
-    },
-    "link_parquet": "https://dgmy-public-mwe.s3.ap-southeast-1.amazonaws.com/mwe_scatterplot.parquet",
-    "link_csv": "https://dgmy-public-mwe.s3.ap-southeast-1.amazonaws.com/mwe_scatterplot.csv",
-    "variables": [
-      {
-        "id": -1,
-        "name": "date",
-        "title_en": "Date",
-        "title_bm": "Tarikh",
-        "desc_en": "[Date] The date in YYYY-MM-DD format",
-        "desc_bm": "[Tarikh] Tarikh dalam format YYYY-MM-DD"
-      },
-      {
-        "id": 0,
-        "name": "mwe_scatterplot",
-        "title_en": "Scatter Plot",
-        "title_bm": "Scatter Plot",
-        "desc_en": "A precise, succinct description of this chart",
-        "desc_bm": "A precise, succinct description of this chart",
-        "catalog_data": {
-          "catalog_filters": {
-            "frequency": "YEARLY",
-            "geographic": ["STATE", "NATIONAL"],
-            "demographic": ["SEX"],
-            "start": "2006",
-            "end": "2023",
-            "data_source": ["MAMPU"]
-          },
-          "metadata_neutral": {
-            "data_as_of": "2023-04-03 23:59",
-            "last_updated": "2023-04-04 06:00",
-            "next_update": "2023-04-05 06:00"
-          },
-          "metadata_lang": {
-            "en": {
-              "methodology": "Lorem Ipsum is simply dummy text of the printing and typesetting industry. Lorem Ipsum has been the industry's standard dummy text ever since the 1500s, when an unknown printer took a galley of type and scrambled it to make a type specimen book.",
-              "caveat": "Contrary to popular belief, Lorem Ipsum is not simply random text. It has roots in a piece of classical Latin literature from 45 BC, making it over 2000 years old. Richard McClintock, a Latin professor at Hampden-Sydney College in Virginia, looked up one of the more obscure Latin words, consectetur, from a Lorem Ipsum passage, and going through the cites of the word in classical literature, discovered the undoubtable source.",
-              "publication": "Lorem Ipsum comes from sections 1.10.32 and 1.10.33 of 'de Finibus Bonorum et Malorum' (The Extremes of Good and Evil) by Cicero, written in 45 BC. This book is a treatise on the theory of ethics, very popular during the Renaissance. The first line of Lorem Ipsum, 'Lorem ipsum dolor sit amet..'', comes from a line in section 1.10.32."
-            },
-            "bm": {
-              "methodology": "Lorem Ipsum is simply dummy text of the printing and typesetting industry. Lorem Ipsum has been the industry's standard dummy text ever since the 1500s, when an unknown printer took a galley of type and scrambled it to make a type specimen book.",
-              "caveat": "Contrary to popular belief, Lorem Ipsum is not simply random text. It has roots in a piece of classical Latin literature from 45 BC, making it over 2000 years old. Richard McClintock, a Latin professor at Hampden-Sydney College in Virginia, looked up one of the more obscure Latin words, consectetur, from a Lorem Ipsum passage, and going through the cites of the word in classical literature, discovered the undoubtable source.",
-              "publication": "Lorem Ipsum comes from sections 1.10.32 and 1.10.33 of 'de Finibus Bonorum et Malorum' (The Extremes of Good and Evil) by Cicero, written in 45 BC. This book is a treatise on the theory of ethics, very popular during the Renaissance. The first line of Lorem Ipsum, 'Lorem ipsum dolor sit amet..'', comes from a line in section 1.10.32."
-            }
-          },
-          "chart": {
-            "chart_type": "SCATTER",
-            "chart_filters": {
-              "SLICE_BY": [],
-              "precision": 0
-            },
-            "chart_variables": {
-              "parents": []
-            }
-          }
-        }
-      }
-    ]
-  }
+	"file": {
+		"manual_trigger": "",
+		"bucket": "dgmy-public-mwe",
+		"file_name": "mwe_scatterplot",
+		"category": "METADATA",
+		"category_en": "Site Metadata",
+		"category_bm": "Metadata Portal",
+		"subcategory": "SAMPLE_CHART",
+		"subcategory_en": "Chart Samples",
+		"subcategory_bm": "Contoh Carta",
+		"description": {
+			"en": "Lorem ipsum.",
+			"bm": "Lorem ipsum."
+		},
+		"link_parquet": "https://dgmy-public-mwe.s3.ap-southeast-1.amazonaws.com/mwe_scatterplot.parquet",
+		"link_csv": "https://dgmy-public-mwe.s3.ap-southeast-1.amazonaws.com/mwe_scatterplot.csv",
+		"variables": [
+			{
+				"id": -1,
+				"name": "date",
+				"title_en": "Date",
+				"title_bm": "Tarikh",
+				"desc_en": "[Date] The date in YYYY-MM-DD format",
+				"desc_bm": "[Tarikh] Tarikh dalam format YYYY-MM-DD"
+			},
+			{
+				"id": 0,
+				"name": "mwe_scatterplot",
+				"title_en": "Scatter Plot",
+				"title_bm": "Scatter Plot",
+				"desc_en": "A precise, succinct description of this chart",
+				"desc_bm": "A precise, succinct description of this chart",
+				"catalog_data": {
+					"catalog_filters": {
+						"frequency": "YEARLY",
+						"geography": ["STATE", "NATIONAL"],
+						"demographic": ["SEX"],
+						"start": "2006",
+						"end": "2023",
+						"data_source": ["MAMPU"]
+					},
+					"metadata_neutral": {
+						"data_as_of": "2023-04-03 23:59",
+						"last_updated": "2023-04-04 06:00",
+						"next_update": "2023-04-05 06:00"
+					},
+					"metadata_lang": {
+						"en": {
+							"methodology": "Lorem Ipsum is simply dummy text of the printing and typesetting industry. Lorem Ipsum has been the industry's standard dummy text ever since the 1500s, when an unknown printer took a galley of type and scrambled it to make a type specimen book.",
+							"caveat": "Contrary to popular belief, Lorem Ipsum is not simply random text. It has roots in a piece of classical Latin literature from 45 BC, making it over 2000 years old. Richard McClintock, a Latin professor at Hampden-Sydney College in Virginia, looked up one of the more obscure Latin words, consectetur, from a Lorem Ipsum passage, and going through the cites of the word in classical literature, discovered the undoubtable source.",
+							"publication": "Lorem Ipsum comes from sections 1.10.32 and 1.10.33 of 'de Finibus Bonorum et Malorum' (The Extremes of Good and Evil) by Cicero, written in 45 BC. This book is a treatise on the theory of ethics, very popular during the Renaissance. The first line of Lorem Ipsum, 'Lorem ipsum dolor sit amet..'', comes from a line in section 1.10.32."
+						},
+						"bm": {
+							"methodology": "Lorem Ipsum is simply dummy text of the printing and typesetting industry. Lorem Ipsum has been the industry's standard dummy text ever since the 1500s, when an unknown printer took a galley of type and scrambled it to make a type specimen book.",
+							"caveat": "Contrary to popular belief, Lorem Ipsum is not simply random text. It has roots in a piece of classical Latin literature from 45 BC, making it over 2000 years old. Richard McClintock, a Latin professor at Hampden-Sydney College in Virginia, looked up one of the more obscure Latin words, consectetur, from a Lorem Ipsum passage, and going through the cites of the word in classical literature, discovered the undoubtable source.",
+							"publication": "Lorem Ipsum comes from sections 1.10.32 and 1.10.33 of 'de Finibus Bonorum et Malorum' (The Extremes of Good and Evil) by Cicero, written in 45 BC. This book is a treatise on the theory of ethics, very popular during the Renaissance. The first line of Lorem Ipsum, 'Lorem ipsum dolor sit amet..'', comes from a line in section 1.10.32."
+						}
+					},
+					"chart": {
+						"chart_type": "SCATTER",
+						"chart_filters": {
+							"SLICE_BY": [],
+							"precision": 0
+						},
+						"chart_variables": {
+							"parents": []
+						}
+					}
+				}
+			}
+		]
+	}
 }

--- a/catalog/mwe_stacked_area.json
+++ b/catalog/mwe_stacked_area.json
@@ -53,7 +53,7 @@
 						"frequency": "DAILY",
 						"limit_frequency": false,
 						"geography": ["STATE", "NATIONAL"],
-						"demographic": ["SEX", "MARITAL"],
+						"demography": ["SEX", "MARITAL"],
 						"start": "2006",
 						"end": "2023",
 						"data_source": ["MAMPU"]

--- a/catalog/mwe_stacked_area.json
+++ b/catalog/mwe_stacked_area.json
@@ -1,97 +1,97 @@
 {
-  "file": {
-    "manual_trigger": "",
-    "bucket": "dgmy-public-mwe",
-    "file_name": "mwe_stacked_area",
-    "category": "METADATA",
-    "category_en": "Site Metadata",
-    "category_bm": "Metadata Portal",
-    "subcategory": "SAMPLE_CHART",
-    "subcategory_en": "Chart Samples",
-    "subcategory_bm": "Contoh Carta",
-    "description": {
-      "en": "Lorem ipsum.",
-      "bm": "Lorem ipsum."
-    },
-    "link_parquet": "https://dgmy-public-mwe.s3.ap-southeast-1.amazonaws.com/mwe_timeseries.parquet",
-    "link_csv": "https://dgmy-public-mwe.s3.ap-southeast-1.amazonaws.com/mwe_timeseries.csv",
-    "variables": [
-      {
-        "id": -1,
-        "name": "date",
-        "title_en": "Date",
-        "title_bm": "Tarikh",
-        "desc_en": "[Date] The date in YYYY-MM-DD format",
-        "desc_bm": "[Tarikh] Tarikh dalam format YYYY-MM-DD"
-      },
-      {
-        "id": -1,
-        "name": "state",
-        "title_en": "State",
-        "title_bm": "Negeri",
-        "desc_en": "[Categorical] Name of the state (16 in total) or Malaysia",
-        "desc_bm": "[Kategori] Name negeri (16 keseluruhan) atau Malaysia"
-      },
-      {
-        "id": -1,
-        "name": "var1",
-        "title_en": "Variable 1",
-        "title_bm": "Pembolehubah 1",
-        "desc_en": "[Integer] A precise, succinct description of this variable",
-        "desc_bm": "[Integer] A precise, succinct description of this variable"
-      },
-      {
-        "id": 0,
-        "name": "mwe_stacked_area",
-        "title_en": "Stacked Area",
-        "title_bm": "Kawasan Bertindan",
-        "desc_en": "A precise, succinct description of this chart",
-        "desc_bm": "A precise, succinct description of this chart",
-        "catalog_data": {
-          "id": 0,
-          "catalog_filters": {
-            "frequency": "DAILY",
-            "limit_frequency": false,
-            "geographic": ["STATE", "NATIONAL"],
-            "demographic": ["SEX", "MARITAL"],
-            "start": "2006",
-            "end": "2023",
-            "data_source": ["MAMPU"]
-          },
-          "metadata_neutral": {
-            "data_as_of": "2023-04-03 23:59",
-            "last_updated": "2023-04-04 06:00",
-            "next_update": "2023-04-05 06:00"
-          },
-          "metadata_lang": {
-            "en": {
-              "methodology": "Lorem Ipsum is simply dummy text of the printing and typesetting industry. Lorem Ipsum has been the industry's standard dummy text ever since the 1500s, when an unknown printer took a galley of type and scrambled it to make a type specimen book.",
-              "caveat": "Contrary to popular belief, Lorem Ipsum is not simply random text. It has roots in a piece of classical Latin literature from 45 BC, making it over 2000 years old. Richard McClintock, a Latin professor at Hampden-Sydney College in Virginia, looked up one of the more obscure Latin words, consectetur, from a Lorem Ipsum passage, and going through the cites of the word in classical literature, discovered the undoubtable source.",
-              "publication": "Lorem Ipsum comes from sections 1.10.32 and 1.10.33 of 'de Finibus Bonorum et Malorum' (The Extremes of Good and Evil) by Cicero, written in 45 BC. This book is a treatise on the theory of ethics, very popular during the Renaissance. The first line of Lorem Ipsum, 'Lorem ipsum dolor sit amet..'', comes from a line in section 1.10.32."
-            },
-            "bm": {
-              "methodology": "Lorem Ipsum is simply dummy text of the printing and typesetting industry. Lorem Ipsum has been the industry's standard dummy text ever since the 1500s, when an unknown printer took a galley of type and scrambled it to make a type specimen book.",
-              "caveat": "Contrary to popular belief, Lorem Ipsum is not simply random text. It has roots in a piece of classical Latin literature from 45 BC, making it over 2000 years old. Richard McClintock, a Latin professor at Hampden-Sydney College in Virginia, looked up one of the more obscure Latin words, consectetur, from a Lorem Ipsum passage, and going through the cites of the word in classical literature, discovered the undoubtable source.",
-              "publication": "Lorem Ipsum comes from sections 1.10.32 and 1.10.33 of 'de Finibus Bonorum et Malorum' (The Extremes of Good and Evil) by Cicero, written in 45 BC. This book is a treatise on the theory of ethics, very popular during the Renaissance. The first line of Lorem Ipsum, 'Lorem ipsum dolor sit amet..'', comes from a line in section 1.10.32."
-            }
-          },
-          "chart": {
-            "chart_type": "STACKED_AREA",
-            "chart_filters": {
-              "SLICE_BY": ["state"],
-              "precision": 0
-            },
-            "chart_variables": {
-              "parents": ["state"],
-              "operation": "SUM",
-              "format": {
-                "x": "date",
-                "y": ["var1", "var2", "var3", "var4"]
-              }
-            }
-          }
-        }
-      }
-    ]
-  }
+	"file": {
+		"manual_trigger": "",
+		"bucket": "dgmy-public-mwe",
+		"file_name": "mwe_stacked_area",
+		"category": "METADATA",
+		"category_en": "Site Metadata",
+		"category_bm": "Metadata Portal",
+		"subcategory": "SAMPLE_CHART",
+		"subcategory_en": "Chart Samples",
+		"subcategory_bm": "Contoh Carta",
+		"description": {
+			"en": "Lorem ipsum.",
+			"bm": "Lorem ipsum."
+		},
+		"link_parquet": "https://dgmy-public-mwe.s3.ap-southeast-1.amazonaws.com/mwe_timeseries.parquet",
+		"link_csv": "https://dgmy-public-mwe.s3.ap-southeast-1.amazonaws.com/mwe_timeseries.csv",
+		"variables": [
+			{
+				"id": -1,
+				"name": "date",
+				"title_en": "Date",
+				"title_bm": "Tarikh",
+				"desc_en": "[Date] The date in YYYY-MM-DD format",
+				"desc_bm": "[Tarikh] Tarikh dalam format YYYY-MM-DD"
+			},
+			{
+				"id": -1,
+				"name": "state",
+				"title_en": "State",
+				"title_bm": "Negeri",
+				"desc_en": "[Categorical] Name of the state (16 in total) or Malaysia",
+				"desc_bm": "[Kategori] Name negeri (16 keseluruhan) atau Malaysia"
+			},
+			{
+				"id": -1,
+				"name": "var1",
+				"title_en": "Variable 1",
+				"title_bm": "Pembolehubah 1",
+				"desc_en": "[Integer] A precise, succinct description of this variable",
+				"desc_bm": "[Integer] A precise, succinct description of this variable"
+			},
+			{
+				"id": 0,
+				"name": "mwe_stacked_area",
+				"title_en": "Stacked Area",
+				"title_bm": "Kawasan Bertindan",
+				"desc_en": "A precise, succinct description of this chart",
+				"desc_bm": "A precise, succinct description of this chart",
+				"catalog_data": {
+					"id": 0,
+					"catalog_filters": {
+						"frequency": "DAILY",
+						"limit_frequency": false,
+						"geography": ["STATE", "NATIONAL"],
+						"demographic": ["SEX", "MARITAL"],
+						"start": "2006",
+						"end": "2023",
+						"data_source": ["MAMPU"]
+					},
+					"metadata_neutral": {
+						"data_as_of": "2023-04-03 23:59",
+						"last_updated": "2023-04-04 06:00",
+						"next_update": "2023-04-05 06:00"
+					},
+					"metadata_lang": {
+						"en": {
+							"methodology": "Lorem Ipsum is simply dummy text of the printing and typesetting industry. Lorem Ipsum has been the industry's standard dummy text ever since the 1500s, when an unknown printer took a galley of type and scrambled it to make a type specimen book.",
+							"caveat": "Contrary to popular belief, Lorem Ipsum is not simply random text. It has roots in a piece of classical Latin literature from 45 BC, making it over 2000 years old. Richard McClintock, a Latin professor at Hampden-Sydney College in Virginia, looked up one of the more obscure Latin words, consectetur, from a Lorem Ipsum passage, and going through the cites of the word in classical literature, discovered the undoubtable source.",
+							"publication": "Lorem Ipsum comes from sections 1.10.32 and 1.10.33 of 'de Finibus Bonorum et Malorum' (The Extremes of Good and Evil) by Cicero, written in 45 BC. This book is a treatise on the theory of ethics, very popular during the Renaissance. The first line of Lorem Ipsum, 'Lorem ipsum dolor sit amet..'', comes from a line in section 1.10.32."
+						},
+						"bm": {
+							"methodology": "Lorem Ipsum is simply dummy text of the printing and typesetting industry. Lorem Ipsum has been the industry's standard dummy text ever since the 1500s, when an unknown printer took a galley of type and scrambled it to make a type specimen book.",
+							"caveat": "Contrary to popular belief, Lorem Ipsum is not simply random text. It has roots in a piece of classical Latin literature from 45 BC, making it over 2000 years old. Richard McClintock, a Latin professor at Hampden-Sydney College in Virginia, looked up one of the more obscure Latin words, consectetur, from a Lorem Ipsum passage, and going through the cites of the word in classical literature, discovered the undoubtable source.",
+							"publication": "Lorem Ipsum comes from sections 1.10.32 and 1.10.33 of 'de Finibus Bonorum et Malorum' (The Extremes of Good and Evil) by Cicero, written in 45 BC. This book is a treatise on the theory of ethics, very popular during the Renaissance. The first line of Lorem Ipsum, 'Lorem ipsum dolor sit amet..'', comes from a line in section 1.10.32."
+						}
+					},
+					"chart": {
+						"chart_type": "STACKED_AREA",
+						"chart_filters": {
+							"SLICE_BY": ["state"],
+							"precision": 0
+						},
+						"chart_variables": {
+							"parents": ["state"],
+							"operation": "SUM",
+							"format": {
+								"x": "date",
+								"y": ["var1", "var2", "var3", "var4"]
+							}
+						}
+					}
+				}
+			}
+		]
+	}
 }

--- a/catalog/mwe_stacked_bar.json
+++ b/catalog/mwe_stacked_bar.json
@@ -51,7 +51,7 @@
 					"catalog_filters": {
 						"frequency": "MONTHLY",
 						"geography": ["NATIONAL"],
-						"demographic": [],
+						"demography": [],
 						"start": "2006",
 						"end": "2023",
 						"data_source": ["MAMPU"]

--- a/catalog/mwe_stacked_bar.json
+++ b/catalog/mwe_stacked_bar.json
@@ -1,110 +1,110 @@
 {
-  "file": {
-    "manual_trigger": "1",
-    "bucket": "dgmy-public-mwe",
-    "file_name": "mwe_stacked_bar",
-    "category": "METADATA",
-    "category_en": "Site Metadata",
-    "category_bm": "Metadata Portal",
-    "subcategory": "SAMPLE_CHART",
-    "subcategory_en": "Chart Samples",
-    "subcategory_bm": "Contoh Carta",
-    "description": {
-      "en": "Lorem ipsum.",
-      "bm": "Lorem ipsum."
-    },
-    "link_parquet": "https://dgmy-public-mwe.s3.ap-southeast-1.amazonaws.com/mwe_bar.parquet",
-    "link_csv": "https://dgmy-public-mwe.s3.ap-southeast-1.amazonaws.com/mwe_bar.csv",
-    "variables": [
-      {
-        "id": -1,
-        "name": "date",
-        "title_en": "Date",
-        "title_bm": "Tarikh",
-        "desc_en": "[Date] The date in YYYY-MM-DD format",
-        "desc_bm": "[Tarikh] Tarikh dalam format YYYY-MM-DD"
-      },
-      {
-        "id": -1,
-        "name": "state",
-        "title_en": "State",
-        "title_bm": "Negeri",
-        "desc_en": "[Categorical] Name of the state (16 in total) or Malaysia",
-        "desc_bm": "[Kategori] Name negeri (16 keseluruhan) atau Malaysia"
-      },
-      {
-        "id": -1,
-        "name": "var1",
-        "title_en": "Variable 1",
-        "title_bm": "Pembolehubah 1",
-        "desc_en": "[Integer] A precise, succinct description of this variable",
-        "desc_bm": "[Integer] A precise, succinct description of this variable"
-      },
-      {
-        "id": 0,
-        "name": "mwe_stacked_bar",
-        "title_en": "Stacked Bar",
-        "title_bm": "Bar Bertindan",
-        "desc_en": "A precise, succinct description of this chart",
-        "desc_bm": "A precise, succinct description of this chart",
-        "catalog_data": {
-          "catalog_filters": {
-            "frequency": "MONTHLY",
-            "geographic": ["NATIONAL"],
-            "demographic": [],
-            "start": "2006",
-            "end": "2023",
-            "data_source": ["MAMPU"]
-          },
-          "metadata_neutral": {
-            "data_as_of": "2023-04-03 23:59",
-            "last_updated": "2023-04-04 06:00",
-            "next_update": "2023-04-05 06:00"
-          },
-          "metadata_lang": {
-            "en": {
-              "methodology": "Lorem Ipsum is simply dummy text of the printing and typesetting industry. Lorem Ipsum has been the industry's standard dummy text ever since the 1500s, when an unknown printer took a galley of type and scrambled it to make a type specimen book.",
-              "caveat": "Contrary to popular belief, Lorem Ipsum is not simply random text. It has roots in a piece of classical Latin literature from 45 BC, making it over 2000 years old. Richard McClintock, a Latin professor at Hampden-Sydney College in Virginia, looked up one of the more obscure Latin words, consectetur, from a Lorem Ipsum passage, and going through the cites of the word in classical literature, discovered the undoubtable source.",
-              "publication": "Lorem Ipsum comes from sections 1.10.32 and 1.10.33 of 'de Finibus Bonorum et Malorum' (The Extremes of Good and Evil) by Cicero, written in 45 BC. This book is a treatise on the theory of ethics, very popular during the Renaissance. The first line of Lorem Ipsum, 'Lorem ipsum dolor sit amet..'', comes from a line in section 1.10.32."
-            },
-            "bm": {
-              "methodology": "Lorem Ipsum is simply dummy text of the printing and typesetting industry. Lorem Ipsum has been the industry's standard dummy text ever since the 1500s, when an unknown printer took a galley of type and scrambled it to make a type specimen book.",
-              "caveat": "Contrary to popular belief, Lorem Ipsum is not simply random text. It has roots in a piece of classical Latin literature from 45 BC, making it over 2000 years old. Richard McClintock, a Latin professor at Hampden-Sydney College in Virginia, looked up one of the more obscure Latin words, consectetur, from a Lorem Ipsum passage, and going through the cites of the word in classical literature, discovered the undoubtable source.",
-              "publication": "Lorem Ipsum comes from sections 1.10.32 and 1.10.33 of 'de Finibus Bonorum et Malorum' (The Extremes of Good and Evil) by Cicero, written in 45 BC. This book is a treatise on the theory of ethics, very popular during the Renaissance. The first line of Lorem Ipsum, 'Lorem ipsum dolor sit amet..'', comes from a line in section 1.10.32."
-            }
-          },
-          "chart": {
-            "chart_type": "STACKED_BAR",
-            "chart_filters": {
-              "SLICE_BY": [],
-              "precision": 0
-            },
-            "chart_variables": {
-              "parents": [],
-              "format": {
-                "x": "state",
-                "y": ["var1", "var2", "var3", "var4"]
-              }
-            }
-          },
-          "translations": {
-            "en": {
-              "x": "State",
-              "y1": "Variable 1",
-              "y2": "Variable 2",
-              "y3": "Variable 3",
-              "y4": "Variable 4"
-            },
-            "bm": {
-              "x": "Negeri",
-              "y1": "Pembolehubah 1",
-              "y2": "Pembolehubah 2",
-              "y3": "Pembolehubah 3",
-              "y4": "Pembolehubah 4"
-            }
-          }
-        }
-      }
-    ]
-  }
+	"file": {
+		"manual_trigger": "1",
+		"bucket": "dgmy-public-mwe",
+		"file_name": "mwe_stacked_bar",
+		"category": "METADATA",
+		"category_en": "Site Metadata",
+		"category_bm": "Metadata Portal",
+		"subcategory": "SAMPLE_CHART",
+		"subcategory_en": "Chart Samples",
+		"subcategory_bm": "Contoh Carta",
+		"description": {
+			"en": "Lorem ipsum.",
+			"bm": "Lorem ipsum."
+		},
+		"link_parquet": "https://dgmy-public-mwe.s3.ap-southeast-1.amazonaws.com/mwe_bar.parquet",
+		"link_csv": "https://dgmy-public-mwe.s3.ap-southeast-1.amazonaws.com/mwe_bar.csv",
+		"variables": [
+			{
+				"id": -1,
+				"name": "date",
+				"title_en": "Date",
+				"title_bm": "Tarikh",
+				"desc_en": "[Date] The date in YYYY-MM-DD format",
+				"desc_bm": "[Tarikh] Tarikh dalam format YYYY-MM-DD"
+			},
+			{
+				"id": -1,
+				"name": "state",
+				"title_en": "State",
+				"title_bm": "Negeri",
+				"desc_en": "[Categorical] Name of the state (16 in total) or Malaysia",
+				"desc_bm": "[Kategori] Name negeri (16 keseluruhan) atau Malaysia"
+			},
+			{
+				"id": -1,
+				"name": "var1",
+				"title_en": "Variable 1",
+				"title_bm": "Pembolehubah 1",
+				"desc_en": "[Integer] A precise, succinct description of this variable",
+				"desc_bm": "[Integer] A precise, succinct description of this variable"
+			},
+			{
+				"id": 0,
+				"name": "mwe_stacked_bar",
+				"title_en": "Stacked Bar",
+				"title_bm": "Bar Bertindan",
+				"desc_en": "A precise, succinct description of this chart",
+				"desc_bm": "A precise, succinct description of this chart",
+				"catalog_data": {
+					"catalog_filters": {
+						"frequency": "MONTHLY",
+						"geography": ["NATIONAL"],
+						"demographic": [],
+						"start": "2006",
+						"end": "2023",
+						"data_source": ["MAMPU"]
+					},
+					"metadata_neutral": {
+						"data_as_of": "2023-04-03 23:59",
+						"last_updated": "2023-04-04 06:00",
+						"next_update": "2023-04-05 06:00"
+					},
+					"metadata_lang": {
+						"en": {
+							"methodology": "Lorem Ipsum is simply dummy text of the printing and typesetting industry. Lorem Ipsum has been the industry's standard dummy text ever since the 1500s, when an unknown printer took a galley of type and scrambled it to make a type specimen book.",
+							"caveat": "Contrary to popular belief, Lorem Ipsum is not simply random text. It has roots in a piece of classical Latin literature from 45 BC, making it over 2000 years old. Richard McClintock, a Latin professor at Hampden-Sydney College in Virginia, looked up one of the more obscure Latin words, consectetur, from a Lorem Ipsum passage, and going through the cites of the word in classical literature, discovered the undoubtable source.",
+							"publication": "Lorem Ipsum comes from sections 1.10.32 and 1.10.33 of 'de Finibus Bonorum et Malorum' (The Extremes of Good and Evil) by Cicero, written in 45 BC. This book is a treatise on the theory of ethics, very popular during the Renaissance. The first line of Lorem Ipsum, 'Lorem ipsum dolor sit amet..'', comes from a line in section 1.10.32."
+						},
+						"bm": {
+							"methodology": "Lorem Ipsum is simply dummy text of the printing and typesetting industry. Lorem Ipsum has been the industry's standard dummy text ever since the 1500s, when an unknown printer took a galley of type and scrambled it to make a type specimen book.",
+							"caveat": "Contrary to popular belief, Lorem Ipsum is not simply random text. It has roots in a piece of classical Latin literature from 45 BC, making it over 2000 years old. Richard McClintock, a Latin professor at Hampden-Sydney College in Virginia, looked up one of the more obscure Latin words, consectetur, from a Lorem Ipsum passage, and going through the cites of the word in classical literature, discovered the undoubtable source.",
+							"publication": "Lorem Ipsum comes from sections 1.10.32 and 1.10.33 of 'de Finibus Bonorum et Malorum' (The Extremes of Good and Evil) by Cicero, written in 45 BC. This book is a treatise on the theory of ethics, very popular during the Renaissance. The first line of Lorem Ipsum, 'Lorem ipsum dolor sit amet..'', comes from a line in section 1.10.32."
+						}
+					},
+					"chart": {
+						"chart_type": "STACKED_BAR",
+						"chart_filters": {
+							"SLICE_BY": [],
+							"precision": 0
+						},
+						"chart_variables": {
+							"parents": [],
+							"format": {
+								"x": "state",
+								"y": ["var1", "var2", "var3", "var4"]
+							}
+						}
+					},
+					"translations": {
+						"en": {
+							"x": "State",
+							"y1": "Variable 1",
+							"y2": "Variable 2",
+							"y3": "Variable 3",
+							"y4": "Variable 4"
+						},
+						"bm": {
+							"x": "Negeri",
+							"y1": "Pembolehubah 1",
+							"y2": "Pembolehubah 2",
+							"y3": "Pembolehubah 3",
+							"y4": "Pembolehubah 4"
+						}
+					}
+				}
+			}
+		]
+	}
 }

--- a/catalog/mwe_table.json
+++ b/catalog/mwe_table.json
@@ -35,7 +35,7 @@
 					"catalog_filters": {
 						"frequency": "YEARLY",
 						"geography": ["STATE", "NATIONAL"],
-						"demographic": ["SEX", "MARITAL"],
+						"demography": ["SEX", "MARITAL"],
 						"start": "2006",
 						"end": "2023",
 						"data_source": ["MAMPU"]

--- a/catalog/mwe_table.json
+++ b/catalog/mwe_table.json
@@ -1,191 +1,180 @@
 {
-  "file": {
-    "manual_trigger": "2",
-    "bucket": "dgmy-public-mwe",
-    "file_name": "mwe_table",
-    "category": "METADATA",
-    "category_en": "Site Metadata",
-    "category_bm": "Metadata Portal",
-    "subcategory": "SAMPLE_CHART",
-    "subcategory_en": "Chart Samples",
-    "subcategory_bm": "Contoh Carta",
-    "description": {
-      "en": "Lorem ipsum.",
-      "bm": "Lorem ipsum."
-    },
-    "link_parquet": "https://dgmy-public-mwe.s3.ap-southeast-1.amazonaws.com/mwe_table.parquet",
-    "link_csv": "https://dgmy-public-mwe.s3.ap-southeast-1.amazonaws.com/mwe_table.csv",
-    "variables": [
-      {
-        "id": -1,
-        "name": "date",
-        "title_en": "Date",
-        "title_bm": "Tarikh",
-        "desc_en": "[Date] The date in YYYY-MM-DD format",
-        "desc_bm": "[Tarikh] Tarikh dalam format YYYY-MM-DD"
-      },
-      {
-        "id": 0,
-        "name": "mwe_table",
-        "title_en": "Table",
-        "title_bm": "Jadual",
-        "desc_en": "A precise, succinct description of this chart",
-        "desc_bm": "A precise, succinct description of this chart",
-        "catalog_data": {
-          "catalog_filters": {
-            "frequency": "YEARLY",
-            "geographic": [
-              "STATE",
-              "NATIONAL"
-            ],
-            "demographic": [
-              "SEX",
-              "MARITAL"
-            ],
-            "start": "2006",
-            "end": "2023",
-            "data_source": [
-              "MAMPU"
-            ]
-          },
-          "metadata_neutral": {
-            "data_as_of": "2023-04-03 23:59",
-            "last_updated": "2023-04-04 06:00",
-            "next_update": "2023-04-05 06:00"
-          },
-          "metadata_lang": {
-            "en": {
-              "methodology": "Lorem Ipsum is simply dummy text of the printing and typesetting industry. Lorem Ipsum has been the industry's standard dummy text ever since the 1500s, when an unknown printer took a galley of type and scrambled it to make a type specimen book.",
-              "caveat": "Contrary to popular belief, Lorem Ipsum is not simply random text. It has roots in a piece of classical Latin literature from 45 BC, making it over 2000 years old. Richard McClintock, a Latin professor at Hampden-Sydney College in Virginia, looked up one of the more obscure Latin words, consectetur, from a Lorem Ipsum passage, and going through the cites of the word in classical literature, discovered the undoubtable source.",
-              "publication": "Lorem Ipsum comes from sections 1.10.32 and 1.10.33 of 'de Finibus Bonorum et Malorum' (The Extremes of Good and Evil) by Cicero, written in 45 BC. This book is a treatise on the theory of ethics, very popular during the Renaissance. The first line of Lorem Ipsum, 'Lorem ipsum dolor sit amet..'', comes from a line in section 1.10.32."
-            },
-            "bm": {
-              "methodology": "Lorem Ipsum is simply dummy text of the printing and typesetting industry. Lorem Ipsum has been the industry's standard dummy text ever since the 1500s, when an unknown printer took a galley of type and scrambled it to make a type specimen book.",
-              "caveat": "Contrary to popular belief, Lorem Ipsum is not simply random text. It has roots in a piece of classical Latin literature from 45 BC, making it over 2000 years old. Richard McClintock, a Latin professor at Hampden-Sydney College in Virginia, looked up one of the more obscure Latin words, consectetur, from a Lorem Ipsum passage, and going through the cites of the word in classical literature, discovered the undoubtable source.",
-              "publication": "Lorem Ipsum comes from sections 1.10.32 and 1.10.33 of 'de Finibus Bonorum et Malorum' (The Extremes of Good and Evil) by Cicero, written in 45 BC. This book is a treatise on the theory of ethics, very popular during the Renaissance. The first line of Lorem Ipsum, 'Lorem ipsum dolor sit amet..'', comes from a line in section 1.10.32."
-            }
-          },
-          "chart": {
-            "chart_type": "TABLE",
-            "chart_filters": {
-              "SLICE_BY": [],
-              "precision": 0
-            },
-            "chart_variables": {
-              "parents": [],
-              "exclude": [],
-              "freeze": [
-                "state",
-                "parlimen"
-              ]
-            }
-          },
-          "translations": {
-            "en": {
-              "state": "State",
-              "parlimen": "Parliament",
-              "area_km2": "Area (km²)",
-              "population_total": "Total Population",
-              "nationality_citizen": "Citizen",
-              "nationality_non_citizen": "Non-citizen",
-              "sex_male": "Male",
-              "sex_female": "Female",
-              "ethnicity_proportion_bumi": "Bumiputera (%)",
-              "ethnicity_proportion_chinese": "Chinese (%)",
-              "ethnicity_proportion_indian": "Indian (%)",
-              "ethnicity_proportion_other": "Other Ethnicities (%)",
-              "age_proportion_0_14": "0-14 Years (%)",
-              "age_proportion_15_64": "15-64 Years (%)",
-              "age_proportion_65_above": "65+ Years (%)",
-              "age_proportion_18_above": "18+ Years (%)",
-              "housing_total": "Total Housing",
-              "household_total": "Total Households",
-              "household_size_avg": "Average Household Size",
-              "live_births": "Total Live Births",
-              "live_births_male": "Male Live Births",
-              "live_births_female": "Female Live Births",
-              "deaths": "Total Deaths",
-              "deaths_male": "Male Deaths",
-              "deaths_female": "Female Deaths",
-              "labour_participation_rate": "Labour Participation Rate",
-              "labour_unemployment_rate": "Unemployment Rate",
-              "income_median": "Median Income",
-              "income_avg": "Average Income",
-              "expenditure_avg": "Average Expenditure",
-              "gini": "Gini Coefficient",
-              "poverty_incidence": "Poverty Incidence",
-              "sme_small": "Small SMEs",
-              "sme_micro": "Micro SMEs",
-              "sme_medium": "Medium SMEs",
-              "businesses_agriculture": "Agriculture Businesses",
-              "businesses_crops": "Crop-related Businesses",
-              "businesses_livestock": "Livestock Businesses",
-              "businesses_fisheries": "Fisheries Businesses",
-              "businesses_forestry": "Forestry Businesses",
-              "businesses_mining": "Mining Businesses",
-              "businesses_manufacturing": "Manufacturing Businesses",
-              "businesses_construction": "Construction Businesses",
-              "businesses_services": "Service-related Businesses",
-              "utilities_pipedwater_home": "Piped Water (Home)",
-              "utilities_pipedwater_public": "Piped Water (Public)",
-              "utilities_pipedwater_other": "Piped Water (Other)",
-              "utilities_electricity_home": "Electricity (Home)",
-              "utilities_electricity_none": "No Electricity"
-            },
-            "bm": {
-              "state": "Negeri",
-              "parlimen": "Parlimen",
-              "area_km2": "Luas (km²)",
-              "population_total": "Jumlah Penduduk",
-              "nationality_citizen": "Warganegara",
-              "nationality_non_citizen": "Bukan Warganegara",
-              "sex_male": "Lelaki",
-              "sex_female": "Perempuan",
-              "ethnicity_proportion_bumi": "Bumiputera (%)",
-              "ethnicity_proportion_chinese": "Cina (%)",
-              "ethnicity_proportion_indian": "India (%)",
-              "ethnicity_proportion_other": "Kumpulan Etnik Lain (%)",
-              "age_proportion_0_14": "0-14 Tahun (%)",
-              "age_proportion_15_64": "15-64 Tahun (%)",
-              "age_proportion_65_above": "65+ Tahun (%)",
-              "age_proportion_18_above": "18+ Tahun (%)",
-              "housing_total": "Jumlah Perumahan",
-              "household_total": "Jumlah Isi Rumah",
-              "household_size_avg": "Purata Saiz Isi Rumah",
-              "live_births": "Jumlah Kelahiran Hidup",
-              "live_births_male": "Kelahiran Lelaki",
-              "live_births_female": "Kelahiran Perempuan",
-              "deaths": "Jumlah Kematian",
-              "deaths_male": "Kematian Lelaki",
-              "deaths_female": "Kematian Perempuan",
-              "labour_participation_rate": "Kadar Penyertaan Buruh",
-              "labour_unemployment_rate": "Kadar Pengangguran",
-              "income_median": "Pendapatan Median",
-              "income_avg": "Pendapatan Purata",
-              "expenditure_avg": "Perbelanjaan Purata",
-              "gini": "Pekali Gini",
-              "poverty_incidence": "Kekerapan Kemiskinan",
-              "sme_small": "PKS Kecil",
-              "sme_micro": "PKS Mikro",
-              "sme_medium": "PKS Sederhana",
-              "businesses_agriculture": "Perniagaan Pertanian",
-              "businesses_crops": "Perniagaan Tanaman",
-              "businesses_livestock": "Perniagaan Penternakan",
-              "businesses_fisheries": "Perniagaan Perikanan",
-              "businesses_forestry": "Perniagaan Perhutanan",
-              "businesses_mining": "Perniagaan Perlombongan",
-              "businesses_manufacturing": "Perniagaan Pengilangan",
-              "businesses_construction": "Perniagaan Pembinaan",
-              "businesses_services": "Perniagaan Perkhidmatan",
-              "utilities_pipedwater_home": "Air Paip (Rumah)",
-              "utilities_pipedwater_public": "Air Paip (Awam)",
-              "utilities_pipedwater_other": "Air Paip (Lain-lain)",
-              "utilities_electricity_home": "Elektrik (Rumah)",
-              "utilities_electricity_none": "Tiada Elektrik"
-            }
-          }
-        }
-      }
-    ]
-  }
+	"file": {
+		"manual_trigger": "2",
+		"bucket": "dgmy-public-mwe",
+		"file_name": "mwe_table",
+		"category": "METADATA",
+		"category_en": "Site Metadata",
+		"category_bm": "Metadata Portal",
+		"subcategory": "SAMPLE_CHART",
+		"subcategory_en": "Chart Samples",
+		"subcategory_bm": "Contoh Carta",
+		"description": {
+			"en": "Lorem ipsum.",
+			"bm": "Lorem ipsum."
+		},
+		"link_parquet": "https://dgmy-public-mwe.s3.ap-southeast-1.amazonaws.com/mwe_table.parquet",
+		"link_csv": "https://dgmy-public-mwe.s3.ap-southeast-1.amazonaws.com/mwe_table.csv",
+		"variables": [
+			{
+				"id": -1,
+				"name": "date",
+				"title_en": "Date",
+				"title_bm": "Tarikh",
+				"desc_en": "[Date] The date in YYYY-MM-DD format",
+				"desc_bm": "[Tarikh] Tarikh dalam format YYYY-MM-DD"
+			},
+			{
+				"id": 0,
+				"name": "mwe_table",
+				"title_en": "Table",
+				"title_bm": "Jadual",
+				"desc_en": "A precise, succinct description of this chart",
+				"desc_bm": "A precise, succinct description of this chart",
+				"catalog_data": {
+					"catalog_filters": {
+						"frequency": "YEARLY",
+						"geography": ["STATE", "NATIONAL"],
+						"demographic": ["SEX", "MARITAL"],
+						"start": "2006",
+						"end": "2023",
+						"data_source": ["MAMPU"]
+					},
+					"metadata_neutral": {
+						"data_as_of": "2023-04-03 23:59",
+						"last_updated": "2023-04-04 06:00",
+						"next_update": "2023-04-05 06:00"
+					},
+					"metadata_lang": {
+						"en": {
+							"methodology": "Lorem Ipsum is simply dummy text of the printing and typesetting industry. Lorem Ipsum has been the industry's standard dummy text ever since the 1500s, when an unknown printer took a galley of type and scrambled it to make a type specimen book.",
+							"caveat": "Contrary to popular belief, Lorem Ipsum is not simply random text. It has roots in a piece of classical Latin literature from 45 BC, making it over 2000 years old. Richard McClintock, a Latin professor at Hampden-Sydney College in Virginia, looked up one of the more obscure Latin words, consectetur, from a Lorem Ipsum passage, and going through the cites of the word in classical literature, discovered the undoubtable source.",
+							"publication": "Lorem Ipsum comes from sections 1.10.32 and 1.10.33 of 'de Finibus Bonorum et Malorum' (The Extremes of Good and Evil) by Cicero, written in 45 BC. This book is a treatise on the theory of ethics, very popular during the Renaissance. The first line of Lorem Ipsum, 'Lorem ipsum dolor sit amet..'', comes from a line in section 1.10.32."
+						},
+						"bm": {
+							"methodology": "Lorem Ipsum is simply dummy text of the printing and typesetting industry. Lorem Ipsum has been the industry's standard dummy text ever since the 1500s, when an unknown printer took a galley of type and scrambled it to make a type specimen book.",
+							"caveat": "Contrary to popular belief, Lorem Ipsum is not simply random text. It has roots in a piece of classical Latin literature from 45 BC, making it over 2000 years old. Richard McClintock, a Latin professor at Hampden-Sydney College in Virginia, looked up one of the more obscure Latin words, consectetur, from a Lorem Ipsum passage, and going through the cites of the word in classical literature, discovered the undoubtable source.",
+							"publication": "Lorem Ipsum comes from sections 1.10.32 and 1.10.33 of 'de Finibus Bonorum et Malorum' (The Extremes of Good and Evil) by Cicero, written in 45 BC. This book is a treatise on the theory of ethics, very popular during the Renaissance. The first line of Lorem Ipsum, 'Lorem ipsum dolor sit amet..'', comes from a line in section 1.10.32."
+						}
+					},
+					"chart": {
+						"chart_type": "TABLE",
+						"chart_filters": {
+							"SLICE_BY": [],
+							"precision": 0
+						},
+						"chart_variables": {
+							"parents": [],
+							"exclude": [],
+							"freeze": ["state", "parlimen"]
+						}
+					},
+					"translations": {
+						"en": {
+							"state": "State",
+							"parlimen": "Parliament",
+							"area_km2": "Area (km²)",
+							"population_total": "Total Population",
+							"nationality_citizen": "Citizen",
+							"nationality_non_citizen": "Non-citizen",
+							"sex_male": "Male",
+							"sex_female": "Female",
+							"ethnicity_proportion_bumi": "Bumiputera (%)",
+							"ethnicity_proportion_chinese": "Chinese (%)",
+							"ethnicity_proportion_indian": "Indian (%)",
+							"ethnicity_proportion_other": "Other Ethnicities (%)",
+							"age_proportion_0_14": "0-14 Years (%)",
+							"age_proportion_15_64": "15-64 Years (%)",
+							"age_proportion_65_above": "65+ Years (%)",
+							"age_proportion_18_above": "18+ Years (%)",
+							"housing_total": "Total Housing",
+							"household_total": "Total Households",
+							"household_size_avg": "Average Household Size",
+							"live_births": "Total Live Births",
+							"live_births_male": "Male Live Births",
+							"live_births_female": "Female Live Births",
+							"deaths": "Total Deaths",
+							"deaths_male": "Male Deaths",
+							"deaths_female": "Female Deaths",
+							"labour_participation_rate": "Labour Participation Rate",
+							"labour_unemployment_rate": "Unemployment Rate",
+							"income_median": "Median Income",
+							"income_avg": "Average Income",
+							"expenditure_avg": "Average Expenditure",
+							"gini": "Gini Coefficient",
+							"poverty_incidence": "Poverty Incidence",
+							"sme_small": "Small SMEs",
+							"sme_micro": "Micro SMEs",
+							"sme_medium": "Medium SMEs",
+							"businesses_agriculture": "Agriculture Businesses",
+							"businesses_crops": "Crop-related Businesses",
+							"businesses_livestock": "Livestock Businesses",
+							"businesses_fisheries": "Fisheries Businesses",
+							"businesses_forestry": "Forestry Businesses",
+							"businesses_mining": "Mining Businesses",
+							"businesses_manufacturing": "Manufacturing Businesses",
+							"businesses_construction": "Construction Businesses",
+							"businesses_services": "Service-related Businesses",
+							"utilities_pipedwater_home": "Piped Water (Home)",
+							"utilities_pipedwater_public": "Piped Water (Public)",
+							"utilities_pipedwater_other": "Piped Water (Other)",
+							"utilities_electricity_home": "Electricity (Home)",
+							"utilities_electricity_none": "No Electricity"
+						},
+						"bm": {
+							"state": "Negeri",
+							"parlimen": "Parlimen",
+							"area_km2": "Luas (km²)",
+							"population_total": "Jumlah Penduduk",
+							"nationality_citizen": "Warganegara",
+							"nationality_non_citizen": "Bukan Warganegara",
+							"sex_male": "Lelaki",
+							"sex_female": "Perempuan",
+							"ethnicity_proportion_bumi": "Bumiputera (%)",
+							"ethnicity_proportion_chinese": "Cina (%)",
+							"ethnicity_proportion_indian": "India (%)",
+							"ethnicity_proportion_other": "Kumpulan Etnik Lain (%)",
+							"age_proportion_0_14": "0-14 Tahun (%)",
+							"age_proportion_15_64": "15-64 Tahun (%)",
+							"age_proportion_65_above": "65+ Tahun (%)",
+							"age_proportion_18_above": "18+ Tahun (%)",
+							"housing_total": "Jumlah Perumahan",
+							"household_total": "Jumlah Isi Rumah",
+							"household_size_avg": "Purata Saiz Isi Rumah",
+							"live_births": "Jumlah Kelahiran Hidup",
+							"live_births_male": "Kelahiran Lelaki",
+							"live_births_female": "Kelahiran Perempuan",
+							"deaths": "Jumlah Kematian",
+							"deaths_male": "Kematian Lelaki",
+							"deaths_female": "Kematian Perempuan",
+							"labour_participation_rate": "Kadar Penyertaan Buruh",
+							"labour_unemployment_rate": "Kadar Pengangguran",
+							"income_median": "Pendapatan Median",
+							"income_avg": "Pendapatan Purata",
+							"expenditure_avg": "Perbelanjaan Purata",
+							"gini": "Pekali Gini",
+							"poverty_incidence": "Kekerapan Kemiskinan",
+							"sme_small": "PKS Kecil",
+							"sme_micro": "PKS Mikro",
+							"sme_medium": "PKS Sederhana",
+							"businesses_agriculture": "Perniagaan Pertanian",
+							"businesses_crops": "Perniagaan Tanaman",
+							"businesses_livestock": "Perniagaan Penternakan",
+							"businesses_fisheries": "Perniagaan Perikanan",
+							"businesses_forestry": "Perniagaan Perhutanan",
+							"businesses_mining": "Perniagaan Perlombongan",
+							"businesses_manufacturing": "Perniagaan Pengilangan",
+							"businesses_construction": "Perniagaan Pembinaan",
+							"businesses_services": "Perniagaan Perkhidmatan",
+							"utilities_pipedwater_home": "Air Paip (Rumah)",
+							"utilities_pipedwater_public": "Air Paip (Awam)",
+							"utilities_pipedwater_other": "Air Paip (Lain-lain)",
+							"utilities_electricity_home": "Elektrik (Rumah)",
+							"utilities_electricity_none": "Tiada Elektrik"
+						}
+					}
+				}
+			}
+		]
+	}
 }

--- a/catalog/mwe_timeseries_1.json
+++ b/catalog/mwe_timeseries_1.json
@@ -1,107 +1,107 @@
 {
-  "file": {
-    "manual_trigger": "",
-    "bucket": "dgmy-public-mwe",
-    "file_name": "mwe_timeseries_1",
-    "category": "METADATA",
-    "category_en": "Site Metadata",
-    "category_bm": "Metadata Portal",
-    "subcategory": "SAMPLE_CHART",
-    "subcategory_en": "Chart Samples",
-    "subcategory_bm": "Contoh Carta",
-    "description": {
-      "en": "Lorem ipsum.",
-      "bm": "Lorem ipsum."
-    },
-    "link_parquet": "https://dgmy-public-mwe.s3.ap-southeast-1.amazonaws.com/mwe_timeseries.parquet",
-    "link_csv": "https://dgmy-public-mwe.s3.ap-southeast-1.amazonaws.com/mwe_timeseries.csv",
-    "variables": [
-      {
-        "id": -1,
-        "name": "date",
-        "title_en": "Date",
-        "title_bm": "Tarikh",
-        "desc_en": "[Date] The date in YYYY-MM-DD format",
-        "desc_bm": "[Tarikh] Tarikh dalam format YYYY-MM-DD"
-      },
-      {
-        "id": -1,
-        "name": "state",
-        "title_en": "State",
-        "title_bm": "Negeri",
-        "desc_en": "[Categorical] Name of the state (16 in total) or Malaysia",
-        "desc_bm": "[Kategori] Name negeri (16 keseluruhan) atau Malaysia"
-      },
-      {
-        "id": -1,
-        "name": "var1",
-        "title_en": "Variable 1",
-        "title_bm": "Pembolehubah 1",
-        "desc_en": "[Integer] A precise, succinct description of this variable",
-        "desc_bm": "[Integer] A precise, succinct description of this variable"
-      },
-      {
-        "id": 0,
-        "name": "mwe_timeseries_1",
-        "title_en": "Timeseries (1 line)",
-        "title_bm": "Siri Masa (1 siri)",
-        "desc_en": "A precise, succinct description of this chart",
-        "desc_bm": "A precise, succinct description of this chart",
-        "catalog_data": {
-          "id": 0,
-          "catalog_filters": {
-            "frequency": "DAILY",
-            "limit_frequency": false,
-            "geographic": ["STATE", "NATIONAL"],
-            "demographic": ["SEX", "MARITAL"],
-            "start": "2006",
-            "end": "2023",
-            "data_source": ["MAMPU"]
-          },
-          "metadata_neutral": {
-            "data_as_of": "2023-04-03 23:59",
-            "last_updated": "2023-04-04 06:00",
-            "next_update": "2023-04-05 06:00"
-          },
-          "metadata_lang": {
-            "en": {
-              "methodology": "Lorem Ipsum is simply dummy text of the printing and typesetting industry. Lorem Ipsum has been the industry's standard dummy text ever since the 1500s, when an unknown printer took a galley of type and scrambled it to make a type specimen book.",
-              "caveat": "Contrary to popular belief, Lorem Ipsum is not simply random text. It has roots in a piece of classical Latin literature from 45 BC, making it over 2000 years old. Richard McClintock, a Latin professor at Hampden-Sydney College in Virginia, looked up one of the more obscure Latin words, consectetur, from a Lorem Ipsum passage, and going through the cites of the word in classical literature, discovered the undoubtable source.",
-              "publication": "Lorem Ipsum comes from sections 1.10.32 and 1.10.33 of 'de Finibus Bonorum et Malorum' (The Extremes of Good and Evil) by Cicero, written in 45 BC. This book is a treatise on the theory of ethics, very popular during the Renaissance. The first line of Lorem Ipsum, 'Lorem ipsum dolor sit amet..'', comes from a line in section 1.10.32."
-            },
-            "bm": {
-              "methodology": "Lorem Ipsum is simply dummy text of the printing and typesetting industry. Lorem Ipsum has been the industry's standard dummy text ever since the 1500s, when an unknown printer took a galley of type and scrambled it to make a type specimen book.",
-              "caveat": "Contrary to popular belief, Lorem Ipsum is not simply random text. It has roots in a piece of classical Latin literature from 45 BC, making it over 2000 years old. Richard McClintock, a Latin professor at Hampden-Sydney College in Virginia, looked up one of the more obscure Latin words, consectetur, from a Lorem Ipsum passage, and going through the cites of the word in classical literature, discovered the undoubtable source.",
-              "publication": "Lorem Ipsum comes from sections 1.10.32 and 1.10.33 of 'de Finibus Bonorum et Malorum' (The Extremes of Good and Evil) by Cicero, written in 45 BC. This book is a treatise on the theory of ethics, very popular during the Renaissance. The first line of Lorem Ipsum, 'Lorem ipsum dolor sit amet..'', comes from a line in section 1.10.32."
-            }
-          },
-          "chart": {
-            "chart_type": "TIMESERIES",
-            "chart_filters": {
-              "SLICE_BY": ["state"],
-              "precision": 0
-            },
-            "chart_variables": {
-              "parents": ["state"],
-              "operation": "SUM",
-              "format": {
-                "x": "date",
-                "y": ["var1"]
-              }
-            }
-          },
-          "translations": {
-            "en": {
-              "x": "Date",
-              "y1": "Variable 1"
-            },
-            "bm": {
-              "x": "Tarikh",
-              "y1": "Pembolehubah 1"
-            }
-          }
-        }
-      }
-    ]
-  }
+	"file": {
+		"manual_trigger": "",
+		"bucket": "dgmy-public-mwe",
+		"file_name": "mwe_timeseries_1",
+		"category": "METADATA",
+		"category_en": "Site Metadata",
+		"category_bm": "Metadata Portal",
+		"subcategory": "SAMPLE_CHART",
+		"subcategory_en": "Chart Samples",
+		"subcategory_bm": "Contoh Carta",
+		"description": {
+			"en": "Lorem ipsum.",
+			"bm": "Lorem ipsum."
+		},
+		"link_parquet": "https://dgmy-public-mwe.s3.ap-southeast-1.amazonaws.com/mwe_timeseries.parquet",
+		"link_csv": "https://dgmy-public-mwe.s3.ap-southeast-1.amazonaws.com/mwe_timeseries.csv",
+		"variables": [
+			{
+				"id": -1,
+				"name": "date",
+				"title_en": "Date",
+				"title_bm": "Tarikh",
+				"desc_en": "[Date] The date in YYYY-MM-DD format",
+				"desc_bm": "[Tarikh] Tarikh dalam format YYYY-MM-DD"
+			},
+			{
+				"id": -1,
+				"name": "state",
+				"title_en": "State",
+				"title_bm": "Negeri",
+				"desc_en": "[Categorical] Name of the state (16 in total) or Malaysia",
+				"desc_bm": "[Kategori] Name negeri (16 keseluruhan) atau Malaysia"
+			},
+			{
+				"id": -1,
+				"name": "var1",
+				"title_en": "Variable 1",
+				"title_bm": "Pembolehubah 1",
+				"desc_en": "[Integer] A precise, succinct description of this variable",
+				"desc_bm": "[Integer] A precise, succinct description of this variable"
+			},
+			{
+				"id": 0,
+				"name": "mwe_timeseries_1",
+				"title_en": "Timeseries (1 line)",
+				"title_bm": "Siri Masa (1 siri)",
+				"desc_en": "A precise, succinct description of this chart",
+				"desc_bm": "A precise, succinct description of this chart",
+				"catalog_data": {
+					"id": 0,
+					"catalog_filters": {
+						"frequency": "DAILY",
+						"limit_frequency": false,
+						"geography": ["STATE", "NATIONAL"],
+						"demographic": ["SEX", "MARITAL"],
+						"start": "2006",
+						"end": "2023",
+						"data_source": ["MAMPU"]
+					},
+					"metadata_neutral": {
+						"data_as_of": "2023-04-03 23:59",
+						"last_updated": "2023-04-04 06:00",
+						"next_update": "2023-04-05 06:00"
+					},
+					"metadata_lang": {
+						"en": {
+							"methodology": "Lorem Ipsum is simply dummy text of the printing and typesetting industry. Lorem Ipsum has been the industry's standard dummy text ever since the 1500s, when an unknown printer took a galley of type and scrambled it to make a type specimen book.",
+							"caveat": "Contrary to popular belief, Lorem Ipsum is not simply random text. It has roots in a piece of classical Latin literature from 45 BC, making it over 2000 years old. Richard McClintock, a Latin professor at Hampden-Sydney College in Virginia, looked up one of the more obscure Latin words, consectetur, from a Lorem Ipsum passage, and going through the cites of the word in classical literature, discovered the undoubtable source.",
+							"publication": "Lorem Ipsum comes from sections 1.10.32 and 1.10.33 of 'de Finibus Bonorum et Malorum' (The Extremes of Good and Evil) by Cicero, written in 45 BC. This book is a treatise on the theory of ethics, very popular during the Renaissance. The first line of Lorem Ipsum, 'Lorem ipsum dolor sit amet..'', comes from a line in section 1.10.32."
+						},
+						"bm": {
+							"methodology": "Lorem Ipsum is simply dummy text of the printing and typesetting industry. Lorem Ipsum has been the industry's standard dummy text ever since the 1500s, when an unknown printer took a galley of type and scrambled it to make a type specimen book.",
+							"caveat": "Contrary to popular belief, Lorem Ipsum is not simply random text. It has roots in a piece of classical Latin literature from 45 BC, making it over 2000 years old. Richard McClintock, a Latin professor at Hampden-Sydney College in Virginia, looked up one of the more obscure Latin words, consectetur, from a Lorem Ipsum passage, and going through the cites of the word in classical literature, discovered the undoubtable source.",
+							"publication": "Lorem Ipsum comes from sections 1.10.32 and 1.10.33 of 'de Finibus Bonorum et Malorum' (The Extremes of Good and Evil) by Cicero, written in 45 BC. This book is a treatise on the theory of ethics, very popular during the Renaissance. The first line of Lorem Ipsum, 'Lorem ipsum dolor sit amet..'', comes from a line in section 1.10.32."
+						}
+					},
+					"chart": {
+						"chart_type": "TIMESERIES",
+						"chart_filters": {
+							"SLICE_BY": ["state"],
+							"precision": 0
+						},
+						"chart_variables": {
+							"parents": ["state"],
+							"operation": "SUM",
+							"format": {
+								"x": "date",
+								"y": ["var1"]
+							}
+						}
+					},
+					"translations": {
+						"en": {
+							"x": "Date",
+							"y1": "Variable 1"
+						},
+						"bm": {
+							"x": "Tarikh",
+							"y1": "Pembolehubah 1"
+						}
+					}
+				}
+			}
+		]
+	}
 }

--- a/catalog/mwe_timeseries_1.json
+++ b/catalog/mwe_timeseries_1.json
@@ -53,7 +53,7 @@
 						"frequency": "DAILY",
 						"limit_frequency": false,
 						"geography": ["STATE", "NATIONAL"],
-						"demographic": ["SEX", "MARITAL"],
+						"demography": ["SEX", "MARITAL"],
 						"start": "2006",
 						"end": "2023",
 						"data_source": ["MAMPU"]

--- a/catalog/mwe_timeseries_2.json
+++ b/catalog/mwe_timeseries_2.json
@@ -1,116 +1,116 @@
 {
-  "file": {
-    "manual_trigger": "",
-    "bucket": "dgmy-public-mwe",
-    "file_name": "mwe_timeseries_2",
-    "category": "METADATA",
-    "category_en": "Site Metadata",
-    "category_bm": "Metadata Portal",
-    "subcategory": "SAMPLE_CHART",
-    "subcategory_en": "Chart Samples",
-    "subcategory_bm": "Contoh Carta",
-    "description": {
-      "en": "Lorem ipsum.",
-      "bm": "Lorem ipsum."
-    },
-    "link_parquet": "https://dgmy-public-mwe.s3.ap-southeast-1.amazonaws.com/mwe_timeseries.parquet",
-    "link_csv": "https://dgmy-public-mwe.s3.ap-southeast-1.amazonaws.com/mwe_timeseries.csv",
-    "variables": [
-      {
-        "id": -1,
-        "name": "date",
-        "title_en": "Date",
-        "title_bm": "Tarikh",
-        "desc_en": "[Date] The date in YYYY-MM-DD format",
-        "desc_bm": "[Tarikh] Tarikh dalam format YYYY-MM-DD"
-      },
-      {
-        "id": -1,
-        "name": "state",
-        "title_en": "State",
-        "title_bm": "Negeri",
-        "desc_en": "[Categorical] Name of the state (16 in total) or Malaysia",
-        "desc_bm": "[Kategori] Name negeri (16 keseluruhan) atau Malaysia"
-      },
-      {
-        "id": -1,
-        "name": "var1",
-        "title_en": "Variable 1",
-        "title_bm": "Pembolehubah 1",
-        "desc_en": "[Integer] A precise, succinct description of this variable",
-        "desc_bm": "[Integer] A precise, succinct description of this variable"
-      },
-      {
-        "id": -1,
-        "name": "var2",
-        "title_en": "Variable 2",
-        "title_bm": "Pembolehubah 2",
-        "desc_en": "[Integer] A precise, succinct description of this variable",
-        "desc_bm": "[Integer] A precise, succinct description of this variable"
-      },
-      {
-        "id": 0,
-        "name": "mwe_timeseries_2",
-        "title_en": "Timeseries (2 lines)",
-        "title_bm": "Siri Masa (2 siri)",
-        "desc_en": "A precise, succinct description of this chart",
-        "desc_bm": "A precise, succinct description of this chart",
-        "catalog_data": {
-          "catalog_filters": {
-            "frequency": "DAILY",
-            "limit_frequency": false,
-            "geographic": ["STATE", "NATIONAL"],
-            "demographic": ["SEX", "MARITAL"],
-            "start": "2006",
-            "end": "2023",
-            "data_source": ["MAMPU"]
-          },
-          "metadata_neutral": {
-            "data_as_of": "2023-04-03 23:59",
-            "last_updated": "2023-04-04 06:00",
-            "next_update": "2023-04-05 06:00"
-          },
-          "metadata_lang": {
-            "en": {
-              "methodology": "Lorem Ipsum is simply dummy text of the printing and typesetting industry. Lorem Ipsum has been the industry's standard dummy text ever since the 1500s, when an unknown printer took a galley of type and scrambled it to make a type specimen book.",
-              "caveat": "Contrary to popular belief, Lorem Ipsum is not simply random text. It has roots in a piece of classical Latin literature from 45 BC, making it over 2000 years old. Richard McClintock, a Latin professor at Hampden-Sydney College in Virginia, looked up one of the more obscure Latin words, consectetur, from a Lorem Ipsum passage, and going through the cites of the word in classical literature, discovered the undoubtable source.",
-              "publication": "Lorem Ipsum comes from sections 1.10.32 and 1.10.33 of 'de Finibus Bonorum et Malorum' (The Extremes of Good and Evil) by Cicero, written in 45 BC. This book is a treatise on the theory of ethics, very popular during the Renaissance. The first line of Lorem Ipsum, 'Lorem ipsum dolor sit amet..'', comes from a line in section 1.10.32."
-            },
-            "bm": {
-              "methodology": "Lorem Ipsum is simply dummy text of the printing and typesetting industry. Lorem Ipsum has been the industry's standard dummy text ever since the 1500s, when an unknown printer took a galley of type and scrambled it to make a type specimen book.",
-              "caveat": "Contrary to popular belief, Lorem Ipsum is not simply random text. It has roots in a piece of classical Latin literature from 45 BC, making it over 2000 years old. Richard McClintock, a Latin professor at Hampden-Sydney College in Virginia, looked up one of the more obscure Latin words, consectetur, from a Lorem Ipsum passage, and going through the cites of the word in classical literature, discovered the undoubtable source.",
-              "publication": "Lorem Ipsum comes from sections 1.10.32 and 1.10.33 of 'de Finibus Bonorum et Malorum' (The Extremes of Good and Evil) by Cicero, written in 45 BC. This book is a treatise on the theory of ethics, very popular during the Renaissance. The first line of Lorem Ipsum, 'Lorem ipsum dolor sit amet..'', comes from a line in section 1.10.32."
-            }
-          },
-          "chart": {
-            "chart_type": "TIMESERIES",
-            "chart_filters": {
-              "SLICE_BY": ["state"],
-              "precision": 0
-            },
-            "chart_variables": {
-              "parents": ["state"],
-              "operation": "SUM",
-              "format": {
-                "x": "date",
-                "y": ["var1", "var2"]
-              }
-            }
-          },
-          "translations": {
-            "en": {
-              "x": "Date",
-              "y1": "Variable 1",
-              "y2": "Variable 2"
-            },
-            "bm": {
-              "x": "Tarikh",
-              "y1": "Pembolehubah 1",
-              "y2": "Pembolehubah 2"
-            }
-          }
-        }
-      }
-    ]
-  }
+	"file": {
+		"manual_trigger": "",
+		"bucket": "dgmy-public-mwe",
+		"file_name": "mwe_timeseries_2",
+		"category": "METADATA",
+		"category_en": "Site Metadata",
+		"category_bm": "Metadata Portal",
+		"subcategory": "SAMPLE_CHART",
+		"subcategory_en": "Chart Samples",
+		"subcategory_bm": "Contoh Carta",
+		"description": {
+			"en": "Lorem ipsum.",
+			"bm": "Lorem ipsum."
+		},
+		"link_parquet": "https://dgmy-public-mwe.s3.ap-southeast-1.amazonaws.com/mwe_timeseries.parquet",
+		"link_csv": "https://dgmy-public-mwe.s3.ap-southeast-1.amazonaws.com/mwe_timeseries.csv",
+		"variables": [
+			{
+				"id": -1,
+				"name": "date",
+				"title_en": "Date",
+				"title_bm": "Tarikh",
+				"desc_en": "[Date] The date in YYYY-MM-DD format",
+				"desc_bm": "[Tarikh] Tarikh dalam format YYYY-MM-DD"
+			},
+			{
+				"id": -1,
+				"name": "state",
+				"title_en": "State",
+				"title_bm": "Negeri",
+				"desc_en": "[Categorical] Name of the state (16 in total) or Malaysia",
+				"desc_bm": "[Kategori] Name negeri (16 keseluruhan) atau Malaysia"
+			},
+			{
+				"id": -1,
+				"name": "var1",
+				"title_en": "Variable 1",
+				"title_bm": "Pembolehubah 1",
+				"desc_en": "[Integer] A precise, succinct description of this variable",
+				"desc_bm": "[Integer] A precise, succinct description of this variable"
+			},
+			{
+				"id": -1,
+				"name": "var2",
+				"title_en": "Variable 2",
+				"title_bm": "Pembolehubah 2",
+				"desc_en": "[Integer] A precise, succinct description of this variable",
+				"desc_bm": "[Integer] A precise, succinct description of this variable"
+			},
+			{
+				"id": 0,
+				"name": "mwe_timeseries_2",
+				"title_en": "Timeseries (2 lines)",
+				"title_bm": "Siri Masa (2 siri)",
+				"desc_en": "A precise, succinct description of this chart",
+				"desc_bm": "A precise, succinct description of this chart",
+				"catalog_data": {
+					"catalog_filters": {
+						"frequency": "DAILY",
+						"limit_frequency": false,
+						"geography": ["STATE", "NATIONAL"],
+						"demographic": ["SEX", "MARITAL"],
+						"start": "2006",
+						"end": "2023",
+						"data_source": ["MAMPU"]
+					},
+					"metadata_neutral": {
+						"data_as_of": "2023-04-03 23:59",
+						"last_updated": "2023-04-04 06:00",
+						"next_update": "2023-04-05 06:00"
+					},
+					"metadata_lang": {
+						"en": {
+							"methodology": "Lorem Ipsum is simply dummy text of the printing and typesetting industry. Lorem Ipsum has been the industry's standard dummy text ever since the 1500s, when an unknown printer took a galley of type and scrambled it to make a type specimen book.",
+							"caveat": "Contrary to popular belief, Lorem Ipsum is not simply random text. It has roots in a piece of classical Latin literature from 45 BC, making it over 2000 years old. Richard McClintock, a Latin professor at Hampden-Sydney College in Virginia, looked up one of the more obscure Latin words, consectetur, from a Lorem Ipsum passage, and going through the cites of the word in classical literature, discovered the undoubtable source.",
+							"publication": "Lorem Ipsum comes from sections 1.10.32 and 1.10.33 of 'de Finibus Bonorum et Malorum' (The Extremes of Good and Evil) by Cicero, written in 45 BC. This book is a treatise on the theory of ethics, very popular during the Renaissance. The first line of Lorem Ipsum, 'Lorem ipsum dolor sit amet..'', comes from a line in section 1.10.32."
+						},
+						"bm": {
+							"methodology": "Lorem Ipsum is simply dummy text of the printing and typesetting industry. Lorem Ipsum has been the industry's standard dummy text ever since the 1500s, when an unknown printer took a galley of type and scrambled it to make a type specimen book.",
+							"caveat": "Contrary to popular belief, Lorem Ipsum is not simply random text. It has roots in a piece of classical Latin literature from 45 BC, making it over 2000 years old. Richard McClintock, a Latin professor at Hampden-Sydney College in Virginia, looked up one of the more obscure Latin words, consectetur, from a Lorem Ipsum passage, and going through the cites of the word in classical literature, discovered the undoubtable source.",
+							"publication": "Lorem Ipsum comes from sections 1.10.32 and 1.10.33 of 'de Finibus Bonorum et Malorum' (The Extremes of Good and Evil) by Cicero, written in 45 BC. This book is a treatise on the theory of ethics, very popular during the Renaissance. The first line of Lorem Ipsum, 'Lorem ipsum dolor sit amet..'', comes from a line in section 1.10.32."
+						}
+					},
+					"chart": {
+						"chart_type": "TIMESERIES",
+						"chart_filters": {
+							"SLICE_BY": ["state"],
+							"precision": 0
+						},
+						"chart_variables": {
+							"parents": ["state"],
+							"operation": "SUM",
+							"format": {
+								"x": "date",
+								"y": ["var1", "var2"]
+							}
+						}
+					},
+					"translations": {
+						"en": {
+							"x": "Date",
+							"y1": "Variable 1",
+							"y2": "Variable 2"
+						},
+						"bm": {
+							"x": "Tarikh",
+							"y1": "Pembolehubah 1",
+							"y2": "Pembolehubah 2"
+						}
+					}
+				}
+			}
+		]
+	}
 }

--- a/catalog/mwe_timeseries_2.json
+++ b/catalog/mwe_timeseries_2.json
@@ -60,7 +60,7 @@
 						"frequency": "DAILY",
 						"limit_frequency": false,
 						"geography": ["STATE", "NATIONAL"],
-						"demographic": ["SEX", "MARITAL"],
+						"demography": ["SEX", "MARITAL"],
 						"start": "2006",
 						"end": "2023",
 						"data_source": ["MAMPU"]


### PR DESCRIPTION
## Changes made
All data catalogue filters are renamed from geographic to geography. This PR should be merged after BE updates the same semantics to avoid breaking changes.

### Update 
`demographic` has also been renamed to `demography`